### PR TITLE
PythonCompiler: remove from_file() helper

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -31,14 +31,6 @@ class PythonCompiler(verbose: Boolean, out: LanguageOutputWriter)
   override def classHeader(name: String): Unit = {
     out.puts(s"class ${type2class(name)}(KaitaiStruct):")
     out.inc
-
-    // Helper method to read from local file
-    out.puts("@classmethod")
-    out.puts("def from_file(cls, filename):")
-    out.inc
-    out.puts("return cls(KaitaiStream(open(filename, 'rb')))")
-    out.dec
-    out.puts
   }
 
   override def classFooter(name: String): Unit = {


### PR DESCRIPTION
This will make the generated code smaller.

(Obviously needs the method to be present in KaitaiStruct instead)