### PR TITLE
Unary operations on Int8/Int16 should be cast to Int32

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -196,8 +196,10 @@ abstract class BaseTranslator(val provider: TypeProvider) {
       case Ast.expr.UnaryOp(op: Ast.unaryop, v: Ast.expr) =>
         val t = detectType(v)
         (t, op) match {
-          case (Int1Type(false), _) => CalcIntType
-          case (_: IntType, _) => t
+          case (intMultiType: IntMultiType, _) =>
+            if (intMultiType.width.width > 4) t
+            else CalcIntType
+          case (_: IntType, _) => CalcIntType
           case (_: FloatType, Ast.unaryop.Minus) => t
           case _ => throw new RuntimeException(s"unable to apply unary operator ${op} to ${t}")
         }


### PR DESCRIPTION
In C# and Java (and probably other languages), negating a `byte` or `short` value automatically converts it to an `int`. This change emulates that logic. (Not sure if this is good code, it doesn't seem very 'Scala-like', please review)

---

KSY to replicate issue:
```yaml
meta:
  id: cast_to_int
  endian: le
seq:
  - id: value
    type: s2
instances:
  invalid_cast:
    value: -value
```
Compiled result (before change):
```cs
// Error CS0266 - Cannot implicitly convert type 'int' to 'short'. An explicit conversion exists (are you missing a cast?)
class CastToInt : KaitaiStruct
{
    ...
    
    private short _invalidCast;
    public short InvalidCast
    {
        get
        {
            ...
            _invalidCast = -Value;
            ...
        }
    }
}
```
After change:
```cs
// No compile errors
class CastToInt : KaitaiStruct
{
    ...
    
    private int _invalidCast;
    public int InvalidCast
    {
        get
        {
            ...
            _invalidCast = -Value;
            ...
        }
    }
}
```