### PR TITLE
Completed C# Compiler - 2nd Attempt

### DIFF
--- a/jvm/src/main/scala/io/kaitai/struct/Main.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/Main.scala
@@ -13,8 +13,9 @@ object Main {
 
     private val _verbose: Boolean = false,
     private val _debug: Boolean = false,
-    private val _javaPackage: String = ""
-  ) extends RuntimeConfig(_verbose, _debug, _javaPackage)
+    private val _javaPackage: String = "",
+    private val _dotNetNamespace: String = ""
+  ) extends RuntimeConfig(_verbose, _debug, _javaPackage, _dotNetNamespace)
 
   val ALL_LANGS = LanguageCompilerStatic.NAME_TO_CLASS.keySet
   val VALID_LANGS = ALL_LANGS + "all"
@@ -54,6 +55,10 @@ object Main {
       opt[String]("java-package") valueName("<package>") action { (x, c) =>
         c.copy(_javaPackage = x)
       } text("Java package (Java only, default: root package)")
+
+      opt[String]("dotnet-namespace") valueName("<namespace>") action { (x, c) =>
+        c.copy(_dotNetNamespace = x)
+      } text(".NET Namespace (.NET only, default: Kaitai)")
 
       opt[Unit]("verbose") action { (x, c) =>
         c.copy(_verbose = true)

--- a/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
@@ -255,7 +255,7 @@ object ClassCompiler {
   }
 
   private def getCompiler(lang: LanguageCompilerStatic, config: RuntimeConfig, out: LanguageOutputWriter) = lang match {
-    case CSharpCompiler => new CSharpCompiler(config.verbose, out)
+    case CSharpCompiler => new CSharpCompiler(config.verbose, out, config.dotNetNamespace)
     case JavaCompiler => new JavaCompiler(config.verbose, out, config.javaPackage)
     case JavaScriptCompiler => new JavaScriptCompiler(config.verbose, out)
     case PythonCompiler => new PythonCompiler(config.verbose, out)

--- a/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
+++ b/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
@@ -1,7 +1,8 @@
 package io.kaitai.struct
 
 class RuntimeConfig(
-  val verbose: Boolean = false,
-  val debug: Boolean = false,
-  val javaPackage: String = ""
+ val verbose: Boolean = false,
+ val debug: Boolean = false,
+ val javaPackage: String = "",
+ val dotNetNamespace: String = "Kaitai"
 )

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -237,39 +237,17 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     val enumClass = type2class(enumName)
 
     out.puts
-    out.puts(s"public enum $enumClass {")
+    out.puts(s"public enum $enumClass")
+    out.puts(s"{")
     out.inc
 
-    val it = enumColl.toIterable
-    if (enumColl.size > 1) {
-      it.dropRight(1).foreach { case (id, label) =>
-        out.puts(s"${value2Const(label)}($id),")
-      }
-    }
-    it.last match {
-      case (id, label) =>
-        out.puts(s"${value2Const(label)}($id);")
+    enumColl.foreach { case (id, label) =>
+      out.puts(s"${publicMemberName(label)} = $id,")
     }
 
-    out.puts
-    out.puts("private final long id;")
-    out.puts(s"$enumClass(long id) { this.id = id; }")
-    out.puts("public long id() { return id; }")
-    out.puts(s"private static final Map<Long, $enumClass> byId = new HashMap<Long, $enumClass>(${enumColl.size});")
-    out.puts("static {")
-    out.inc
-    out.puts(s"for ($enumClass e : $enumClass.values())")
-    out.inc
-    out.puts(s"byId.put(e.id(), e);")
-    out.dec
-    out.dec
-    out.puts("}")
-    out.puts(s"public static $enumClass byId(long id) { return byId.get(id); }")
     out.dec
     out.puts("}")
   }
-
-  def value2Const(s: String) = s.toUpperCase
 
   def kaitaiType2NativeType(attrType: BaseType): String = kaitaiType2JavaTypePrim(attrType)
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -5,7 +5,7 @@ import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.exprlang.Ast.expr
 import io.kaitai.struct.exprlang.DataType.{BytesType, CalcIntType, StrType, _}
 import io.kaitai.struct.format.{NoRepeat, RepeatEos, RepeatExpr, RepeatSpec, _}
-import io.kaitai.struct.translators.{BaseTranslator, JavaTranslator, TypeProvider}
+import io.kaitai.struct.translators.{BaseTranslator, CSharpTranslator, TypeProvider}
 
 class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
   extends LanguageCompiler(verbose, out)
@@ -13,7 +13,7 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
     with NoNeedForFullClassPath {
   import CSharpCompiler._
 
-  override def getTranslator(tp: TypeProvider): BaseTranslator = new JavaTranslator(tp)
+  override def getTranslator(tp: TypeProvider): BaseTranslator = new CSharpTranslator(tp)
 
   override def fileHeader(topClassName: String): Unit = {
     out.puts(s"// $headerComment")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -86,22 +86,22 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   }
 
   override def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit = {
-    out.puts(s"${privateMemberName(attrName)} = _io.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
+    out.puts(s"${privateMemberName(attrName)} = ${normalIO}.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
   }
 
   override def attrProcess(proc: ProcessExpr, varSrc: String, varDest: String): Unit = {
     proc match {
       case ProcessXor(xorValue) =>
-        out.puts(s"this.$varDest = _io.processXorInt(this.$varSrc, ${expression(xorValue)});")
+        out.puts(s"this.$varDest = ${normalIO}.processXorInt(this.$varSrc, ${expression(xorValue)});")
       case ProcessZlib =>
-        out.puts(s"this.$varDest = _io.processZlib(this.$varSrc);")
+        out.puts(s"this.$varDest = ${normalIO}.processZlib(this.$varSrc);")
       case ProcessRotate(isLeft, rotValue) =>
         val expr = if (isLeft) {
           expression(rotValue)
         } else {
           s"8 - (${expression(rotValue)})"
         }
-        out.puts(s"this.$varDest = _io.processRotateLeft(this.$varSrc, $expr, 1);")
+        out.puts(s"this.$varDest = ${normalIO}.processRotateLeft(this.$varSrc, $expr, 1);")
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -206,11 +206,11 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   }
 
   override def instanceDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
-    out.puts(s"private ${kaitaiType2JavaTypeBoxed(attrType)} ${privateMemberName(attrName)};")
+    out.puts(s"private ${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")
   }
 
   override def instanceHeader(className: String, instName: String, dataType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2JavaTypeBoxed(dataType)} ${publicMemberName(instName)}() throws IOException {")
+    out.puts(s"public ${kaitaiType2NativeType(dataType)} ${publicMemberName(instName)}() throws IOException {")
     out.inc
   }
 
@@ -249,65 +249,33 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     out.puts("}")
   }
 
-  def kaitaiType2NativeType(attrType: BaseType): String = kaitaiType2JavaTypePrim(attrType)
-
   /**
-    * Determine Java data type corresponding to a KS data type. A "primitive" type (i.e. "int", "long", etc) will
-    * be returned if possible.
+    * Determine .NET data type corresponding to a KS data type.
     *
     * @param attrType KS data type
-    * @return Java data type
+    * @return .NET data type
     */
-  def kaitaiType2JavaTypePrim(attrType: BaseType): String = {
+  def kaitaiType2NativeType(attrType: BaseType): String = {
     attrType match {
-      case Int1Type(false) => "int"
-      case IntMultiType(false, Width2, _) => "int"
-      case IntMultiType(false, Width4, _) => "long"
-      case IntMultiType(false, Width8, _) => "long"
+      case Int1Type(false) => "byte"
+      case IntMultiType(false, Width2, _) => "ushort"
+      case IntMultiType(false, Width4, _) => "uint"
+      case IntMultiType(false, Width8, _) => "ulong"
 
-      case Int1Type(true) => "byte"
+      case Int1Type(true) => "sbyte"
       case IntMultiType(true, Width2, _) => "short"
       case IntMultiType(true, Width4, _) => "int"
       case IntMultiType(true, Width8, _) => "long"
 
-      case _: StrType => "String"
+      case CalcIntType => "int"
+
+      case _: StrType => "string"
       case _: BytesType => "byte[]"
 
       case t: UserType => types2class(t.name)
       case EnumType(name, _) => type2class(name)
 
-      case ArrayType(inType) => kaitaiType2JavaTypeBoxed(attrType)
-    }
-  }
-
-  /**
-    * Determine Java data type corresponding to a KS data type. A non-primitive type (i.e. "Integer", "Long", etc) will
-    * be returned, to be used when proper objects should be used.
-    *
-    * @param attrType KS data type
-    * @return Java data type
-    */
-  def kaitaiType2JavaTypeBoxed(attrType: BaseType): String = {
-    attrType match {
-      case Int1Type(false) => "Integer"
-      case IntMultiType(false, Width2, _) => "Integer"
-      case IntMultiType(false, Width4, _) => "Long"
-      case IntMultiType(false, Width8, _) => "Long"
-
-      case Int1Type(true) => "Byte"
-      case IntMultiType(true, Width2, _) => "Short"
-      case IntMultiType(true, Width4, _) => "Integer"
-      case IntMultiType(true, Width8, _) => "Long"
-
-      case CalcIntType => "Integer"
-
-      case _: StrType => "String"
-      case _: BytesType => "byte[]"
-
-      case t: UserType => type2class(t.name.last)
-      case EnumType(name, _) => type2class(name)
-
-      case ArrayType(inType) => s"ArrayList<${kaitaiType2JavaTypeBoxed(inType)}>"
+      case ArrayType(inType) => s"List<${kaitaiType2NativeType(inType)}>"
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -105,7 +105,7 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     }
   }
 
-  override def normalIO: String = "_io"
+  override def normalIO: String = "m_io"
 
   override def allocateIO(varName: String, rep: RepeatSpec): String = {
     val privateVarName = privateMemberName(varName)
@@ -282,9 +282,19 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
 
   def types2class(names: List[String]) = names.map(x => type2class(x)).mkString(".")
 
-  def publicMemberName(ksName: String): String = Utils.upperCamelCase(ksName)
+  def publicMemberName(ksName: String): String = {
+    if (ksName.startsWith("_"))
+      s"M${Utils.upperCamelCase(ksName)}"
+    else
+      Utils.upperCamelCase(ksName)
+  }
 
-  override def privateMemberName(ksName: String): String = s"m${Utils.upperCamelCase(ksName)}"
+  override def privateMemberName(ksName: String): String = {
+    if (ksName.startsWith("_"))
+      s"m${Utils.lowerCamelCase(ksName)}"
+    else
+      s"_${Utils.lowerCamelCase(ksName)}"
+  }
 
   def kstructName = "KaitaiStruct"
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -140,10 +140,7 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     out.inc
   }
 
-  override def condIfFooter(expr: expr): Unit = {
-    out.dec
-    out.puts("}")
-  }
+  override def condIfFooter(expr: expr): Unit = fileFooter(null)
 
   override def condRepeatEosHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
     if (needRaw)
@@ -157,10 +154,7 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     out.puts(s"${privateMemberName(id)}.Add($expr);")
   }
 
-  override def condRepeatEosFooter: Unit = {
-    out.dec
-    out.puts("}")
-  }
+  override def condRepeatEosFooter: Unit = fileFooter(null)
 
   override def condRepeatExprHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
     if (needRaw)
@@ -174,10 +168,7 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     out.puts(s"${privateMemberName(id)}.Add($expr);")
   }
 
-  override def condRepeatExprFooter: Unit = {
-    out.dec
-    out.puts("}")
-  }
+  override def condRepeatExprFooter: Unit = fileFooter(null)
 
   override def handleAssignmentSimple(id: String, expr: String): Unit = {
     out.puts(s"${privateMemberName(id)} = $expr;")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -82,7 +82,7 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   }
 
   override def attributeReader(attrName: String, attrType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2NativeType(attrType)} ${publicMemberName(attrName)}() { return ${privateMemberName(attrName)}; }")
+    out.puts(s"public ${kaitaiType2NativeType(attrType)} ${publicMemberName(attrName)} { get { return ${privateMemberName(attrName)}; } }")
   }
 
   override def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -38,37 +38,44 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   }
 
   override def classHeader(name: String): Unit = {
-    val staticStr = if (out.indentLevel > 0) {
-      "static "
-    } else {
-      ""
-    }
 
-    out.puts(s"public ${staticStr}class ${type2class(name)} : $kstructName {")
+    out.puts(s"public partial class ${type2class(name)} : $kstructName")
+    out.puts(s"{")
     out.inc
 
-    out.puts(s"public static ${type2class(name)} fromFile(String fileName) {")
+    out.puts(s"public static ${type2class(name)} FromFile(string fileName)")
+    out.puts(s"{")
     out.inc
     out.puts(s"return new ${type2class(name)}(new $kstreamName(fileName));")
     out.dec
     out.puts("}")
   }
 
-  override def classFooter(name: String): Unit = {
-    out.dec
-    out.puts("}")
-  }
+  override def classFooter(name: String): Unit = fileFooter(name)
 
   override def classConstructorHeader(name: String, parentClassName: String, rootClassName: String): Unit = {
     out.puts
-    out.puts(s"public ${type2class(name)}($kstreamName _io, ${type2class(parentClassName)} _parent = null, ${type2class(rootClassName)} _root = null) : base(_io) {")
+    out.puts(s"public ${type2class(name)}($kstreamName io, ${type2class(parentClassName)} parent = null, ${type2class(rootClassName)} root = null) : base(io)")
+    out.puts(s"{")
     out.inc
-    out.puts(s"${privateMemberName("_root")} = (_root == null) ? this : _root;")
-    out.puts(s"${privateMemberName("_parent")} = _parent;")
+    out.puts(s"${privateMemberName("_parent")} = parent;")
+
+    if (name == rootClassName)
+      out.puts(s"${privateMemberName("_root")} = root ?? this;")
+    else
+      out.puts(s"${privateMemberName("_root")} = root;")
+
+    out.puts("_parse();")
+    out.dec
+    out.puts("}")
     out.puts
+
+    out.puts("private void _parse()")
+    out.puts("{")
+    out.inc
   }
 
-  override def classConstructorFooter: Unit = classFooter(null)
+  override def classConstructorFooter: Unit = fileFooter(null)
 
   override def attributeDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
     out.puts(s"private ${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -218,10 +218,10 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   override def instanceAttrName(instName: String): String = instName
 
   override def instanceFooter: Unit = {
-    out.puts("}")
     out.dec
     out.puts("}")
     out.dec
+    out.puts("}")
   }
 
   override def instanceCheckCacheAndReturn(instName: String): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -280,23 +280,13 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     }
   }
 
-  def lowerCamelCase(s: String): String = {
-    if (s == "_root" || s == "_parent" || s == "_io") {
-      s
-    } else if (s.startsWith("_raw_")) {
-      "_raw_" + lowerCamelCase(s.substring("_raw_".length))
-    } else {
-      Utils.lowerCamelCase(s)
-    }
-  }
-
   def types2class(names: List[String]) = names.map(x => type2class(x)).mkString(".")
 
   def publicMemberName(ksName: String): String = Utils.upperCamelCase(ksName)
 
   override def privateMemberName(ksName: String): String = s"m${Utils.upperCamelCase(ksName)}"
 
-  def kstructName = "Kaitai.KaitaiStruct"
+  def kstructName = "KaitaiStruct"
 
   def kstreamName = "KaitaiStream"
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -7,7 +7,7 @@ import io.kaitai.struct.exprlang.DataType.{BytesType, CalcIntType, StrType, _}
 import io.kaitai.struct.format.{NoRepeat, RepeatEos, RepeatExpr, RepeatSpec, _}
 import io.kaitai.struct.translators.{BaseTranslator, CSharpTranslator, TypeProvider}
 
-class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
+class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: String = "Kaitai")
   extends LanguageCompiler(verbose, out)
     with EveryReadIsExpression
     with NoNeedForFullClassPath {
@@ -17,11 +17,24 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   override def fileHeader(topClassName: String): Unit = {
     out.puts(s"// $headerComment")
-    out.puts
-    out.puts("using System;")
-    out.puts("using Kaitai;")
+
+    var ns = "Kaitai";
+    if (!namespace.isEmpty) ns = namespace;
 
     out.puts
+    out.puts("using System;")
+    out.puts("using System.Collections.Generic;")
+    if (ns != "Kaitai") out.puts("using Kaitai;")
+    out.puts
+
+    out.puts(s"namespace $ns")
+    out.puts(s"{")
+    out.inc
+  }
+
+  override def fileFooter(topClassName: String): Unit = {
+    out.dec
+    out.puts("}")
   }
 
   override def classHeader(name: String): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -1,0 +1,48 @@
+package io.kaitai.struct.translators
+
+import io.kaitai.struct.Utils
+import io.kaitai.struct.exprlang.Ast
+import io.kaitai.struct.exprlang.Ast._
+
+class CSharpTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
+  override def doName(s: String) =
+    s match {
+      case "_root" => s
+      case "_parent" => s
+      case "_io" => s
+      case _ => s"${Utils.lowerCamelCase(s)}"
+    }
+
+  override def doEnumByLabel(enumType: String, label: String): String =
+    s"${Utils.upperCamelCase(enumType)}.${Utils.upperCamelCase(label)}"
+
+  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr) = {
+    if (op == Ast.cmpop.Eq) {
+      s"${translate(left)} == ${translate(right)}"
+    } else if (op == Ast.cmpop.NotEq) {
+      s"${translate(left)} != ${translate(right)}"
+    } else {
+      s"(${translate(left)}.CompareTo(${translate(right)}) ${cmpOp(op)} 0)"
+    }
+  }
+
+  override def doSubscript(container: expr, idx: expr): String =
+    s"${translate(container)}[${translate(idx)}]"
+  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
+    s"${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)}"
+
+  // Predefined methods of various types
+  override def strToInt(s: expr, base: expr): String =
+  s"long.Parse(${translate(s)})"
+  override def strLength(s: expr): String =
+    s"${translate(s)}.Length"
+  override def strSubstring(s: expr, from: expr, to: expr): String =
+    s"${translate(s)}.Substring(${translate(from)}, ${translate(to)} - ${translate(from)})"
+
+  override def arrayFirst(a: expr): String =
+    s"${translate(a)}[0]"
+  override def arrayLast(a: expr): String = {
+    val v = translate(a)
+    s"$v[$v.Length - 1]"
+  }
+}

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -6,12 +6,10 @@ import io.kaitai.struct.exprlang.Ast._
 
 class CSharpTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
   override def doName(s: String) =
