### PR TITLE
Add CDATA to C# XML docstrings

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -90,9 +90,9 @@ class CSharpCompiler(verbose: Boolean, out: LanguageOutputWriter, namespace: Str
 
   override def attributeDoc(id: Identifier, doc: String): Unit = {
     out.puts
-    out.puts( "/// <summary>")
+    out.puts( "/// <summary><![CDATA[")
     out.puts(s"/// $doc")
-    out.puts( "/// </summary>")
+    out.puts( "/// ]]></summary>")
   }
 
   override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = {


### PR DESCRIPTION
XML special characters have to be escaped in C# docstrings, but this can be avoided by using a CDATA section. There's no harm in putting everything inside CDATA, so this is easier than performing an XML escape.

(Technically if the docstring contains the characters `]]>` then it'll still break, so maybe an XML escape is a better idea?)