### PR TITLE
C# Compiler: Force cast calculated instance values 

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -279,6 +279,10 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   override def instanceReturn(instName: InstanceIdentifier): Unit = {
     out.puts(s"return ${privateMemberName(instName)};")
   }
+  
+  override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit =
+  // Perform explicit cast as unsigned integers can't be directly assigned to the default int type
+    handleAssignmentSimple(instName, s"(${kaitaiType2NativeType(dataType)}) (${expression(value)})")
 
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {
     val enumClass = type2class(enumName)

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -279,9 +279,9 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
   override def instanceReturn(instName: InstanceIdentifier): Unit = {
     out.puts(s"return ${privateMemberName(instName)};")
   }
-  
+
   override def instanceCalculate(instName: InstanceIdentifier, dataType: BaseType, value: expr): Unit =
-  // Perform explicit cast as unsigned integers can't be directly assigned to the default int type
+    // Perform explicit cast as unsigned integers can't be directly assigned to the default int type
     handleAssignmentSimple(instName, s"(${kaitaiType2NativeType(dataType)}) (${expression(value)})")
 
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Map[Long, String]): Unit = {


### PR DESCRIPTION
Allows the ExprMod test to be compiled.

Note that the test still won't actually *pass* at this point because of the way `%` on negative numbers differs between languages. But this change is required so it will actually compile.

I'm not sure that this project should enforce mod consistency between languages to begin with, but that's another discussion entirely. On that note, [Wikipedia has a ridiculously comprehensive list](https://en.wikipedia.org/wiki/Modulo_operation#Remainder_calculation_for_the_modulo_operation) of how different languages behave when modding negative numbers.