### PR TITLE
#44: #29 ch…

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -294,7 +294,8 @@ class JavaScriptCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
       case BytesEosType(_) =>
         s"$io.readBytesFull()"
       case t: UserType =>
-        s"new ${type2class(t.name.last)}($io, this, this._root)"
+      	val addArgs = if (t.isOpaque) "" else ", this, this._root"
+        s"new ${type2class(t.name.last)}($io$addArgs)"
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -240,7 +240,8 @@ class RubyCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
       case BytesEosType(_) =>
         s"$io.read_bytes_full"
       case t: UserType =>
-        s"${type2class(t.name.last)}.new($io, self, @_root)"
+        val addArgs = if (t.isOpaque) "" else ", self, @_root"
+        s"${type2class(t.name.last)}.new($io$addArgs)"
     }
   }
 


### PR DESCRIPTION
…anged the CTORs called in case of opaque types and it looks this change was missed for Ruby by accident. With this change #44 is fixed.