### PR TITLE
BaseTranslator: Add floating point expressions

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/DataType.scala
@@ -42,7 +42,8 @@ object DataType {
     def apiCall: String
   }
 
-  abstract class IntType extends BaseType
+  abstract class NumericType extends BaseType
+  abstract class IntType extends NumericType
   case object CalcIntType extends IntType
   case class Int1Type(signed: Boolean) extends IntType with ReadableType {
     override def apiCall: String = if (signed) "s1" else "u1"
@@ -54,7 +55,7 @@ object DataType {
     }
   }
 
-  abstract class FloatType extends BaseType
+  abstract class FloatType extends NumericType
   case object CalcFloatType extends FloatType
   case class FloatMultiType(width: IntWidth, endian: Endianness) extends FloatType with ReadableType {
     override def apiCall: String = {

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
@@ -115,8 +115,8 @@ object Expressions {
       enumByName |
       STRING.rep(1).map(_.mkString).map(Ast.expr.Str) |
       NAME.map(Ast.expr.Name(_)) |
-      INT_NUMBER.map(Ast.expr.IntNum) |
-      FLOAT_NUMBER.map(Ast.expr.FloatNum)
+      FLOAT_NUMBER.map(Ast.expr.FloatNum) |
+      INT_NUMBER.map(Ast.expr.IntNum)
     )
   }
   val list_contents = P( test.rep(1, ",") ~ ",".? )

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -3,14 +3,15 @@ package io.kaitai.struct.translators
 import io.kaitai.struct.Utils
 import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.exprlang.Ast.expr
+import io.kaitai.struct.exprlang.DataType.IntType
 
 class JavaScriptTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
-  override def intBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr) = {
-    op match {
-      case Ast.operator.Div =>
+  override def numericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr) = {
+    (detectType(left), detectType(right), op) match {
+      case (_: IntType, _: IntType, Ast.operator.Div) =>
         s"Math.floor(${translate(left)} / ${translate(right)})"
       case _ =>
-        super.intBinOp(left, op, right)
+        super.numericBinOp(left, op, right)
     }
   }
 
@@ -44,6 +45,6 @@ class JavaScriptTranslator(provider: TypeProvider) extends BaseTranslator(provid
     s"${translate(a)}[0]"
   override def arrayLast(a: expr): String = {
     val v = translate(a)
-    s"$v.get($v.length - 1)"
+    s"$v[$v.length - 1]"
   }
 }


### PR DESCRIPTION
Okay, this one's a bit large, sorry about that. Hopefully these changes make sense. This is just for the expression/translator side of things, .ksy file tests will come later.

- `DataType.scala`
    - I've created a `NumericType` that both `IntType` and `FloatType` inherit from. Most operations use the same logic for both, so it's easier to do pattern matching this way.
- `Expressions.scala`
    - Moving the `FLOAT_NUMBER` above the `INT_NUMBER` fixes errors when parsing decimal values.
- `BaseTranslator.scala`
    - Added `doFloatLiteral`
    - Changed `doIntCompareOp` to `doNumericCompareOp` - all int and float compares go through this method
    - Changed `intBinOp` to `numericBinOp` - the logic for operators is the same for all languages for all numeric types (except JavaScript integer divides)
    - Only the `Minus` unary operation is valid for floats
    - If the left and right hand sides of a binary operation are integers, than `CalcIntType` will be used, otherwise `CalcFloatType` will be used when both sides are numeric.
- `JavaScriptTranslator.scala`
    - `Math.floor` should only be used for divides when both sides are integers