### PR TITLE
#39: Invalid "switch"-statement generated for Java.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -173,11 +173,11 @@ abstract class BaseTranslator(val provider: TypeProvider) {
 
   def doBooleanOp(op: Ast.boolop, values: Seq[Ast.expr]): String = {
     val opStr = s"${booleanOp(op)}"
-    val dividerStr = s" ) ${opStr} ( "
-    val valuesStr = values.map(translate).mkString("( ", dividerStr, " )")
+    val dividerStr = s") ${opStr} ("
+    val valuesStr = values.map(translate).mkString("(", dividerStr, ")")
 
     // Improve compatibility for statements like: ( ... && ... || ... ) ? ... : ...
-    s" ( ${valuesStr} ) "
+    s" (${valuesStr}) "
   }
 
   def booleanOp(op: Ast.boolop) = op match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -172,8 +172,12 @@ abstract class BaseTranslator(val provider: TypeProvider) {
   }
 
   def doBooleanOp(op: Ast.boolop, values: Seq[Ast.expr]): String = {
-    val opStr = s" ${booleanOp(op)} "
-    values.map(translate).mkString(opStr)
+    val opStr = s"${booleanOp(op)}"
+    val dividerStr = s" ) ${opStr} ( "
+    val valuesStr = values.map(translate).mkString("( ", dividerStr, " )")
+
+    // Improve compatibility for statements like: ( ... && ... || ... ) ? ... : ...
+    s" ( ${valuesStr} ) "
   }
 
   def booleanOp(op: Ast.boolop) = op match {


### PR DESCRIPTION
In case of multiple boolean operations as condition of a switch statement, parenthesis weren't properly generated. This at least in Java created code which didn't compile.

https://github.com/kaitai-io/kaitai_struct_compiler/issues/39