### PR TITLE
Translator tests: Add floating point tests

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -166,21 +166,16 @@ class TranslatorSpec extends FunSuite with TableDrivenPropertyChecks {
   )
 
   for ((src, tp, expType, expOut) <- tests) {
-    val tryParse = Try(Expressions.parse(src))
     LanguageCompilerStatic.NAME_TO_CLASS.foreach { case (langName, langObj) =>
       test(s"$langName:$src") {
-        tryParse match {
-          case Failure(ex) =>
-            fail("failed to parse")
-          case Success(e) =>
-            val tr: BaseTranslator = langObj.getTranslator(tp)
-            expOut.get(langObj) match {
-              case Some(expResult) =>
-                tr.detectType(e) should be(expType)
-                tr.translate(e) should be(expResult)
-              case None =>
-                fail("no expected result")
-            }
+        val e = Expressions.parse(src)
+        val tr: BaseTranslator = langObj.getTranslator(tp)
+        expOut.get(langObj) match {
+          case Some(expResult) =>
+            tr.detectType(e) should be(expType)
+            tr.translate(e) should be(expResult)
+          case None =>
+            fail("no expected result")
         }
       }
     }


### PR DESCRIPTION
Floating point expressions aren't supported yet so they just throw an exception in the test runner before any results are generated. I wrapped the expression parse in a `Try` type, is that the best way to do it in Scala? I put the exception handler inside the compiler loop so that a failure is generated for each language.