### PR TITLE
#38: fix _parent not derived in value instances

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -5,7 +5,7 @@ import io.kaitai.struct.format._
 import io.kaitai.struct.translators.{TypeMismatchError, TypeProvider, TypeUndecidedError}
 
 class ClassTypeProvider(topClass: ClassSpec) extends TypeProvider {
-  var nowClass           : ClassSpec         = topClass
+  var nowClass : ClassSpec = topClass
   var possibleParentClass: Option[ClassSpec] = None
 
   var _currentIteratorType: Option[BaseType] = None

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -5,7 +5,7 @@ import io.kaitai.struct.format._
 import io.kaitai.struct.translators.{TypeMismatchError, TypeProvider, TypeUndecidedError}
 
 class ClassTypeProvider(topClass: ClassSpec) extends TypeProvider {
-  var nowClass : ClassSpec = topClass
+  var nowClass: ClassSpec = topClass
   var possibleParentClass: Option[ClassSpec] = None
 
   var _currentIteratorType: Option[BaseType] = None

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -5,7 +5,8 @@ import io.kaitai.struct.format._
 import io.kaitai.struct.translators.{TypeMismatchError, TypeProvider, TypeUndecidedError}
 
 class ClassTypeProvider(topClass: ClassSpec) extends TypeProvider {
-  var nowClass = topClass
+  var nowClass           : ClassSpec         = topClass
+  var possibleParentClass: Option[ClassSpec] = None
 
   var _currentIteratorType: Option[BaseType] = None
   var _currentSwitchType: Option[BaseType] = None
@@ -21,9 +22,13 @@ class ClassTypeProvider(topClass: ClassSpec) extends TypeProvider {
       case "_root" =>
         makeUserType(topClass)
       case "_parent" =>
-        if (inClass.parentClass == UnknownClassSpec)
+        var parent = inClass.parentClass
+        if ((parent == UnknownClassSpec) && (possibleParentClass != None))
+          parent = possibleParentClass.get
+        if (parent == UnknownClassSpec)
           throw new RuntimeException(s"Unable to derive _parent type in ${inClass.name.mkString("::")}")
-        makeUserType(inClass.parentClass)
+
+        makeUserType(parent)
       case "_io" =>
         KaitaiStreamType
       case "_" =>

--- a/shared/src/main/scala/io/kaitai/struct/TypeProcessor.scala
+++ b/shared/src/main/scala/io/kaitai/struct/TypeProcessor.scala
@@ -20,7 +20,7 @@ object TypeProcessor {
 
   def processTypes(topClass: ClassSpec): Unit = {
     // Set top class name from meta
-    topClass.name        = List(topClass.meta.get.id.get)
+    topClass.name = List(topClass.meta.get.id.get)
     topClass.parentClass = GenericStructClassSpec
 
     markupClassNames(topClass)
@@ -63,7 +63,7 @@ object TypeProcessor {
 //    Console.println(s"deriveValueType(${curClass.name.mkString("::")})")
     var hasChanged = false
 
-    provider.nowClass            = curClass
+    provider.nowClass = curClass
     provider.possibleParentClass = _parentsByChild.get(curClass.name.mkString("::"))
 
     curClass.instances.foreach {

--- a/shared/src/main/scala/io/kaitai/struct/TypeProcessor.scala
+++ b/shared/src/main/scala/io/kaitai/struct/TypeProcessor.scala
@@ -16,7 +16,7 @@ object TypeProcessor {
   // types and for some reasion their ClassSpec couldn't be queried as a key in the map without
   // running into UnsupportedOperationException of AbstractIdentifier.toString. This doesn't happen
   // if we provide a string using ClassSpec on our own.
-  val _parentsByChild = Map[String, ClassSpec]()
+  val parentsByChild = Map[String, ClassSpec]()
 
   def processTypes(topClass: ClassSpec): Unit = {
     // Set top class name from meta
@@ -64,7 +64,7 @@ object TypeProcessor {
     var hasChanged = false
 
     provider.nowClass = curClass
-    provider.possibleParentClass = _parentsByChild.get(curClass.name.mkString("::"))
+    provider.possibleParentClass = parentsByChild.get(curClass.name.mkString("::"))
 
     curClass.instances.foreach {
       case (instName, inst) =>
@@ -158,7 +158,7 @@ object TypeProcessor {
         // call is the proper one, so we simply overwrite mappings. Depending on the target language
         // in case of multiple incompatible usages compiler errors occur or such and things can be
         // fixed as needed.
-        _parentsByChild(child.name.mkString("::")) = curClass
+        parentsByChild(child.name.mkString("::")) = curClass
         res
       }
     }

--- a/shared/src/main/scala/io/kaitai/struct/TypeProcessor.scala
+++ b/shared/src/main/scala/io/kaitai/struct/TypeProcessor.scala
@@ -5,17 +5,28 @@ import io.kaitai.struct.format._
 import io.kaitai.struct.translators.{BaseTranslator, RubyTranslator, TypeUndecidedError}
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.Map
 
 object TypeProcessor {
+  // We need to record the parent types of resolved user types at their usage, which we know about
+  // on resolving user types, to be able to properly resolve "_parent" in value instances to solve
+  // some chicken&egg problem in the current implementation.
+  //
+  // The key is a string by purpose currently, because on deriving value there may be some opaque
+  // types and for some reasion their ClassSpec couldn't be queried as a key in the map without
+  // running into UnsupportedOperationException of AbstractIdentifier.toString. This doesn't happen
+  // if we provide a string using ClassSpec on our own.
+  val _parentsByChild = Map[String, ClassSpec]()
+
   def processTypes(topClass: ClassSpec): Unit = {
     // Set top class name from meta
-    topClass.name = List(topClass.meta.get.id.get)
+    topClass.name        = List(topClass.meta.get.id.get)
+    topClass.parentClass = GenericStructClassSpec
 
     markupClassNames(topClass)
     resolveUserTypes(topClass)
     deriveValueTypes(topClass)
     markupParentTypes(topClass)
-    topClass.parentClass = GenericStructClassSpec
   }
 
   // ==================================================================
@@ -52,7 +63,9 @@ object TypeProcessor {
 //    Console.println(s"deriveValueType(${curClass.name.mkString("::")})")
     var hasChanged = false
 
-    provider.nowClass = curClass
+    provider.nowClass            = curClass
+    provider.possibleParentClass = _parentsByChild.get(curClass.name.mkString("::"))
+
     curClass.instances.foreach {
       case (instName, inst) =>
         inst match {
@@ -139,8 +152,15 @@ object TypeProcessor {
       case None =>
         // Type definition not found - generate special "opaque placeholder" ClassSpec
         Some(ClassSpec.opaquePlaceholder(typeName))
-      case Some(x) =>
+      case Some(child) => {
+        // We might be called multiple times, but only have two situations: It's either always the
+        // same context or in case of different/incompatible ones there's some chance that the last
+        // call is the proper one, so we simply overwrite mappings. Depending on the target language
+        // in case of multiple incompatible usages compiler errors occur or such and things can be
+        // fixed as needed.
+        _parentsByChild(child.name.mkString("::")) = curClass
         res
+      }
     }
   }
 


### PR DESCRIPTION
This is a first attempt to fix the problem that `parent` can't be resolved if it's used in `value` instances, because the former would normally be resolved after the latter. I couldn't find an easy way to switch the processing order of both, because during resolving `_parent` one needs "something" to assign the parent to and I don't see what this should be.

So I tried by simply collection parent-child-relationship on its own and provide that only for processing fo `value` instances and that worked. My KSY compiles now and the tests still pass as well. Not sure if this si the right approach, though.