### PR TITLE
Formal names

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
@@ -228,7 +228,7 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
 //    }
   }
 
-  def compileEnum(enumName: NamedIdentifier, enumColl: Map[Long, String]): Unit = {
+  def compileEnum(enumName: String, enumColl: Map[Long, String]): Unit = {
     lang.enumDeclaration(nowClassName, enumName, enumColl)
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
@@ -97,8 +97,8 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
     lang.classHeader(name)
 
     val extraAttrs = ListBuffer[AttrSpec]()
-    extraAttrs += AttrSpec("_root", UserTypeInstream(topClassName))
-    extraAttrs += AttrSpec("_parent", UserTypeInstream(curClass.parentTypeName))
+    extraAttrs += AttrSpec(RootIdentifier, UserTypeInstream(topClassName))
+    extraAttrs += AttrSpec(ParentIdentifier, UserTypeInstream(curClass.parentTypeName))
 
     // Forward declarations for recursive types
     curClass.types.foreach { case (typeName, intClass) => lang.classForwardDeclaration(List(typeName)) }
@@ -136,7 +136,7 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
     }
   }
 
-  def compileInstance(className: List[String], instName: String, instSpec: InstanceSpec, extraAttrs: ListBuffer[AttrSpec]): Unit = {
+  def compileInstance(className: List[String], instName: InstanceIdentifier, instSpec: InstanceSpec, extraAttrs: ListBuffer[AttrSpec]): Unit = {
     // Determine datatype
     val dataType = getInstanceDataType(instSpec)
 
@@ -147,7 +147,8 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
     lang.instanceCheckCacheAndReturn(instName)
 
     instSpec match {
-      case ValueInstanceSpec(value, _) => lang.instanceCalculate(instName, dataType, value)
+      case ValueInstanceSpec(value, _) =>
+        lang.instanceCalculate(instName, dataType, value)
       case i: ParseInstanceSpec =>
         val io = i.io match {
           case None => lang.normalIO
@@ -157,7 +158,7 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
           lang.pushPos(io)
           lang.seek(io, pos)
         }
-        lang.attrParse(i, lang.instanceAttrName(instName), extraAttrs, io)
+        lang.attrParse(i, instName, extraAttrs, io)
         i.pos.foreach((pos) => lang.popPos(io))
     }
 
@@ -166,34 +167,36 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
     lang.instanceFooter
   }
 
-  override def determineType(attrName: String): BaseType = determineType(nowClass, nowClassName, attrName)
+  override def determineType(attrName: Identifier): BaseType = determineType(nowClass, nowClassName, attrName)
 
-  override def determineType(typeName: List[String], attrName: String): BaseType = {
+  override def determineType(typeName: List[String], attrName: Identifier): BaseType = {
     getTypeByName(nowClass, typeName) match {
       case Some(t) => determineType(t, typeName, attrName)
       case None => throw new RuntimeException(s"Unable to determine type for $attrName in type $typeName")
     }
   }
 
-  def determineType(classSpec: ClassSpec, className: List[String], attrName: String): BaseType = {
+  def determineType(classSpec: ClassSpec, className: List[String], attrName: Identifier): BaseType = {
     attrName match {
-      case "_root" =>
+      case RootIdentifier =>
         UserTypeInstream(topClassName)
-      case "_parent" =>
+      case ParentIdentifier =>
         UserTypeInstream(classSpec.parentTypeName)
-      case "_io" =>
+      case IoIdentifier =>
         KaitaiStreamType
-      case _ =>
+      case namedId: NamedIdentifier =>
         classSpec.seq.foreach { el =>
           if (el.id == attrName)
             return el.dataTypeComposite
         }
-        classSpec.instances.get(attrName) match {
+        throw new RuntimeException(s"Unable to access ${namedId.name} in $className context")
+      case instId: InstanceIdentifier =>
+        classSpec.instances.get(instId) match {
           case Some(i: ValueInstanceSpec) => return i.dataType.get
           case Some(i: ParseInstanceSpec) => return i.dataTypeComposite
           case None => // do nothing
         }
-        throw new RuntimeException(s"Unable to access ${attrName} in ${className} context")
+        throw new RuntimeException(s"Unable to access ${instId.name} in $className context")
     }
   }
 
@@ -225,7 +228,7 @@ class ClassCompiler(val topClass: ClassSpec, val lang: LanguageCompiler) extends
 //    }
   }
 
-  def compileEnum(enumName: String, enumColl: Map[Long, String]): Unit = {
+  def compileEnum(enumName: NamedIdentifier, enumColl: Map[Long, String]): Unit = {
     lang.enumDeclaration(nowClassName, enumName, enumColl)
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
@@ -33,7 +33,7 @@ trait AttrLikeSpec {
 }
 
 case class AttrSpec(
-  id: String,
+  id: Identifier,
   dataType: BaseType,
   cond: ConditionalSpec = ConditionalSpec(None, NoRepeat)
 ) extends AttrLikeSpec
@@ -106,7 +106,7 @@ object AttrSpec {
       case None => NoRepeat
     }
 
-    AttrSpec(id, dataType, ConditionalSpec(ifExpr, repeatSpec))
+    AttrSpec(NamedIdentifier(id), dataType, ConditionalSpec(ifExpr, repeatSpec))
   }
 
   private def boolFromStr(s: String, byDef: Boolean): Boolean = {

--- a/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
@@ -18,7 +18,7 @@ case class ClassSpec(
                       seq: List[AttrSpec],
                       types: Map[String, ClassSpec],
                       instances: Map[InstanceIdentifier, InstanceSpec],
-                      enums: Map[NamedIdentifier, Map[Long, String]]
+                      enums: Map[String, Map[Long, String]]
                     ) {
   var _parentType: NamedClassSpec = UnknownNamedClass
 
@@ -56,11 +56,11 @@ object ClassSpec {
     } else {
       _instances.toMap.map { case (k, v) => InstanceIdentifier(k) -> v }
     }
-    val enums: Map[NamedIdentifier, Map[Long, String]] = if (_enums == null) {
+    val enums: Map[String, Map[Long, String]] = if (_enums == null) {
       Map()
     } else {
       _enums.toMap.map { case(k, v) =>
-        NamedIdentifier(k) -> v.toMap.map { case (enumId, enumLabel) => (Utils.strToLong(enumId), enumLabel) }
+        k -> v.toMap.map { case (enumId, enumLabel) => (Utils.strToLong(enumId), enumLabel) }
       }
     }
 

--- a/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
@@ -17,8 +17,8 @@ case class ClassSpec(
                       meta: Option[MetaSpec],
                       seq: List[AttrSpec],
                       types: Map[String, ClassSpec],
-                      instances: Map[String, InstanceSpec],
-                      enums: Map[String, Map[Long, String]]
+                      instances: Map[InstanceIdentifier, InstanceSpec],
+                      enums: Map[NamedIdentifier, Map[Long, String]]
                     ) {
   var _parentType: NamedClassSpec = UnknownNamedClass
 
@@ -51,15 +51,17 @@ object ClassSpec {
     } else {
       _types.toMap
     }
-    val instances: Map[String, InstanceSpec] = if (_instances == null) {
+    val instances: Map[InstanceIdentifier, InstanceSpec] = if (_instances == null) {
       Map()
     } else {
-      _instances.toMap
+      _instances.toMap.map { case (k, v) => InstanceIdentifier(k) -> v }
     }
-    val enums: Map[String, Map[Long, String]] = if (_enums == null) {
+    val enums: Map[NamedIdentifier, Map[Long, String]] = if (_enums == null) {
       Map()
     } else {
-      _enums.toMap.map { case(k, v) => (k, v.toMap.map { case (enumId, enumLabel) => (Utils.strToLong(enumId), enumLabel) }) }
+      _enums.toMap.map { case(k, v) =>
+        NamedIdentifier(k) -> v.toMap.map { case (enumId, enumLabel) => (Utils.strToLong(enumId), enumLabel) }
+      }
     }
 
     ClassSpec(meta, seq, types, instances, enums)

--- a/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
@@ -1,6 +1,8 @@
 package io.kaitai.struct.format
 
-abstract class Identifier
+abstract class Identifier {
+  override def toString: String = throw new UnsupportedOperationException
+}
 
 case class NamedIdentifier(name: String) extends Identifier {
   Identifier.checkIdentifier(name)

--- a/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
@@ -3,16 +3,20 @@ package io.kaitai.struct.format
 abstract class Identifier
 
 case class NamedIdentifier(name: String) extends Identifier {
-  name match {
-    case Identifier.ReIdentifier(_) =>
-      // name is valid, everything's fine
-    case _ =>
-      throw new RuntimeException("invalid identifier: \"" + name + "\"")
-  }
+  Identifier.checkIdentifier(name)
 }
 
 object Identifier {
   val ReIdentifier = "^[a-z][a-z0-9_]*$".r
+
+  def checkIdentifier(id: String): Unit = {
+    id match {
+      case ReIdentifier() =>
+      // name is valid, everything's fine
+      case _ =>
+        throw new RuntimeException("invalid identifier: \"" + id + "\"")
+    }
+  }
 }
 
 case class RawIdentifier(innerId: Identifier) extends Identifier
@@ -20,12 +24,7 @@ case class RawIdentifier(innerId: Identifier) extends Identifier
 case class IoStorageIdentifier(innerId: Identifier) extends Identifier
 
 case class InstanceIdentifier(name: String) extends Identifier {
-  name match {
-    case Identifier.ReIdentifier(_) =>
-      // name is valid, everything's fine
-    case _ =>
-      throw new RuntimeException("invalid identifier: \"" + name + "\"")
-  }
+  Identifier.checkIdentifier(name)
 }
 
 case class SpecialIdentifier(name: String) extends Identifier

--- a/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
@@ -17,6 +17,8 @@ object Identifier {
 
 case class RawIdentifier(innerId: Identifier) extends Identifier
 
+case class IoStorageIdentifier(innerId: Identifier) extends Identifier
+
 case class InstanceIdentifier(name: String) extends Identifier {
   name match {
     case Identifier.ReIdentifier(_) =>

--- a/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
@@ -26,8 +26,8 @@ case class InstanceIdentifier(name: String) extends Identifier {
   }
 }
 
-class SpecialIdentifier(name: String) extends Identifier
+case class SpecialIdentifier(name: String) extends Identifier
 
-case object RootIdentifier extends SpecialIdentifier("_root")
-case object ParentIdentifier extends SpecialIdentifier("_parent")
-case object IoIdentifier extends SpecialIdentifier("_io")
+object RootIdentifier extends SpecialIdentifier("_root")
+object ParentIdentifier extends SpecialIdentifier("_parent")
+object IoIdentifier extends SpecialIdentifier("_io")

--- a/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/Identifier.scala
@@ -1,0 +1,33 @@
+package io.kaitai.struct.format
+
+abstract class Identifier
+
+case class NamedIdentifier(name: String) extends Identifier {
+  name match {
+    case Identifier.ReIdentifier(_) =>
+      // name is valid, everything's fine
+    case _ =>
+      throw new RuntimeException("invalid identifier: \"" + name + "\"")
+  }
+}
+
+object Identifier {
+  val ReIdentifier = "^[a-z][a-z0-9_]*$".r
+}
+
+case class RawIdentifier(innerId: Identifier) extends Identifier
+
+case class InstanceIdentifier(name: String) extends Identifier {
+  name match {
+    case Identifier.ReIdentifier(_) =>
+      // name is valid, everything's fine
+    case _ =>
+      throw new RuntimeException("invalid identifier: \"" + name + "\"")
+  }
+}
+
+class SpecialIdentifier(name: String) extends Identifier
+
+case object RootIdentifier extends SpecialIdentifier("_root")
+case object ParentIdentifier extends SpecialIdentifier("_parent")
+case object IoIdentifier extends SpecialIdentifier("_io")

--- a/shared/src/main/scala/io/kaitai/struct/languages/AllocateAndStoreIO.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/AllocateAndStoreIO.scala
@@ -1,6 +1,6 @@
 package io.kaitai.struct.languages
 
-import io.kaitai.struct.format.{Identifier, NamedIdentifier, RepeatSpec}
+import io.kaitai.struct.format.{Identifier, IoStorageIdentifier, RepeatSpec}
 
 /**
   * Allocates new IO and returns attribute identifier that it will be stored
@@ -8,5 +8,5 @@ import io.kaitai.struct.format.{Identifier, NamedIdentifier, RepeatSpec}
   * keep track of allocated IOs.
   */
 trait AllocateAndStoreIO {
-  def allocateIO(varName: Identifier, rep: RepeatSpec): NamedIdentifier
+  def allocateIO(varName: Identifier, rep: RepeatSpec): IoStorageIdentifier
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/AllocateAndStoreIO.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/AllocateAndStoreIO.scala
@@ -1,0 +1,12 @@
+package io.kaitai.struct.languages
+
+import io.kaitai.struct.format.{Identifier, NamedIdentifier, RepeatSpec}
+
+/**
+  * Allocates new IO and returns attribute identifier that it will be stored
+  * at. This is used for languages without garbage collection that need to
+  * keep track of allocated IOs.
+  */
+trait AllocateAndStoreIO {
+  def allocateIO(varName: Identifier, rep: RepeatSpec): NamedIdentifier
+}

--- a/shared/src/main/scala/io/kaitai/struct/languages/AllocateIOLocalVar.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/AllocateIOLocalVar.scala
@@ -1,0 +1,11 @@
+package io.kaitai.struct.languages
+
+import io.kaitai.struct.format.{Identifier, RepeatSpec}
+
+/**
+  * Allocates new auxiliary IOs as local vars - no references saved and thus
+  * probably garbage collector will deal with them.
+  */
+trait AllocateIOLocalVar {
+  def allocateIO(varName: Identifier, rep: RepeatSpec): String
+}

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -232,9 +232,6 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit =
-    handleAssignmentSimple(instName, expression(value))
-
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     val enumClass = type2class(enumName)
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -429,6 +429,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
       case IoStorageIdentifier(inner) => s"io_${privateMemberName(inner)}"
       case si: SpecialIdentifier => si.name
       case ni: NamedIdentifier => ni.name
+      case ni: InstanceIdentifier => ni.name
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -117,7 +117,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
 
   override def attributeDeclaration(attrName: Identifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
     ensureMode(PrivateAccess)
-    outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${idToStr(attrName)};")
+    outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")
 
     if (condSpec.ifExpr.nonEmpty) {
       outHdr.puts(s"bool ${flagForInstName(attrName)};")
@@ -425,8 +425,8 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
 
   override def idToStr(id: Identifier): String = {
     id match {
-      case RawIdentifier(inner) => s"raw_${privateMemberName(inner)}"
-      case IoStorageIdentifier(inner) => s"io_${privateMemberName(inner)}"
+      case RawIdentifier(inner) => s"_raw_${idToStr(inner)}"
+      case IoStorageIdentifier(inner) => s"_io_${idToStr(inner)}"
       case si: SpecialIdentifier => si.name
       case ni: NamedIdentifier => ni.name
       case ni: InstanceIdentifier => ni.name

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -330,10 +330,6 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit = {
-    outSrc.puts(s"${privateMemberName(instName)} = ${expression(value)};")
-  }
-
   override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Map[Long, String]): Unit = {
     val enumClass = type2class(List(enumName))
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -220,11 +220,11 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
   override def popPos(io: String): Unit =
     outSrc.puts(s"$io->seek(_pos);")
 
-  override def instanceClear(instName: InstanceIdentifier): Unit = {
+  override def instanceClear(instName: Identifier): Unit = {
     outSrc.puts(s"${flagForInstName(instName)} = false;")
   }
 
-  override def instanceSetCalculated(instName: InstanceIdentifier): Unit = {
+  override def instanceSetCalculated(instName: Identifier): Unit = {
     outSrc.puts(s"${flagForInstName(instName)} = true;")
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -9,7 +9,6 @@ import io.kaitai.struct.{LanguageOutputWriter, Utils}
 
 class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: LanguageOutputWriter)
   extends LanguageCompiler(verbose, outSrc)
-    with StreamStructNames
     with AllocateAndStoreIO
     with EveryReadIsExpression {
   import CppCompiler._
@@ -93,8 +92,8 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
       s"${type2class(rootClassName)} *_root) : $kstructName(_io) {"
     )
     outSrc.inc
-    handleAssignmentSimple("_parent", "_parent")
-    handleAssignmentSimple("_root", if (name == rootClassName) {
+    handleAssignmentSimple(ParentIdentifier, "_parent")
+    handleAssignmentSimple(RootIdentifier, if (name == rootClassName) {
       "this"
     } else {
       "_root"
@@ -118,7 +117,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
 
   override def attributeDeclaration(attrName: Identifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
     ensureMode(PrivateAccess)
-    outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")
+    outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${idToStr(attrName)};")
 
     if (condSpec.ifExpr.nonEmpty) {
       outHdr.puts(s"bool ${flagForInstName(attrName)};")
@@ -140,10 +139,10 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
 
   override def attributeReader(attrName: Identifier, attrType: BaseType): Unit = {
     ensureMode(PublicAccess)
-    outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${attrReaderName(attrName)}() const { return ${privateMemberName(attrName)}; }")
+    outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${publicMemberName(attrName)}() const { return ${privateMemberName(attrName)}; }")
   }
 
-  override def attrDestructor(attr: AttrLikeSpec, id: String): Unit = {
+  override def attrDestructor(attr: AttrLikeSpec, id: Identifier): Unit = {
     var t = attr.dataTypeComposite
 
     if (attr.isArray) {
@@ -167,35 +166,36 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     }
   }
 
-  override def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit = {
+  override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = {
     val strLiteral = contents.map { x => "\\x%02x".format(x) }.mkString
     outSrc.puts(s"${privateMemberName(attrName)} = $normalIO->ensure_fixed_contents(${contents.length}, " + "\"" + strLiteral + "\");")
   }
 
-  override def attrProcess(proc: ProcessExpr, varSrc: String, varDest: String): Unit = {
+  override def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit = {
+    val srcName = privateMemberName(varSrc)
+    val destName = privateMemberName(varDest)
+
     proc match {
       case ProcessXor(xorValue) =>
         val procName = translator.detectType(xorValue) match {
           case _: IntType => "process_xor_one"
           case _: BytesType => "process_xor_many"
         }
-        outSrc.puts(s"${privateMemberName(varDest)} = $kstreamName::$procName(${privateMemberName(varSrc)}, ${expression(xorValue)});")
+        outSrc.puts(s"$destName = $kstreamName::$procName($srcName, ${expression(xorValue)});")
       case ProcessRotate(isLeft, rotValue) =>
         val expr = if (isLeft) {
           expression(rotValue)
         } else {
           s"8 - (${expression(rotValue)})"
         }
-        outSrc.puts(s"${privateMemberName(varDest)} = $kstreamName::process_rotate_left(${privateMemberName(varSrc)}, $expr);")
+        outSrc.puts(s"$destName = $kstreamName::process_rotate_left($srcName, $expr);")
     }
   }
 
-  override def normalIO: String = privateMemberName("_io")
-
-  override def allocateIO(varName: Identifier, rep: RepeatSpec): NamedIdentifier = {
+  override def allocateIO(varName: Identifier, rep: RepeatSpec): IoStorageIdentifier = {
     val memberName = privateMemberName(varName)
 
-    val ioName = s"_io_$varName"
+    val ioName = IoStorageIdentifier(varName)
 
     val args = rep match {
       case RepeatEos | RepeatExpr(_) => s"$memberName.get($memberName.size() - 1)"
@@ -220,11 +220,11 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
   override def popPos(io: String): Unit =
     outSrc.puts(s"$io->seek(_pos);")
 
-  override def instanceClear(instName: String): Unit = {
+  override def instanceClear(instName: InstanceIdentifier): Unit = {
     outSrc.puts(s"${flagForInstName(instName)} = false;")
   }
 
-  override def instanceSetCalculated(instName: String): Unit = {
+  override def instanceSetCalculated(instName: InstanceIdentifier): Unit = {
     outSrc.puts(s"${flagForInstName(instName)} = true;")
   }
 
@@ -238,7 +238,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.puts("}")
   }
 
-  override def condRepeatEosHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
+  override def condRepeatEosHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
     if (needRaw)
       outSrc.puts(s"this._raw_${privateMemberName(id)} = new ArrayList<byte[]>();")
     outSrc.puts(s"${privateMemberName(id)} = new std::vector<${kaitaiType2NativeType(dataType)}>();")
@@ -246,7 +246,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.inc
   }
 
-  override def handleAssignmentRepeatEos(id: String, expr: String): Unit = {
+  override def handleAssignmentRepeatEos(id: Identifier, expr: String): Unit = {
     outSrc.puts(s"${privateMemberName(id)}->push_back($expr);")
   }
 
@@ -255,7 +255,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.puts("}")
   }
 
-  override def condRepeatExprHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
+  override def condRepeatExprHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
     if (needRaw)
       outSrc.puts(s"this._raw_${privateMemberName(id)} = new ArrayList<byte[]>((int) (${expression(repeatExpr)}));")
     outSrc.puts(s"${privateMemberName(id)} = new std::vector<${kaitaiType2NativeType(dataType)}>();")
@@ -264,7 +264,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.inc
   }
 
-  override def handleAssignmentRepeatExpr(id: String, expr: String): Unit = {
+  override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit = {
     outSrc.puts(s"${privateMemberName(id)}->push_back($expr);")
   }
 
@@ -273,7 +273,7 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.puts("}")
   }
 
-  override def handleAssignmentSimple(id: String, expr: String): Unit = {
+  override def handleAssignmentSimple(id: Identifier, expr: String): Unit = {
     outSrc.puts(s"${privateMemberName(id)} = $expr;")
   }
 
@@ -295,44 +295,42 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
       case BytesEosType(_) =>
         s"$io->read_bytes_full()"
       case t: UserType =>
-        s"new ${type2class(t.name)}($io, this, ${privateMemberName("_root")})"
+        s"new ${type2class(t.name)}($io, this, ${privateMemberName(RootIdentifier)})"
     }
   }
 
-  override def instanceDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
+  override def instanceDeclaration(attrName: InstanceIdentifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
     ensureMode(PrivateAccess)
     outHdr.puts(s"bool ${flagForInstName(attrName)};")
     outHdr.puts(s"${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")
   }
 
-  override def instanceHeader(className: List[String], instName: NamedIdentifier, dataType: BaseType): Unit = {
+  override def instanceHeader(className: List[String], instName: InstanceIdentifier, dataType: BaseType): Unit = {
     ensureMode(PublicAccess)
-    outHdr.puts(s"${kaitaiType2NativeType(dataType)} ${attrReaderName(instName)}();")
+    outHdr.puts(s"${kaitaiType2NativeType(dataType)} ${publicMemberName(instName)}();")
 
     outSrc.puts
-    outSrc.puts(s"${kaitaiType2NativeType(dataType, true, className)} ${type2class(className)}::${attrReaderName(instName)}() {")
+    outSrc.puts(s"${kaitaiType2NativeType(dataType, true, className)} ${type2class(className)}::${publicMemberName(instName)}() {")
     outSrc.inc
   }
-
-  override def instanceAttrName(instName: String): String = instName
 
   override def instanceFooter: Unit = {
     outSrc.dec
     outSrc.puts("}")
   }
 
-  override def instanceCheckCacheAndReturn(instName: String): Unit = {
+  override def instanceCheckCacheAndReturn(instName: InstanceIdentifier): Unit = {
     outSrc.puts(s"if (${flagForInstName(instName)})")
     outSrc.inc
     instanceReturn(instName)
     outSrc.dec
   }
 
-  override def instanceReturn(instName: String): Unit = {
+  override def instanceReturn(instName: InstanceIdentifier): Unit = {
     outSrc.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: String, dataType: BaseType, value: expr): Unit = {
+  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit = {
     outSrc.puts(s"${privateMemberName(instName)} = ${expression(value)};")
   }
 
@@ -411,33 +409,12 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
 
   def defineName(className: String) = className.toUpperCase + "_H_"
 
-  override def privateMemberName(ksName: Identifier): String = {
+  def flagForInstName(ksName: Identifier) = {
     ksName match {
-      case RawIdentifier(inner) => s"m_raw_${privateMemberName(inner)}"
-      case si: SpecialIdentifier => s"m_${si.name}"
-      case ni: NamedIdentifier => s"m_${ni.name}"
+      case NamedIdentifier(name) => s"f_$name"
+      case InstanceIdentifier(name) => s"f_$name"
     }
   }
-
-  def attrReaderName(ksName: String) = {
-    /*
-    if (ksName == "_root" || ksName == "_parent" || ksName == "_io") {
-      "m" + ksName
-    } else if (ksName.startsWith("_raw_")) {
-      "m_raw_" + Utils.lowerCamelCase(ksName.substring("_raw_".length))
-    } else {
-      Utils.lowerCamelCase(ksName)
-    }*/
-    ksName
-  }
-
-  def flagForInstName(ksName: NamedIdentifier) = s"f_${ksName.name}"
-
-  def rawMemberName(ksName: String) = "raw_" + ksName
-
-  override def kstructName = "kaitai::kstruct"
-
-  override def kstreamName = "kaitai::kstream"
 
   def type2class(components: List[String]) = {
     components.map {
@@ -445,10 +422,26 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
       case s => s + "_t"
     }.mkString("::")
   }
+
+  override def idToStr(id: Identifier): String = {
+    id match {
+      case RawIdentifier(inner) => s"raw_${privateMemberName(inner)}"
+      case IoStorageIdentifier(inner) => s"io_${privateMemberName(inner)}"
+      case si: SpecialIdentifier => si.name
+      case ni: NamedIdentifier => ni.name
+    }
+  }
+
+  override def privateMemberName(id: Identifier): String = s"m_${idToStr(id)}"
+
+  override def publicMemberName(id: Identifier): String = idToStr(id)
 }
 
-object CppCompiler extends LanguageCompilerStatic {
+object CppCompiler extends LanguageCompilerStatic with StreamStructNames {
   override def getTranslator(tp: TypeProvider): BaseTranslator = new CppTranslator(tp)
   override def indent: String = "    "
   override def outFileName(topClassName: String): String = topClassName
+
+  override def kstructName = "kaitai::kstruct"
+  override def kstreamName = "kaitai::kstream"
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/EveryReadIsExpression.scala
@@ -158,4 +158,7 @@ trait EveryReadIsExpression extends LanguageCompiler {
   def handleAssignmentSimple(id: Identifier, expr: String): Unit
 
   def parseExpr(dataType: BaseType, io: String): String
+
+  def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: Ast.expr) =
+    handleAssignmentSimple(instName, expression(value))
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -103,7 +103,7 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
   }
 
   override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = {
-    out.puts(s"${privateMemberName(attrName)} = _io.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
+    out.puts(s"${privateMemberName(attrName)} = $normalIO.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
   }
 
   override def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -9,7 +9,6 @@ import io.kaitai.struct.{LanguageOutputWriter, RuntimeConfig, Utils}
 
 class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: String = "")
   extends LanguageCompiler(verbose, out)
-    with StreamStructNames
     with EveryReadIsExpression
     with UniversalFooter
     with AllocateIOLocalVar
@@ -125,8 +124,6 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
         out.puts(s"$destName = _io.processRotateLeft($srcName, $expr, 1);")
     }
   }
-
-  override def normalIO: String = "_io"
 
   override def allocateIO(varName: Identifier, rep: RepeatSpec): String = {
     val javaName = idToStr(varName)
@@ -248,8 +245,8 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
     }
   }
 
-  override def enumDeclaration(curClass: String, enumName: NamedIdentifier, enumColl: Map[Long, String]): Unit = {
-    val enumClass = type2class(enumName.name)
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
+    val enumClass = type2class(enumName)
 
     out.puts
     out.puts(s"public enum $enumClass {")
@@ -297,12 +294,12 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
 
   override def privateMemberName(id: Identifier): String = s"this.${idToStr(id)}"
 
-  override def kstreamName: String = "KaitaiStream"
-
-  override def kstructName: String = "KaitaiStruct"
+  override def publicMemberName(id: Identifier) = idToStr(id)
 }
 
-object JavaCompiler extends LanguageCompilerStatic with UpperCamelCaseClasses {
+object JavaCompiler extends LanguageCompilerStatic
+  with UpperCamelCaseClasses
+  with StreamStructNames {
   override def getTranslator(tp: TypeProvider): BaseTranslator = new JavaTranslator(tp)
   override def indent: String = "    "
   override def outFileName(topClassName: String): String = s"${type2class(topClassName)}.java"
@@ -379,4 +376,7 @@ object JavaCompiler extends LanguageCompilerStatic with UpperCamelCaseClasses {
   }
 
   def types2class(names: List[String]) = names.map(x => type2class(x)).mkString(".")
+
+  override def kstreamName: String = "KaitaiStream"
+  override def kstructName: String = "KaitaiStruct"
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -1,17 +1,18 @@
 package io.kaitai.struct.languages
 
-import io.kaitai.struct.{LanguageOutputWriter, RuntimeConfig, Utils}
 import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.exprlang.Ast.expr
 import io.kaitai.struct.exprlang.DataType._
 import io.kaitai.struct.format._
 import io.kaitai.struct.translators.{BaseTranslator, JavaTranslator, TypeProvider}
+import io.kaitai.struct.{LanguageOutputWriter, RuntimeConfig, Utils}
 
 class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: String = "")
   extends LanguageCompiler(verbose, out)
     with StreamStructNames
     with EveryReadIsExpression
     with UniversalFooter
+    with AllocateIOLocalVar
     with NoNeedForFullClassPath {
   import JavaCompiler._
 
@@ -94,38 +95,41 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
     out.inc
   }
 
-  override def attributeDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
-    out.puts(s"private ${kaitaiType2JavaType(attrType)} ${lowerCamelCase(attrName)};")
+  override def attributeDeclaration(attrName: Identifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
+    out.puts(s"private ${kaitaiType2JavaType(attrType)} ${idToStr(attrName)};")
   }
 
-  override def attributeReader(attrName: String, attrType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2JavaType(attrType)} ${lowerCamelCase(attrName)}() { return ${lowerCamelCase(attrName)}; }")
+  override def attributeReader(attrName: Identifier, attrType: BaseType): Unit = {
+    out.puts(s"public ${kaitaiType2JavaType(attrType)} ${idToStr(attrName)}() { return ${idToStr(attrName)}; }")
   }
 
-  override def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit = {
-    out.puts(s"this.${lowerCamelCase(attrName)} = _io.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
+  override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = {
+    out.puts(s"${privateMemberName(attrName)} = _io.ensureFixedContents(${contents.length}, new byte[] { ${contents.mkString(", ")} });")
   }
 
-  override def attrProcess(proc: ProcessExpr, varSrc: String, varDest: String): Unit = {
+  override def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit = {
+    val srcName = privateMemberName(varSrc)
+    val destName = privateMemberName(varDest)
+
     proc match {
       case ProcessXor(xorValue) =>
-        out.puts(s"this.$varDest = _io.processXor(this.$varSrc, ${expression(xorValue)});")
+        out.puts(s"$destName = _io.processXor($srcName, ${expression(xorValue)});")
       case ProcessZlib =>
-        out.puts(s"this.$varDest = _io.processZlib(this.$varSrc);")
+        out.puts(s"$destName = _io.processZlib($srcName);")
       case ProcessRotate(isLeft, rotValue) =>
         val expr = if (isLeft) {
           expression(rotValue)
         } else {
           s"8 - (${expression(rotValue)})"
         }
-        out.puts(s"this.$varDest = _io.processRotateLeft(this.$varSrc, $expr, 1);")
+        out.puts(s"$destName = _io.processRotateLeft($srcName, $expr, 1);")
     }
   }
 
   override def normalIO: String = "_io"
 
-  override def allocateIO(varName: String, rep: RepeatSpec): String = {
-    val javaName = lowerCamelCase(varName)
+  override def allocateIO(varName: Identifier, rep: RepeatSpec): String = {
+    val javaName = idToStr(varName)
 
     val ioName = s"_io_$javaName"
 
@@ -157,31 +161,31 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
     out.inc
   }
 
-  override def condRepeatEosHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
+  override def condRepeatEosHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
     if (needRaw)
-      out.puts(s"this._raw_${lowerCamelCase(id)} = new ArrayList<byte[]>();")
+      out.puts(s"${privateMemberName(RawIdentifier(id))} = new ArrayList<byte[]>();")
     out.puts(s"${privateMemberName(id)} = new ${kaitaiType2JavaType(ArrayType(dataType))}();")
     out.puts(s"while (!$io.isEof()) {")
     out.inc
   }
 
-  override def handleAssignmentRepeatEos(id: String, expr: String): Unit = {
+  override def handleAssignmentRepeatEos(id: Identifier, expr: String): Unit = {
     out.puts(s"${privateMemberName(id)}.add($expr);")
   }
 
-  override def condRepeatExprHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
+  override def condRepeatExprHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
     if (needRaw)
-      out.puts(s"this._raw_${lowerCamelCase(id)} = new ArrayList<byte[]>((int) (${expression(repeatExpr)}));")
-    out.puts(s"${lowerCamelCase(id)} = new ${kaitaiType2JavaType(ArrayType(dataType))}((int) (${expression(repeatExpr)}));")
+      out.puts(s"${privateMemberName(RawIdentifier(id))} = new ArrayList<byte[]>((int) (${expression(repeatExpr)}));")
+    out.puts(s"${idToStr(id)} = new ${kaitaiType2JavaType(ArrayType(dataType))}((int) (${expression(repeatExpr)}));")
     out.puts(s"for (int i = 0; i < ${expression(repeatExpr)}; i++) {")
     out.inc
   }
 
-  override def handleAssignmentRepeatExpr(id: String, expr: String): Unit = {
+  override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit = {
     out.puts(s"${privateMemberName(id)}.add($expr);")
   }
 
-  override def handleAssignmentSimple(id: String, expr: String): Unit = {
+  override def handleAssignmentSimple(id: Identifier, expr: String): Unit = {
     out.puts(s"${privateMemberName(id)} = $expr;")
   }
 
@@ -207,29 +211,27 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
     }
   }
 
-  override def instanceDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
-    out.puts(s"private ${kaitaiType2JavaTypeBoxed(attrType)} ${lowerCamelCase(attrName)};")
+  override def instanceDeclaration(attrName: InstanceIdentifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
+    out.puts(s"private ${kaitaiType2JavaTypeBoxed(attrType)} ${idToStr(attrName)};")
   }
 
-  override def instanceHeader(className: String, instName: String, dataType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2JavaTypeBoxed(dataType)} ${lowerCamelCase(instName)}() throws IOException {")
+  override def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit = {
+    out.puts(s"public ${kaitaiType2JavaTypeBoxed(dataType)} ${idToStr(instName)}() throws IOException {")
     out.inc
   }
 
-  override def instanceAttrName(instName: String): String = instName
-
-  override def instanceCheckCacheAndReturn(instName: String): Unit = {
-    out.puts(s"if (${lowerCamelCase(instName)} != null)")
+  override def instanceCheckCacheAndReturn(instName: InstanceIdentifier): Unit = {
+    out.puts(s"if (${privateMemberName(instName)} != null)")
     out.inc
     instanceReturn(instName)
     out.dec
   }
 
-  override def instanceReturn(instName: String): Unit = {
-    out.puts(s"return ${lowerCamelCase(instName)};")
+  override def instanceReturn(instName: InstanceIdentifier): Unit = {
+    out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: String, dataType: BaseType, value: expr): Unit = {
+  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit = {
     val primType = kaitaiType2JavaTypePrim(dataType)
     val boxedType = kaitaiType2JavaTypeBoxed(dataType)
 
@@ -240,14 +242,14 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
       // Double c = 1.0f + 1;
 
       out.puts(s"$primType _tmp = ${expression(value)};")
-      out.puts(s"${lowerCamelCase(instName)} = _tmp;")
+      out.puts(s"${privateMemberName(instName)} = _tmp;")
     } else {
-      out.puts(s"${lowerCamelCase(instName)} = ${expression(value)};")
+      out.puts(s"${privateMemberName(instName)} = ${expression(value)};")
     }
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
-    val enumClass = type2class(enumName)
+  override def enumDeclaration(curClass: String, enumName: NamedIdentifier, enumColl: Map[Long, String]): Unit = {
+    val enumClass = type2class(enumName.name)
 
     out.puts
     out.puts(s"public enum $enumClass {")
@@ -284,17 +286,16 @@ class JavaCompiler(verbose: Boolean, out: LanguageOutputWriter, destPackage: Str
 
   def value2Const(s: String) = s.toUpperCase
 
-  def lowerCamelCase(s: String): String = {
-    if (s == "_root" || s == "_parent" || s == "_io") {
-      s
-    } else if (s.startsWith("_raw_")) {
-      "_raw_" + lowerCamelCase(s.substring("_raw_".length))
-    } else {
-      Utils.lowerCamelCase(s)
+  def idToStr(id: Identifier): String = {
+    id match {
+      case SpecialIdentifier(name) => name
+      case NamedIdentifier(name) => Utils.lowerCamelCase(name)
+      case InstanceIdentifier(name) => Utils.lowerCamelCase(name)
+      case RawIdentifier(innerId) => "_raw_" + idToStr(innerId)
     }
   }
 
-  override def privateMemberName(ksName: String): String = s"this.${lowerCamelCase(ksName)}"
+  override def privateMemberName(id: Identifier): String = s"this.${idToStr(id)}"
 
   override def kstreamName: String = "KaitaiStream"
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -230,9 +230,6 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit =
-    handleAssignmentSimple(instName, expression(value))
-
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     out.puts
     out.puts(s"${type2class(curClass)}.${type2class(enumName)} = Object.freeze({")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -9,6 +9,7 @@ import io.kaitai.struct.{LanguageOutputWriter, Utils}
 
 class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
   extends LanguageCompiler(verbose, out)
+    with AllocateIOLocalVar
     with StreamStructNames
     with EveryReadIsExpression
     with NoNeedForFullClassPath {
@@ -70,45 +71,47 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts("}")
   }
 
-  override def attributeDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit = {}
+  override def attributeDeclaration(attrName: Identifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {}
 
-  override def attributeReader(attrName: String, attrType: BaseType): Unit = {}
+  override def attributeReader(attrName: Identifier, attrType: BaseType): Unit = {}
 
-  override def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit = {
-    out.puts(s"${privateMemberName(attrName)} = _io.ensureFixedContents(${contents.length}, [${contents.mkString(", ")}]);")
+  override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = {
+    out.puts(s"${privateMemberName(attrName)} = $normalIO.ensureFixedContents(${contents.length}, [${contents.mkString(", ")}]);")
   }
 
-  override def attrProcess(proc: ProcessExpr, varSrc: String, varDest: String): Unit = {
+  override def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit = {
+    val srcName = privateMemberName(varSrc)
+    val destName = privateMemberName(varDest)
+
     proc match {
       case ProcessXor(xorValue) =>
         val procName = translator.detectType(xorValue) match {
           case _: IntType => "processXorOne"
           case _: BytesType => "processXorMany"
         }
-        out.puts(s"${privateMemberName(varDest)} = $kstreamName.$procName(${privateMemberName(varSrc)}, ${expression(xorValue)});")
+        out.puts(s"$destName = $kstreamName.$procName($srcName, ${expression(xorValue)});")
       case ProcessZlib =>
-        out.puts(s"this.$varDest = $kstreamName.processZlib(this.$varSrc);")
+        out.puts(s"$destName = $kstreamName.processZlib($srcName);")
       case ProcessRotate(isLeft, rotValue) =>
         val expr = if (isLeft) {
           expression(rotValue)
         } else {
           s"8 - (${expression(rotValue)})"
         }
-        out.puts(s"this.$varDest = $kstreamName.processRotateLeft(this.$varSrc, $expr, 1);")
+        out.puts(s"$destName = $kstreamName.processRotateLeft($srcName, $expr, 1);")
     }
   }
 
-  override def normalIO: String = "this._io"
+  override def allocateIO(varName: Identifier, rep: RepeatSpec): String = {
+    val langName = idToStr(varName)
+    val memberCall = privateMemberName(varName)
 
-  override def allocateIO(varName: String, rep: RepeatSpec): String = {
-    val langName = lowerCamelCase(varName)
-
-    val ioName = s"this._io_$langName"
+    val ioName = s"_io_$langName"
 
     val args = rep match {
-      case RepeatEos => s"this.$langName[this.$langName.length - 1]"
-      case RepeatExpr(_) => s"this.$langName[i]"
-      case NoRepeat => s"this.$langName"
+      case RepeatEos => s"$memberCall[$memberCall.length - 1]"
+      case RepeatExpr(_) => s"$memberCall[i]"
+      case NoRepeat => memberCall
     }
 
     out.puts(s"$ioName = new $kstreamName($args);")
@@ -139,16 +142,16 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts("}")
   }
 
-  override def condRepeatEosHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
+  override def condRepeatEosHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean): Unit = {
     if (needRaw)
-      out.puts(s"this._raw_${lowerCamelCase(id)} = [];")
-    out.puts(s"this.${lowerCamelCase(id)} = [];")
+      out.puts(s"${privateMemberName(RawIdentifier(id))} = [];")
+    out.puts(s"${privateMemberName(id)} = [];")
     out.puts(s"while (!$io.isEof()) {")
     out.inc
   }
 
-  override def handleAssignmentRepeatEos(id: String, expr: String): Unit = {
-    out.puts(s"this.${lowerCamelCase(id)}.push($expr);")
+  override def handleAssignmentRepeatEos(id: Identifier, expr: String): Unit = {
+    out.puts(s"this.${idToStr(id)}.push($expr);")
   }
 
   override def condRepeatEosFooter: Unit = {
@@ -156,16 +159,16 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts("}")
   }
 
-  override def condRepeatExprHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
+  override def condRepeatExprHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit = {
     if (needRaw)
-      out.puts(s"this._raw_${lowerCamelCase(id)} = new Array(${expression(repeatExpr)});")
-    out.puts(s"this.${lowerCamelCase(id)} = new Array(${expression(repeatExpr)});")
+      out.puts(s"${privateMemberName(RawIdentifier(id))} = new Array(${expression(repeatExpr)});")
+    out.puts(s"${privateMemberName(id)} = new Array(${expression(repeatExpr)});")
     out.puts(s"for (var i = 0; i < ${expression(repeatExpr)}; i++) {")
     out.inc
   }
 
-  override def handleAssignmentRepeatExpr(id: String, expr: String): Unit = {
-    out.puts(s"this.${lowerCamelCase(id)}[i] = $expr;")
+  override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit = {
+    out.puts(s"${privateMemberName(id)}[i] = $expr;")
   }
 
   override def condRepeatExprFooter: Unit = {
@@ -173,8 +176,8 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts("}")
   }
 
-  override def handleAssignmentSimple(id: String, expr: String): Unit = {
-    out.puts(s"this.${lowerCamelCase(id)} = $expr;")
+  override def handleAssignmentSimple(id: Identifier, expr: String): Unit = {
+    out.puts(s"${privateMemberName(id)} = $expr;")
   }
 
   override def parseExpr(dataType: BaseType, io: String): String = {
@@ -202,14 +205,12 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     }
   }
 
-  override def instanceHeader(className: String, instName: String, dataType: BaseType): Unit = {
-    out.puts(s"Object.defineProperty(${type2class(className)}.prototype, '${lowerCamelCase(instName)}', {")
+  override def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit = {
+    out.puts(s"Object.defineProperty(${type2class(className)}.prototype, '${publicMemberName(instName)}', {")
     out.inc
     out.puts("get: function() {")
     out.inc
   }
-
-  override def instanceAttrName(instName: String) = s"_m_$instName"
 
   override def instanceFooter: Unit = {
     out.dec
@@ -218,20 +219,19 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts("});")
   }
 
-  override def instanceCheckCacheAndReturn(instName: String): Unit = {
-    out.puts(s"if (this.${lowerCamelCase(instanceAttrName(instName))} !== undefined)")
+  override def instanceCheckCacheAndReturn(instName: InstanceIdentifier): Unit = {
+    out.puts(s"if (${privateMemberName(instName)} !== undefined)")
     out.inc
     instanceReturn(instName)
     out.dec
   }
 
-  override def instanceReturn(instName: String): Unit = {
-    out.puts(s"return this.${lowerCamelCase(instanceAttrName(instName))};")
+  override def instanceReturn(instName: InstanceIdentifier): Unit = {
+    out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: String, dataType: BaseType, value: expr): Unit = {
-    out.puts(s"this.${lowerCamelCase(instanceAttrName(instName))} = ${expression(value)};")
-  }
+  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit =
+    handleAssignmentSimple(instName, expression(value))
 
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     out.puts
@@ -246,21 +246,23 @@ class JavaScriptCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   def enumValue(enumName: String, label: String) = label.toUpperCase
 
-  def lowerCamelCase(s: String): String = {
-    if (s.charAt(0) == '_') {
-      if (s.startsWith("_raw_")) {
-        "_raw_" + lowerCamelCase(s.substring("_raw_".length))
-      } else if (s.startsWith("_m_")) {
-        "_m_" + lowerCamelCase(s.substring("_m_".length))
-      } else {
-        throw new RuntimeException(s"internal error: don't know how to make '$s' a field name")
-      }
-    } else {
-      Utils.lowerCamelCase(s)
+  def idToStr(id: Identifier): String = {
+    id match {
+      case SpecialIdentifier(name) => name
+      case NamedIdentifier(name) => Utils.lowerCamelCase(name)
+      case InstanceIdentifier(name) => s"_m_${Utils.lowerCamelCase(name)}"
+      case RawIdentifier(innerId) => "_raw_" + idToStr(innerId)
     }
   }
 
-  override def privateMemberName(ksName: String): String = s"this.$ksName"
+  override def privateMemberName(id: Identifier): String = s"this.${idToStr(id)}"
+
+  override def publicMemberName(id: Identifier): String = {
+    id match {
+      case NamedIdentifier(name) => Utils.lowerCamelCase(name)
+      case InstanceIdentifier(name) => Utils.lowerCamelCase(name)
+    }
+  }
 
   override def kstreamName: String = "KaitaiStream"
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
@@ -58,8 +58,8 @@ abstract class LanguageCompiler(verbose: Boolean, out: LanguageOutputWriter) {
   def seek(io: String, pos: Ast.expr): Unit
   def popPos(io: String): Unit
 
-  def instanceClear(instName: InstanceIdentifier): Unit = {}
-  def instanceSetCalculated(instName: InstanceIdentifier): Unit = {}
+  def instanceClear(instName: Identifier): Unit = {}
+  def instanceSetCalculated(instName: Identifier): Unit = {}
   def instanceDeclaration(attrName: InstanceIdentifier, attrType: BaseType, condSpec: ConditionalSpec) = attributeDeclaration(attrName, attrType, condSpec)
   def instanceHeader(className: List[String], instName: InstanceIdentifier, dataType: BaseType): Unit
   def instanceFooter: Unit

--- a/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
@@ -52,7 +52,7 @@ abstract class LanguageCompiler(verbose: Boolean, out: LanguageOutputWriter) {
 
   def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit
 
-  def normalIO: String
+  def normalIO: String = privateMemberName(IoIdentifier)
   def useIO(ioEx: Ast.expr): String
   def pushPos(io: String): Unit
   def seek(io: String, pos: Ast.expr): Unit
@@ -67,7 +67,7 @@ abstract class LanguageCompiler(verbose: Boolean, out: LanguageOutputWriter) {
   def instanceReturn(instName: InstanceIdentifier): Unit
   def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr)
 
-  def enumDeclaration(curClass: List[String], enumName: NamedIdentifier, enumColl: Map[Long, String]): Unit
+  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Map[Long, String]): Unit
 
   def expression(e: Ast.expr): String = translator.translate(e)
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
@@ -71,8 +71,36 @@ abstract class LanguageCompiler(verbose: Boolean, out: LanguageOutputWriter) {
 
   def expression(e: Ast.expr): String = translator.translate(e)
 
+  /**
+    * Renders identifier to a string, specifically for a given
+    * language and settings. This usually includes things like
+    * case and separator conversion and does *not* include things
+    * like prepending "@" or "this." or "self." that might be
+    * used to access private member.
+    *
+    * @param id identifier to render
+    * @return identifier as string
+    */
   def idToStr(id: Identifier): String
+
+  /**
+    * Renders identifier as a proper reference to a private member
+    * that represents this field. This might include some prefixes
+    * like "@" or "this." or "self.".
+    *
+    * @param id identifier to render
+    * @return identifier as string
+    */
   def privateMemberName(id: Identifier): String
+
+  /**
+    * Renders identifier as a proper reference to a public member
+    * that represents this field.
+    *
+    * @param id identifier to render
+    * @return identifier as string
+    */
+  def publicMemberName(id: Identifier): String
 }
 
 trait LanguageCompilerStatic {

--- a/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LanguageCompiler.scala
@@ -33,47 +33,46 @@ abstract class LanguageCompiler(verbose: Boolean, out: LanguageOutputWriter) {
   def classDestructorHeader(name: List[String], parentTypeName: List[String], topClassName: List[String]): Unit = {}
   def classDestructorFooter: Unit = {}
 
-  def attributeDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec): Unit
-  def attributeReader(attrName: String, attrType: BaseType): Unit
+  def attributeDeclaration(attrName: Identifier, attrType: BaseType, condSpec: ConditionalSpec): Unit
+  def attributeReader(attrName: Identifier, attrType: BaseType): Unit
 
-  def attrParse(attr: AttrLikeSpec, id: String, extraAttrs: ListBuffer[AttrSpec], io: String): Unit
-  def attrDestructor(attr: AttrLikeSpec, id: String): Unit = {}
+  def attrParse(attr: AttrLikeSpec, id: Identifier, extraAttrs: ListBuffer[AttrSpec], io: String): Unit
+  def attrDestructor(attr: AttrLikeSpec, id: Identifier): Unit = {}
 
-  def attrFixedContentsParse(attrName: String, contents: Array[Byte]): Unit
+  def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit
 
   def condIfHeader(expr: Ast.expr): Unit
   def condIfFooter(expr: Ast.expr): Unit
 
-  def condRepeatEosHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean): Unit
+  def condRepeatEosHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean): Unit
   def condRepeatEosFooter: Unit
 
-  def condRepeatExprHeader(id: String, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit
+  def condRepeatExprHeader(id: Identifier, io: String, dataType: BaseType, needRaw: Boolean, repeatExpr: expr): Unit
   def condRepeatExprFooter: Unit
 
-  def attrProcess(proc: ProcessExpr, varSrc: String, varDest: String): Unit
+  def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit
 
   def normalIO: String
-  def allocateIO(varName: String, rep: RepeatSpec): String
   def useIO(ioEx: Ast.expr): String
   def pushPos(io: String): Unit
   def seek(io: String, pos: Ast.expr): Unit
   def popPos(io: String): Unit
 
-  def instanceClear(instName: String): Unit = {}
-  def instanceSetCalculated(instName: String): Unit = {}
-  def instanceDeclaration(attrName: String, attrType: BaseType, condSpec: ConditionalSpec) = attributeDeclaration(attrName, attrType, condSpec)
-  def instanceHeader(className: List[String], instName: String, dataType: BaseType): Unit
-  def instanceAttrName(instName: String): String
+  def instanceClear(instName: InstanceIdentifier): Unit = {}
+  def instanceSetCalculated(instName: InstanceIdentifier): Unit = {}
+  def instanceDeclaration(attrName: InstanceIdentifier, attrType: BaseType, condSpec: ConditionalSpec) = attributeDeclaration(attrName, attrType, condSpec)
+  def instanceHeader(className: List[String], instName: InstanceIdentifier, dataType: BaseType): Unit
   def instanceFooter: Unit
-  def instanceCheckCacheAndReturn(instName: String): Unit
-  def instanceReturn(instName: String): Unit
-  def instanceCalculate(instName: String, dataType: BaseType, value: expr)
+  def instanceCheckCacheAndReturn(instName: InstanceIdentifier): Unit
+  def instanceReturn(instName: InstanceIdentifier): Unit
+  def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr)
 
-  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Map[Long, String]): Unit
+  def enumDeclaration(curClass: List[String], enumName: NamedIdentifier, enumColl: Map[Long, String]): Unit
 
   def expression(e: Ast.expr): String = translator.translate(e)
 
-  def privateMemberName(ksName: String): String
+  def idToStr(id: Identifier): String
+  def privateMemberName(id: Identifier): String
 }
 
 trait LanguageCompilerStatic {

--- a/shared/src/main/scala/io/kaitai/struct/languages/NoNeedForFullClassPath.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NoNeedForFullClassPath.scala
@@ -20,7 +20,7 @@ trait NoNeedForFullClassPath {
     instanceHeader(className.last, instName, dataType)
   def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit
 
-  def enumDeclaration(curClass: List[String], enumName: InstanceIdentifier, enumColl: Map[Long, String]): Unit =
+  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Map[Long, String]): Unit =
     enumDeclaration(curClass.last, enumName, enumColl)
-  def enumDeclaration(curClass: String, enumName: InstanceIdentifier, enumColl: Map[Long, String]): Unit
+  def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/NoNeedForFullClassPath.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NoNeedForFullClassPath.scala
@@ -1,6 +1,7 @@
 package io.kaitai.struct.languages
 
 import io.kaitai.struct.exprlang.DataType.BaseType
+import io.kaitai.struct.format.InstanceIdentifier
 
 trait NoNeedForFullClassPath {
   def classHeader(name: List[String]): Unit =
@@ -15,11 +16,11 @@ trait NoNeedForFullClassPath {
     classConstructorHeader(name.last, parentClassName.last, rootClassName.last)
   def classConstructorHeader(name: String, parentClassName: String, rootClassName: String): Unit
 
-  def instanceHeader(className: List[String], instName: String, dataType: BaseType): Unit =
+  def instanceHeader(className: List[String], instName: InstanceIdentifier, dataType: BaseType): Unit =
     instanceHeader(className.last, instName, dataType)
-  def instanceHeader(className: String, instName: String, dataType: BaseType): Unit
+  def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit
 
-  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Map[Long, String]): Unit =
+  def enumDeclaration(curClass: List[String], enumName: InstanceIdentifier, enumColl: Map[Long, String]): Unit =
     enumDeclaration(curClass.last, enumName, enumColl)
-  def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit
+  def enumDeclaration(curClass: String, enumName: InstanceIdentifier, enumColl: Map[Long, String]): Unit
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -202,23 +202,6 @@ class PHPCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: String
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit = {
-    val primType = kaitaiType2JavaTypePrim(dataType)
-    val boxedType = kaitaiType2JavaTypeBoxed(dataType)
-
-    if (primType != boxedType) {
-      // Special trick to achieve both implicit type conversion + boxing.
-      // Unfortunately, Java can't do both in one assignment, i.e. this would fail:
-      //
-      // Double c = 1.0f + 1;
-
-      out.puts(s"$primType _tmp = ${expression(value)};")
-      out.puts(s"${privateMemberName(instName)} = _tmp;")
-    } else {
-      out.puts(s"${privateMemberName(instName)} = ${expression(value)};")
-    }
-  }
-
   override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Map[Long, String]): Unit = {
     val enumClass = type2class(enumName)
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -202,6 +202,8 @@ class PythonCompiler(verbose: Boolean, out: LanguageOutputWriter)
   }
 
   override def privateMemberName(id: Identifier): String = s"self.${idToStr(id)}"
+
+  override def publicMemberName(id: Identifier): String = idToStr(id)
 }
 
 object PythonCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -160,7 +160,7 @@ class PythonCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   override def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit = {
     out.puts("@property")
-    out.puts(s"def $instName(self):")
+    out.puts(s"def ${publicMemberName(instName)}(self):")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -176,10 +176,6 @@ class PythonCompiler(verbose: Boolean, out: LanguageOutputWriter)
     out.puts(s"return ${privateMemberName(instName)}")
   }
 
-  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit = {
-    out.puts(s"${privateMemberName(instName)} = ${expression(value)};")
-  }
-
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     out.puts
     out.puts(s"class ${type2class(enumName)}(Enum):")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -203,7 +203,14 @@ class PythonCompiler(verbose: Boolean, out: LanguageOutputWriter)
 
   override def privateMemberName(id: Identifier): String = s"self.${idToStr(id)}"
 
-  override def publicMemberName(id: Identifier): String = idToStr(id)
+  override def publicMemberName(id: Identifier): String = {
+    id match {
+      case SpecialIdentifier(name) => name
+      case NamedIdentifier(name) => name
+      case InstanceIdentifier(name) => name
+      case RawIdentifier(innerId) => s"_raw_${publicMemberName(innerId)}"
+    }
+  }
 }
 
 object PythonCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -225,7 +225,7 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
     out.puts(s"${privateMemberName(instName)} = ${expression(value)}")
   }
 
-  override def enumDeclaration(curClass: String, enumName: NamedIdentifier, enumColl: Map[NamedIdentifier, String]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     out.puts
     out.puts(s"${value2Const(enumName)} = {")
     out.inc
@@ -240,16 +240,18 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
 
   def value2Const(s: String) = s.toUpperCase
 
-  override def idToStr(ksName: Identifier): String = {
-    ksName match {
+  override def idToStr(id: Identifier): String = {
+    id match {
       case NamedIdentifier(name) => name
-      case SpecialIdentifier(name) => name
+      case si: SpecialIdentifier => si.name
       case RawIdentifier(inner) => s"_raw_${idToStr(inner)}"
       case InstanceIdentifier(name) => s"_inst_$name"
     }
   }
 
-  override def privateMemberName(ksName: Identifier): String = s"@${idToStr(ksName)}"
+  override def privateMemberName(id: Identifier): String = s"@${idToStr(id)}"
+
+  override def publicMemberName(id: Identifier): String = idToStr(id)
 }
 
 object RubyCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -247,7 +247,7 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
       case NamedIdentifier(name) => name
       case si: SpecialIdentifier => si.name
       case RawIdentifier(inner) => s"_raw_${idToStr(inner)}"
-      case InstanceIdentifier(name) => s"_inst_$name"
+      case InstanceIdentifier(name) => name
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -66,7 +66,7 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
   override def attributeDeclaration(attrName: Identifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {}
 
   override def attributeReader(attrName: Identifier, attrType: BaseType): Unit = {
-    out.puts(s"attr_reader :$attrName")
+    out.puts(s"attr_reader :${publicMemberName(attrName)}")
   }
 
   override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = {
@@ -98,11 +98,13 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
 
   override def normalIO: String = "@_io"
 
-  override def allocateIO(varName: Identifier, rep: RepeatSpec): String = {
+  override def allocateIO(id: Identifier, rep: RepeatSpec): String = {
+    val memberName = privateMemberName(id)
+
     val args = rep match {
-      case RepeatEos => s"@$varName.last"
-      case RepeatExpr(_) => s"@$varName[i]"
-      case NoRepeat => s"@$varName"
+      case RepeatEos => s"$memberName.last"
+      case RepeatExpr(_) => s"$memberName[i]"
+      case NoRepeat => s"$memberName"
     }
 
     out.puts(s"io = $kstreamName.new($args)")
@@ -156,7 +158,7 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
     if (needRaw)
       out.puts(s"@_raw_$id = []")
 
-    out.puts(s"@$id = []")
+    out.puts(s"${privateMemberName(id)} = []")
     out.puts(s"while not $io.eof?")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -223,10 +223,6 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
     out.puts(privateMemberName(instName))
   }
 
-  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit = {
-    out.puts(s"${privateMemberName(instName)} = ${expression(value)}")
-  }
-
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     out.puts
     out.puts(s"${value2Const(enumName)} = {")

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -6,8 +6,8 @@ import io.kaitai.struct.exprlang.DataType._
 import io.kaitai.struct.format.Identifier
 
 trait TypeProvider {
-  def determineType(parentType: List[String], attrName: Identifier): BaseType
-  def determineType(attrName: Identifier): BaseType
+  def determineType(parentType: List[String], attrName: String): BaseType
+  def determineType(attrName: String): BaseType
 }
 
 class TypeMismatchError(msg: String) extends RuntimeException(msg)

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -1,12 +1,13 @@
 package io.kaitai.struct.translators
 
 import io.kaitai.struct.exprlang.Ast
-import io.kaitai.struct.exprlang.Ast.{cmpop, expr, identifier}
+import io.kaitai.struct.exprlang.Ast.{cmpop, expr}
 import io.kaitai.struct.exprlang.DataType._
+import io.kaitai.struct.format.Identifier
 
 trait TypeProvider {
-  def determineType(parentType: List[String], attrName: String): BaseType
-  def determineType(attrName: String): BaseType
+  def determineType(parentType: List[String], attrName: Identifier): BaseType
+  def determineType(attrName: Identifier): BaseType
 }
 
 class TypeMismatchError(msg: String) extends RuntimeException(msg)


### PR DESCRIPTION
Well, this looks like a *big* commit, but in reality, it's all about massive refactoring, no new functionality here.

The basic idea is simple: previously, we've worked with `String` as identifiers, using `String` both for identifier from the .ksy file itself (i.e. `foo_bar`), rendition of it to language-specific style `fooBar` and rendition of it with some special stuff appended/prendended to be invoked as a private member name or something (i.e. `this.fooBar` or `self.foo_bar` or `@foo_bar` or something).

It created a huge mess with all that chain of `lowerCamelCase` functions that were abused and that lead to lots of code duplication and hardships while developing new languages support. For example, it would be great to just change `this.` into `$this->` in exactly one place and kind of convert Java into PHP.

So, here's what I came up with:

* All identifiers are now not the simple `String`, but a string wrapped in some subclass of `Identifier`.
* It is illegal to use identifier as is, embedding / concatenating it to the string. Before usage, identifier must undergo some transformation into a string, there are now 3 of them:
  * `idToStr` - basic transformation used in a language (`foo_bar` -> `fooBar`)
  * `privateMemberName` - transform identifier to something that's ready to be used as a reference to private member (`foo_bar` -> `@foo_bar` in Ruby, `this.fooBar` in Java, `_fooBar` in C# or something along the lines)
  * `publicMemberName` - transform identifier to the name of public member (i.e. a getter method, or property, or something like that — `foo_bar` -> `foo_bar` in Ruby, `fooBar` in Java, `FooBar` in C#).

There are no more plain string mangling, appending cryptic `_io_`, `_raw_`, etc, prefixes. If you want an additional identifier for a raw byte array for a given identifier, it is `RawIdentifier(existingId)` - voila, that's neatly wrapper, and all id-to-string functions are expected to work properly with that. The same stuff mostly applies to temporary IO vars.

In future, probably it should be very easy to add options to override default languages identifier transformation rules using this thing.

It's still not a very polished code (but it seems to pass the tests), so I would really love to hear some thoughts and feedback on it, especially from @LogicAndTrick, who seems to be working on support for yet another language.