### PR TITLE
Switch

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/DataType.scala
@@ -108,6 +108,8 @@ object DataType {
 
   case class EnumType(name: String, basedOn: IntType) extends BaseType
 
+  case class SwitchType(on: Ast.expr, cases: Map[Ast.expr, BaseType]) extends BaseType
+
   private val ReIntType = """([us])(2|4|8)(le|be)?""".r
   private val ReFloatType = """f(4|8)(le|be)?""".r
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -223,6 +223,22 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
     }
   }
 
+  override def switchStart(id: Identifier, on: Ast.expr): Unit =
+    out.puts(s"switch (${expression(on)}) {")
+
+  override def switchCaseStart(condition: Ast.expr): Unit = {
+    out.puts(s"case ${expression(condition)}:")
+    out.inc
+  }
+
+  override def switchCaseEnd(): Unit = {
+    out.puts("break;")
+    out.dec
+  }
+
+  override def switchEnd(): Unit =
+    out.puts("}")
+
   override def instanceDeclaration(attrName: InstanceIdentifier, attrType: BaseType, condSpec: ConditionalSpec): Unit = {
     out.puts(s"private ${kaitaiType2NativeType(attrType)} ${privateMemberName(attrName)};")
   }
@@ -337,6 +353,9 @@ object CSharpCompiler extends LanguageCompilerStatic
       case EnumType(name, _) => type2class(name)
 
       case ArrayType(inType) => s"List<${kaitaiType2NativeType(inType)}>"
+
+      // TODO: implement proper type derivation
+      case SwitchType(_, _) => kstructName
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -181,6 +181,20 @@ class PythonCompiler(verbose: Boolean, out: LanguageOutputWriter)
     }
   }
 
+  override def switchStart(id: Identifier, on: Ast.expr): Unit = {
+    out.puts(s"_on = ${expression(on)}")
+  }
+
+  override def switchCaseStart(condition: Ast.expr): Unit = {
+    out.puts(s"if _on == ${expression(condition)}:")
+    out.inc
+  }
+
+  override def switchCaseEnd(): Unit =
+    out.dec
+
+  override def switchEnd(): Unit = {}
+
   override def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit = {
     out.puts("@property")
     out.puts(s"def ${publicMemberName(instName)}(self):")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -236,6 +236,20 @@ class RubyCompiler(verbose: Boolean, override val debug: Boolean, out: LanguageO
     }
   }
 
+  override def switchStart(id: Identifier, on: Ast.expr): Unit =
+    out.puts(s"case ${expression(on)}")
+
+  override def switchCaseStart(condition: Ast.expr): Unit = {
+    out.puts(s"when ${expression(condition)}")
+    out.inc
+  }
+
+  override def switchCaseEnd(): Unit =
+    out.dec
+
+  override def switchEnd(): Unit =
+    out.puts("end")
+
   override def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit = {
     out.puts(s"def ${instName.name}")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -63,6 +63,8 @@ trait EveryReadIsExpression extends LanguageCompiler {
         attrUserTypeParse(id, t, io, extraAttrs, rep)
       case t: BytesType =>
         attrBytesTypeParse(id, t, io, extraAttrs, rep)
+      case SwitchType(on, cases) =>
+        attrSwitchTypeParse(id, on, cases, io, extraAttrs, rep)
       case _ =>
         val expr = parseExpr(dataType, io)
         handleAssignment(id, expr, rep)
@@ -130,6 +132,16 @@ trait EveryReadIsExpression extends LanguageCompiler {
     }
   }
 
+  def attrSwitchTypeParse(id: Identifier, on: Ast.expr, cases: Map[Ast.expr, BaseType], io: String, extraAttrs: ListBuffer[AttrSpec], rep: RepeatSpec): Unit = {
+    switchStart(id, on)
+    cases.foreach { case (condition, dataType) =>
+      switchCaseStart(condition)
+      attrParse2(id, dataType, io, extraAttrs, rep)
+      switchCaseEnd()
+    }
+    switchEnd()
+  }
+
   def handleAssignment(id: Identifier, expr: String, rep: RepeatSpec): Unit = {
     rep match {
       case RepeatEos => handleAssignmentRepeatEos(id, expr)
@@ -151,4 +163,9 @@ trait EveryReadIsExpression extends LanguageCompiler {
 
   def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: Ast.expr) =
     handleAssignmentSimple(instName, expression(value))
+
+  def switchStart(id: Identifier, on: Ast.expr): Unit = ???
+  def switchCaseStart(condition: Ast.expr): Unit = ???
+  def switchCaseEnd(): Unit = ???
+  def switchEnd(): Unit = ???
 }


### PR DESCRIPTION
Implemented very basic type switching: format parsing + language support for Ruby, Java, C# and Python.

The syntax is:

```yaml
  - id: code
    type: u1
  - id: body
    type:
      switch-on: code
      cases:
        73: intval
        83: strval
```

or, with enums (implies that `code_enum` is defined):

```yaml
  - id: code
    type: u1
    enum: code_enum
  - id: body
    type:
      switch-on: code
      cases:
        code_enum::intval: intval
        code_enum::strval: strval
```

No `else` case support so far, support for anything else besides user types is not tested (should work for duck-typed languages, would fail for C# and Java).

There are 2 new tests: `switch_manual_int` and `switch_manual_enum` already committed to tests repo. C#, Java and Ruby implementations work (although C# again has name clashes of enums vs attributes). Python implementation probably works too, but right now it's held back by class addressing issues.