### PR TITLE
Add floating point data type

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/DataType.scala
@@ -39,6 +39,15 @@ object DataType {
     }
   }
 
+  abstract class FloatType extends BaseType {
+    def apiCall: String
+  }
+  case class FloatMultiType(width: IntWidth, endian: Endianness) extends FloatType {
+    override def apiCall: String = {
+      s"f${width.width}${endian.toString}"
+    }
+  }
+
   trait Processing {
     def process: Option[ProcessExpr]
   }
@@ -85,6 +94,7 @@ object DataType {
   case class EnumType(name: String, basedOn: IntType) extends BaseType
 
   private val ReIntType = """([us])(2|4|8)(le|be)?""".r
+  private val ReFloatType = """f(4|8)(le|be)?""".r
 
   def fromYaml(
     dt: String,
@@ -121,6 +131,22 @@ object DataType {
               defaultEndian match {
                 case Some(e) => e
                 case None => throw new RuntimeException(s"unable to use integer type '${dt}' without default endianness")
+              }
+          }
+        )
+      case ReFloatType(widthStr, endianStr) =>
+        FloatMultiType(
+          widthStr match {
+            case "4" => Width4
+            case "8" => Width8
+          },
+          endianStr match {
+            case "le" => LittleEndian
+            case "be" => BigEndian
+            case null =>
+              defaultEndian match {
+                case Some(e) => e
+                case None => throw new RuntimeException(s"unable to use floating point type '${dt}' without default endianness")
               }
           }
         )


### PR DESCRIPTION
This adds a base data type for floating point values. There's a sample test case in a branch here: https://github.com/kaitai-io/kaitai_struct_tests/commit/613a01bd20cd6c00bb6bf9633558dbcd6244168c

- I'm using the `IntWidth` type, but should I create a new `FloatWidth` type instead? Or perhaps `IntWidth` should be renamed to something more generic like `TypeWidth`?
- The `FloatType` extends the `BaseType`, but it shares an interface with `IntType`, so it might be better to abstract the `apiCall` method into a parent type `ApiType` or `NativeType`? I'm not sure what the best way to approach it is in Scala.

Because they don't share an interface, the compiler can't look like this:
```
      case t: IntType | t: FloatType => // or just `case t: ApiType`
        s"$io.Read${Utils.capitalize(t.apiCall)}()"
```
It has to look like this instead:
```
      case t: IntType =>
        s"$io.Read${Utils.capitalize(t.apiCall)}()"
      case t: FloatType =>
        s"$io.Read${Utils.capitalize(t.apiCall)}()"
```