### PR TITLE
Use a boolean flag to check if instances have already been calculated

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -267,6 +267,10 @@ class CppCompiler(verbose: Boolean, outSrc: LanguageOutputWriter, outHdr: Langua
     outSrc.puts(s"${flagForInstName(instName)} = true;")
   }
 
+  override def condIfClear(instName: Identifier): Unit = instanceClear(instName)
+
+  override def condIfSetCalculated(instName: Identifier): Unit = instanceSetCalculated(instName)
+
   override def condIfHeader(expr: Ast.expr): Unit = {
     outSrc.puts(s"if (${expression(expr)}) {")
     outSrc.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -21,9 +21,9 @@ trait EveryReadIsExpression extends LanguageCompiler with ObjectOrientedLanguage
 
     attr.cond.ifExpr match {
       case Some(e) =>
-        instanceClear(id)
+        condIfClear(id)
         condIfHeader(e)
-        instanceSetCalculated(id)
+        condIfSetCalculated(id)
       case None => // ignore
     }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -59,6 +59,8 @@ abstract class LanguageCompiler(verbose: Boolean, out: LanguageOutputWriter) {
 
   def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit
 
+  def condIfClear(instName: Identifier): Unit = {}
+  def condIfSetCalculated(instName: Identifier): Unit = {}
   def condIfHeader(expr: Ast.expr): Unit
   def condIfFooter(expr: Ast.expr): Unit
 


### PR DESCRIPTION
Fixes kaitai-io/kaitai_struct#32. I had to make some minor changes to the C++ compiler and related files because the `instanceClear` and `instanceSetCalculated` were being re-used for non-instance related stuff. I don't think it should cause any issues. C# tests pass, I'm unable to run the C++ tests myself.