-    s match {
-      case "_root" => s
-      case "_parent" => s
-      case "_io" => s
-      case _ => s"${Utils.lowerCamelCase(s)}"
-    }
+    if (s.startsWith("_"))
+      s"M${Utils.upperCamelCase(s)}"
+    else
+      s"${Utils.upperCamelCase(s)}"
 
   override def doEnumByLabel(enumType: String, label: String): String =
     s"${Utils.upperCamelCase(enumType)}.${Utils.upperCamelCase(label)}"


### PR DESCRIPTION
I've made changes from the review in #1 and rebased it onto the original `csharp` branch. I've split the changes into multiple commits, hopefully that makes it easier to review. Let me know if I've done anything wrong!

--- 
There is one remaining issue which is the naming conflicts I explained in the previous PR.

Right now I've gone with the "standards first" approach, which basically favours the C# naming standards over passing the test cases.

Five of the test cases generate classes that do not compile. One option to fix it is to use camelCase for the public getters instead of CamelCase, but this deviates from the standard naming convention that's used in .NET. I've made a patch and a branch with an extra commit to make this change and fix the test cases. The branch is [csharp-camelcase](https://github.com/LogicAndTrick/kaitai_struct_compiler/tree/csharp-camelcase) and the diff is [here](https://github.com/LogicAndTrick/kaitai_struct_compiler/blob/csharp-camelcase/Use%20camelCase%20for%20public%20getters.diff). Let me know and I'll add it to this PR branch.