### PR TITLE
Completed C# Compiler

### DIFF
--- a/jvm/src/main/scala/io/kaitai/struct/Main.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/Main.scala
@@ -13,8 +13,9 @@ object Main {
 
     private val _verbose: Boolean = false,
     private val _debug: Boolean = false,
-    private val _javaPackage: String = ""
-  ) extends RuntimeConfig(_verbose, _debug, _javaPackage)
+    private val _javaPackage: String = "",
+    private val _dotNetNamespace: String = ""
+  ) extends RuntimeConfig(_verbose, _debug, _javaPackage, _dotNetNamespace)
 
   val ALL_LANGS = LanguageCompilerStatic.NAME_TO_CLASS.keySet
   val VALID_LANGS = ALL_LANGS + "all"
@@ -54,6 +55,10 @@ object Main {
       opt[String]("java-package") valueName("<package>") action { (x, c) =>
         c.copy(_javaPackage = x)
       } text("Java package (Java only, default: root package)")
+
+      opt[String]("dotnet-namespace") valueName("<namespace>") action { (x, c) =>
+        c.copy(_dotNetNamespace = x)
+      } text(".NET Namespace (.NET only, default: Kaitai)")
 
       opt[Unit]("verbose") action { (x, c) =>
         c.copy(_verbose = true)

--- a/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
+++ b/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
@@ -3,5 +3,6 @@ package io.kaitai.struct
 class RuntimeConfig(
   val verbose: Boolean = false,
   val debug: Boolean = false,
-  val javaPackage: String = ""
+  val javaPackage: String = "",
+  val dotNetNamespace: String = "Kaitai"
 )

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -3,40 +3,50 @@ package io.kaitai.struct.languages
 import io.kaitai.struct.{LanguageOutputWriter, RuntimeConfig, Utils}
 import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.exprlang.Ast.expr
-import io.kaitai.struct.exprlang.DataType.{BytesType, CalcIntType, StrType, _}
-import io.kaitai.struct.format.{NoRepeat, RepeatEos, RepeatExpr, RepeatSpec, _}
-import io.kaitai.struct.translators.{BaseTranslator, JavaTranslator, TypeProvider}
+import io.kaitai.struct.exprlang.DataType._
+import io.kaitai.struct.format._
+import io.kaitai.struct.translators.{BaseTranslator, CSharpTranslator, TypeProvider}
 
-class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
+class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: String = "")
   extends LanguageCompiler(verbose, out)
     with EveryReadIsExpression
     with NoNeedForFullClassPath {
   import CSharpCompiler._
 
-  override def getTranslator(tp: TypeProvider): BaseTranslator = new JavaTranslator(tp)
+  override def getTranslator(tp: TypeProvider): BaseTranslator = new CSharpTranslator(tp)
 
   override def fileHeader(topClassName: String): Unit = {
     out.puts(s"// $headerComment")
-    out.puts
-    out.puts("using System;")
-    out.puts("using Kaitai;")
+
+    var ns = "Kaitai";
+    if (!namespace.isEmpty) ns = namespace;
 
     out.puts
+    out.puts("using System;")
+    out.puts("using System.Collections.Generic;")
+    if (ns != "Kaitai") out.puts("using Kaitai;")
+    out.puts
+
+    out.puts(s"namespace $ns")
+    out.puts(s"{")
+    out.inc
+  }
+
+  override def fileFooter(topClassName: String): Unit = {
+    out.dec
+    out.puts("}")
   }
 
   override def classHeader(name: String): Unit = {
-    val staticStr = if (out.indentLevel > 0) {
-      "static "
-    } else {
-      ""
-    }
 
-    out.puts(s"public ${staticStr}class ${type2class(name)} : $kstructName {")
+    out.puts(s"public partial class ${type2class(name)} : KaitaiStruct")
+    out.puts(s"{")
     out.inc
 
-    out.puts(s"public static ${type2class(name)} fromFile(String fileName) {")
+    out.puts(s"public static ${type2class(name)} FromFile(string fileName)")
+    out.puts(s"{")
     out.inc
-    out.puts(s"return new ${type2class(name)}(new $kstreamName(fileName));")
+    out.puts(s"return new ${type2class(name)}(new KaitaiStream(fileName));")
     out.dec
     out.puts("}")
   }
@@ -48,72 +58,99 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   override def classConstructorHeader(name: String, parentClassName: String, rootClassName: String): Unit = {
     out.puts
-    out.puts(s"public ${type2class(name)}($kstreamName _io, ${type2class(parentClassName)} _parent = null, ${type2class(rootClassName)} _root = null) : base(_io) {")
+    out.puts(s"public ${type2class(name)}(KaitaiStream stream) : this(stream, null)")
+    out.puts(s"{")
+    out.puts
+    out.puts("}")
+    out.puts
+
+    out.puts(s"public ${type2class(name)}(KaitaiStream stream, ${type2class(parentClassName)} parent) : this(stream, parent, null)")
+    out.puts(s"{")
     out.inc
-    out.puts(s"${privateMemberName("_root")} = (_root == null) ? this : _root;")
-    out.puts(s"${privateMemberName("_parent")} = _parent;")
+    if (name == rootClassName)
+      out.puts("_root = this;")
+    out.dec
+    out.puts("}")
+    out.puts
+
+    out.puts(s"public ${type2class(name)}(KaitaiStream stream, ${type2class(parentClassName)} parent, ${type2class(rootClassName)} root) : base(stream)")
+    out.puts(s"{")
+    out.inc
+    out.puts("_parent = parent;")
+    out.puts("_root = root;")
+    out.puts("ParseInternal();")
+    out.dec
+    out.puts("}")
+    out.puts
+
+    out.puts("private void ParseInternal()")
+    out.puts("{")
+    out.inc
+  }
+
+  override def classConstructorFooter: Unit = {
+    out.dec
+    out.puts("}")
     out.puts
   }
 
-  override def classConstructorFooter: Unit = classFooter(null)
-
   override def attributeDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
-    out.puts(s"private ${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")
+    out.puts(s"private ${kaitaiType2NativeType(attrType)} ${camelCase(attrName)};")
   }
 
   override def attributeReader(attrName: String, attrType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2NativeType(attrType)} ${publicMemberName(attrName)}() { return ${privateMemberName(attrName)}; }")
+    out.puts(s"public ${kaitaiType2NativeType(attrType)} Get${pascalCase(attrName)}() { return ${camelCase(attrName)}; }")
   }
 
   override def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit = {
-    out.puts(s"${privateMemberName(attrName)} = _io.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
+    out.puts(s"${camelCase(attrName)} = _stream.EnsureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
   }
 
   override def attrProcess(proc: ProcessExpr, varSrc: String, varDest: String): Unit = {
     proc match {
       case ProcessXor(xorValue) =>
-        out.puts(s"this.$varDest = _io.processXorInt(this.$varSrc, ${expression(xorValue)});")
+        out.puts(s"this.$varDest = _stream.ProcessXorInt(this.$varSrc, ${expression(xorValue)});")
       case ProcessZlib =>
-        out.puts(s"this.$varDest = _io.processZlib(this.$varSrc);")
+        out.puts(s"$varDest = _stream.ProcessZlib($varSrc);")
       case ProcessRotate(isLeft, rotValue) =>
         val expr = if (isLeft) {
           expression(rotValue)
         } else {
           s"8 - (${expression(rotValue)})"
         }
-        out.puts(s"this.$varDest = _io.processRotateLeft(this.$varSrc, $expr, 1);")
+        out.puts(s"$varDest = _stream.ProcessRotateLeft($varSrc, $expr, 1);")
     }
   }
 
-  override def normalIO: String = "_io"
+  override def normalIO: String = "_stream"
 
   override def allocateIO(varName: String, rep: RepeatSpec): String = {
-    val javaName = lowerCamelCase(varName)
+    val camelVarName = camelCase(varName)
 
-    val ioName = s"_io_$javaName"
+    val ioName = s"stream_$camelVarName"
 
     val args = rep match {
-      case RepeatEos | RepeatExpr(_) => s"$javaName.get($javaName.size() - 1)"
-      case NoRepeat => javaName
+      case RepeatEos | RepeatExpr(_) => s"$camelVarName[$camelVarName.Count - 1]"
+      case NoRepeat => camelVarName
     }
 
-    out.puts(s"$kstreamName $ioName = new $kstreamName($args);")
+    out.puts(s"KaitaiStream $ioName = new KaitaiStream($args);")
     ioName
   }
 
   override def useIO(ioEx: expr): String = {
-    out.puts(s"$kstreamName io = ${expression(ioEx)};")
+    out.puts(s"KaitaiStream io = ${expression(ioEx)};")
     "io"
   }
 
   override def pushPos(io: String): Unit =
-  out.puts(s"long _pos = $io.pos();")
+    out.puts(s"long _pos = $io.Pos();")
 
   override def seek(io: String, pos: Ast.expr): Unit =
-  out.puts(s"$io.seek(${expression(pos)});")
+    out.puts(s"$io.Seek(${expression(pos)});")
 
   override def popPos(io: String): Unit =
-  out.puts(s"$io.seek(_pos);")
+    out.puts(s"$io.Seek(_pos);")
 
   override def condIfHeader(expr: expr): Unit = {
     out.puts(s"if (${expression(expr)}) {")
@@ -127,14 +164,14 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   override def condRepeatEosHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
     if (needRaw)
-      out.puts(s"this._raw_${lowerCamelCase(id)} = new ArrayList<byte[]>();")
-    out.puts(s"this.${lowerCamelCase(id)} = new ${kaitaiType2NativeType(ArrayType(dataType))}();")
-    out.puts(s"while (!$io.isEof()) {")
+      out.puts(s"_raw_${id} = new List<byte[]>();")
+    out.puts(s"${camelCase(id)} = new ${kaitaiType2NativeType(ArrayType(dataType))}();")
+    out.puts(s"while (!$io.IsEof()) {")
     out.inc
   }
 
   override def handleAssignmentRepeatEos(id: String, expr: String): Unit = {
-    out.puts(s"${privateMemberName(id)}.add($expr);")
+    out.puts(s"${camelCase(id)}.Add($expr);")
   }
 
   override def condRepeatEosFooter: Unit = {
@@ -144,14 +181,14 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   override def condRepeatExprHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
     if (needRaw)
-      out.puts(s"this._raw_${lowerCamelCase(id)} = new ArrayList<byte[]>((int) (${expression(repeatExpr)}));")
-    out.puts(s"${lowerCamelCase(id)} = new ${kaitaiType2NativeType(ArrayType(dataType))}((int) (${expression(repeatExpr)}));")
+      out.puts(s"_raw_${id} = new List<byte[]>((int) (${expression(repeatExpr)}));")
+    out.puts(s"${camelCase(id)} = new ${kaitaiType2NativeType(ArrayType(dataType))}((int) (${expression(repeatExpr)}));")
     out.puts(s"for (int i = 0; i < ${expression(repeatExpr)}; i++) {")
     out.inc
   }
 
   override def handleAssignmentRepeatExpr(id: String, expr: String): Unit = {
-    out.puts(s"${privateMemberName(id)}.add($expr);")
+    out.puts(s"${camelCase(id)}.Add($expr);")
   }
 
   override def condRepeatExprFooter: Unit = {
@@ -160,164 +197,130 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
   }
 
   override def handleAssignmentSimple(id: String, expr: String): Unit = {
-    out.puts(s"${privateMemberName(id)} = $expr;")
+    out.puts(s"${camelCase(id)} = $expr;")
   }
 
   override def parseExpr(dataType: BaseType, io: String): String = {
     dataType match {
       case t: IntType =>
-        s"$io.read${Utils.capitalize(t.apiCall)}()"
+        s"$io.Read${Utils.capitalize(t.apiCall)}()"
       // Aw, crap, can't use interpolated strings here: https://issues.scala-lang.org/browse/SI-6476
       case StrByteLimitType(bs, encoding) =>
-        s"$io.readStrByteLimit(${expression(bs)}, " + '"' + encoding + "\")"
+        s"$io.ReadStringByteLimit(${expression(bs)}, " + '"' + encoding + "\")"
       case StrEosType(encoding) =>
-        io + ".readStrEos(\"" + encoding + "\")"
+        io + ".ReadStringEos(\"" + encoding + "\")"
       case StrZType(encoding, terminator, include, consume, eosError) =>
-        io + ".readStrz(\"" + encoding + '"' + s", $terminator, $include, $consume, $eosError)"
+        io + ".ReadStringTerminated(\"" + encoding + '"' + s", $terminator, $include, $consume, $eosError)"
       case EnumType(enumName, t) =>
-        s"${type2class(enumName)}.byId($io.read${Utils.capitalize(t.apiCall)}())"
+        s"((${type2class(enumName)}) $io.Read${Utils.capitalize(t.apiCall)}())"
       case BytesLimitType(size, _) =>
-        s"$io.readBytes(${expression(size)})"
+        s"$io.ReadBytes(${expression(size)})"
       case BytesEosType(_) =>
-        s"$io.readBytesFull()"
+        s"$io.ReadBytesFull()"
       case t: UserType =>
         s"new ${types2class(t.name)}($io, this, _root)"
     }
   }
 
   override def instanceDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
-    out.puts(s"private ${kaitaiType2JavaTypeBoxed(attrType)} ${lowerCamelCase(attrName)};")
+    out.puts(s"private ${kaitaiType2NativeType(attrType)} ${camelCase(attrName)};")
   }
 
   override def instanceHeader(className: String, instName: String, dataType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2JavaTypeBoxed(dataType)} ${lowerCamelCase(instName)}() throws IOException {")
+    out.puts(s"public ${kaitaiType2NativeType(dataType)} Get${pascalCase(instName)}()")
+    out.puts(s"{")
     out.inc
-  }
 
-  override def instanceAttrName(instName: String): String = instName
-
-  override def instanceFooter: Unit = classConstructorFooter
-
-  override def instanceCheckCacheAndReturn(instName: String): Unit = {
-    out.puts(s"if (${lowerCamelCase(instName)} != null)")
+    // Move this out of `instanceCheckCacheAndReturn` because we need to know the datatype
+    out.puts(s"if (${camelCase(instName)} != default(${kaitaiType2NativeType(dataType)}))")
     out.inc
     instanceReturn(instName)
     out.dec
   }
 
+  override def instanceAttrName(instName: String): String = instName
+
+  override def instanceFooter: Unit = {
+    out.dec
+    out.puts(s"}")
+  }
+
+  override def instanceCheckCacheAndReturn(instName: String): Unit = {
+    // out.puts(s"if (${camelCase(instName)} != null)")
+    // out.inc
+    // instanceReturn(instName)
+    // out.dec
+  }
+
   override def instanceReturn(instName: String): Unit = {
-    out.puts(s"return ${lowerCamelCase(instName)};")
+    out.puts(s"return ${camelCase(instName)};")
   }
 
   override def instanceCalculate(instName: String, value: Ast.expr): Unit = {
-    out.puts(s"${lowerCamelCase(instName)} = ${expression(value)};")
+    out.puts(s"${camelCase(instName)} = ${expression(value)};")
   }
 
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     val enumClass = type2class(enumName)
 
     out.puts
-    out.puts(s"public enum $enumClass {")
+    out.puts(s"public enum $enumClass")
+    out.puts(s"{")
     out.inc
 
-    val it = enumColl.toIterable
-    if (enumColl.size > 1) {
-      it.dropRight(1).foreach { case (id, label) =>
-        out.puts(s"${value2Const(label)}($id),")
-      }
-    }
-    it.last match {
-      case (id, label) =>
-        out.puts(s"${value2Const(label)}($id);")
+    enumColl.foreach { case (id, label) =>
+      out.puts(s"${pascalCase(label)} = $id,")
     }
 
-    out.puts
-    out.puts("private final long id;")
-    out.puts(s"$enumClass(long id) { this.id = id; }")
-    out.puts("public long id() { return id; }")
-    out.puts(s"private static final Map<Long, $enumClass> byId = new HashMap<Long, $enumClass>(${enumColl.size});")
-    out.puts("static {")
-    out.inc
-    out.puts(s"for ($enumClass e : $enumClass.values())")
-    out.inc
-    out.puts(s"byId.put(e.id(), e);")
-    out.dec
-    out.dec
-    out.puts("}")
-    out.puts(s"public static $enumClass byId(long id) { return byId.get(id); }")
     out.dec
     out.puts("}")
   }
 
-  def value2Const(s: String) = s.toUpperCase
-
-  def kaitaiType2NativeType(attrType: BaseType): String = kaitaiType2JavaTypePrim(attrType)
-
   /**
-    * Determine Java data type corresponding to a KS data type. A "primitive" type (i.e. "int", "long", etc) will
-    * be returned if possible.
+    * Determine .NET data type corresponding to a KS data type.
     *
     * @param attrType KS data type
-    * @return Java data type
+    * @return .NET data type
     */
-  def kaitaiType2JavaTypePrim(attrType: BaseType): String = {
+  def kaitaiType2NativeType(attrType: BaseType): String = {
     attrType match {
-      case Int1Type(false) => "int"
-      case IntMultiType(false, Width2, _) => "int"
-      case IntMultiType(false, Width4, _) => "long"
-      case IntMultiType(false, Width8, _) => "long"
+      case Int1Type(false) => "byte"
+      case IntMultiType(false, Width2, _) => "ushort"
+      case IntMultiType(false, Width4, _) => "uint"
+      case IntMultiType(false, Width8, _) => "ulong"
 
-      case Int1Type(true) => "byte"
+      case Int1Type(true) => "sbyte"
       case IntMultiType(true, Width2, _) => "short"
       case IntMultiType(true, Width4, _) => "int"
       case IntMultiType(true, Width8, _) => "long"
 
-      case _: StrType => "String"
+      case CalcIntType => "int"
+
+      case _: StrType => "string"
       case _: BytesType => "byte[]"
 
       case t: UserType => types2class(t.name)
-      case EnumType(name, _) => type2class(name)
+      case EnumType(name, _) => pascalCase(name)
 
-      case ArrayType(inType) => kaitaiType2JavaTypeBoxed(attrType)
+      case ArrayType(inType) => s"List<${kaitaiType2NativeType(inType)}>"
     }
   }
 
-  /**
-    * Determine Java data type corresponding to a KS data type. A non-primitive type (i.e. "Integer", "Long", etc) will
-    * be returned, to be used when proper objects should be used.
-    *
-    * @param attrType KS data type
-    * @return Java data type
-    */
-  def kaitaiType2JavaTypeBoxed(attrType: BaseType): String = {
-    attrType match {
-      case Int1Type(false) => "Integer"
-      case IntMultiType(false, Width2, _) => "Integer"
-      case IntMultiType(false, Width4, _) => "Long"
-      case IntMultiType(false, Width8, _) => "Long"
-
-      case Int1Type(true) => "Byte"
-      case IntMultiType(true, Width2, _) => "Short"
-      case IntMultiType(true, Width4, _) => "Integer"
-      case IntMultiType(true, Width8, _) => "Long"
-
-      case CalcIntType => "Integer"
-
-      case _: StrType => "String"
-      case _: BytesType => "byte[]"
-
-      case t: UserType => type2class(t.name.last)
-      case EnumType(name, _) => type2class(name)
-
-      case ArrayType(inType) => s"ArrayList<${kaitaiType2JavaTypeBoxed(inType)}>"
+  def pascalCase(s: String): String = {
+    if (s == "_root" || s == "_parent" || s == "_stream") {
+      "Kaitai" + Utils.upperCamelCase(s.substring(1))
+    } else if (s.startsWith("_raw_")) {
+      Utils.upperCamelCase(s.substring(1))
+    } else {
+      Utils.upperCamelCase(s)
     }
   }
 
-  def lowerCamelCase(s: String): String = {
-    if (s == "_root" || s == "_parent" || s == "_io") {
+  def camelCase(s: String): String = {
+    if (s == "_root" || s == "_parent" || s == "_stream") {
       s
     } else if (s.startsWith("_raw_")) {
-      "_raw_" + lowerCamelCase(s.substring("_raw_".length))
+      s
     } else {
       Utils.lowerCamelCase(s)
     }
@@ -325,22 +328,12 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   def types2class(names: List[String]) = names.map(x => type2class(x)).mkString(".")
 
-  def publicMemberName(ksName: String): String = Utils.upperCamelCase(ksName)
-
-  override def privateMemberName(ksName: String): String = s"m${Utils.upperCamelCase(ksName)}"
-
-  def kstructName = "Kaitai.KaitaiStruct"
-
-  def kstreamName = "KaitaiStream"
-
-  def type2class(name: String): String = name match {
-    case "kaitai_struct" => kstructName
-    case "kaitai_stream" => kstreamName
-    case _ => Utils.upperCamelCase(name)
-  }
+  override def privateMemberName(ksName: String): String = s"${Utils.lowerCamelCase(ksName)}"
 }
 
 object CSharpCompiler extends LanguageCompilerStatic with UpperCamelCaseClasses {
   override def indent: String = "    "
   override def outFileName(topClassName: String): String = s"${type2class(topClassName)}.cs"
+  override def outFilePath(config: RuntimeConfig, outDir: String, topClassName: String): String =
+    s"$outDir/src/${config.dotNetNamespace.replace('.', '/')}/${outFileName(topClassName)}"
 }

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -1,0 +1,49 @@
+package io.kaitai.struct.translators
+
+import io.kaitai.struct.Utils
+import io.kaitai.struct.exprlang.Ast
+import io.kaitai.struct.exprlang.Ast._
+
+class CSharpTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
+  override def doName(s: String) =
+    s match {
+      case "_root" => "GetKaitaiRoot()"
+      case "_parent" => "GetKaitaiParent()"
+      case "_stream" => "GetKaitaiStream()"
+      case "_io" => "GetKaitaiStream()"
+      case _ => s"Get${Utils.upperCamelCase(s)}()"
+    }
+
+  override def doEnumByLabel(enumType: String, label: String): String =
+    s"${Utils.upperCamelCase(enumType)}.${Utils.upperCamelCase(label)}"
+
+  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr) = {
+    if (op == Ast.cmpop.Eq) {
+      s"${translate(left)} == ${translate(right)}"
+    } else if (op == Ast.cmpop.NotEq) {
+      s"${translate(left)} != ${translate(right)}"
+    } else {
+      s"(${translate(left)}.CompareTo(${translate(right)}) ${cmpOp(op)} 0)"
+    }
+  }
+
+  override def doSubscript(container: expr, idx: expr): String =
+    s"${translate(container)}[${translate(idx)}]"
+  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
+    s"${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)}"
+
+  // Predefined methods of various types
+  override def strToInt(s: expr, base: expr): String =
+  s"long.Parse(${translate(s)})"
+  override def strLength(s: expr): String =
+    s"${translate(s)}.Length"
+  override def strSubstring(s: expr, from: expr, to: expr): String =
+    s"${translate(s)}.Substring(${translate(from)}, ${translate(to)} - ${translate(from)})"
+
+  override def arrayFirst(a: expr): String =
+    s"${translate(a)}[0]"
+  override def arrayLast(a: expr): String = {
+    val v = translate(a)
+    s"$v[$v.Length - 1]"
+  }
+}


### PR DESCRIPTION
I started this a few days ago, and I just noticed that you were working on it as well so hopefully this can save you some time. I've compiled the test cases and the outputs all build using .NET Core. I haven't tried running them, though.

I've made some changes so that the result fits into the .NET naming standards and it takes advantage of some of the C#/.NET features that Java doesn't have.

- Added a .NET namespace config option (but defaults to `Kaitai` if not specified)
- Using .NET naming standards (public members use `PascalCase`, private members use `camelCase`)
    - Properties can't have the same name as classes, so the public getters are named `Get{Thing}()` instead of just `{Thing}()`
- I've done a (hopefully) complete implementation of the `KaitaiStream` class in my runtime fork at [LogicAndTrick/kaitai_struct_csharp_runtime](https://github.com/LogicAndTrick/kaitai_struct_csharp_runtime), let me know if you would like a PR for the runtime.
    - The runtime stream is based off .NET's `BinaryReader` class which has implementations for little-endian types, so only the BE methods need to be implemented.
    - As a bonus the `BinaryReader` already has `ReadSingle` and `ReadDouble` (and others), so floating point support comes free.
- All the classes are marked as `partial` so users can add methods and properties to the class without touching the generated file

Apologies if this conflicts with anything you're working on! I've never used Scala before, so hopefully I didn't do anything wrong.