### PR TITLE
CppCompiler: fixed switch

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -422,9 +422,19 @@ class CppCompiler(config: RuntimeConfig, outSrc: LanguageOutputWriter, outHdr: L
     }
   }
 
-  override def switchCaseStart(condition: Ast.expr): Unit = {
+  override def switchCaseFirstStart(condition: Ast.expr): Unit = {
     if (switchIfs) {
       outSrc.puts(s"if (on == ${expression(condition)}) {")
+      outSrc.inc
+    } else {
+      outSrc.puts(s"case ${expression(condition)}:")
+      outSrc.inc
+    }
+  }
+
+  override def switchCaseStart(condition: Ast.expr): Unit = {
+    if (switchIfs) {
+      outSrc.puts(s"else if (on == ${expression(condition)}) {")
       outSrc.inc
     } else {
       outSrc.puts(s"case ${expression(condition)}:")


### PR DESCRIPTION
Switch on no Int/Enum type doesn't work properly when there is more than 2 cases (e.q. png.ksv). If length is fixed and switch match some not last case then data is consumed 2 times.  