### PR TITLE
C#: Fix the failing `to_i` expression test

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -282,7 +282,7 @@ class TranslatorSpec extends FunSuite with TableDrivenPropertyChecks {
 
     full("\"12345\".to_i", CalcIntType, CalcIntType, Map(
       CppCompiler -> "std::stoi(std::string(\"12345\"))",
-      CSharpCompiler -> "long.Parse(\"12345\")",
+      CSharpCompiler -> "Convert.ToInt64(\"12345\", 10)",
       JavaCompiler -> "Long.parseLong(\"12345\", 10)",
       JavaScriptCompiler -> "Number.parseInt(\"12345\", 10)",
       PerlCompiler -> "\"12345\"",

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -42,7 +42,7 @@ class CSharpTranslator(provider: TypeProvider) extends BaseTranslator(provider) 
 
   // Predefined methods of various types
   override def strToInt(s: expr, base: expr): String =
-  s"long.Parse(${translate(s)})"
+    s"Convert.ToInt64(${translate(s)}, ${translate(base)})"
   override def strLength(s: expr): String =
     s"${translate(s)}.Length"
   override def strSubstring(s: expr, from: expr, to: expr): String =


### PR DESCRIPTION
The `"1234fe".to_i(16)` expression test was passing everywhere else but not C#, this should fix it. 