### PR TITLE
Less io exceptions

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -72,7 +72,7 @@ class JavaCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
 
   override def classConstructorHeader(name: String, parentClassName: String, rootClassName: String): Unit = {
     out.puts
-    out.puts(s"public ${type2class(name)}($kstreamName _io) throws IOException {")
+    out.puts(s"public ${type2class(name)}($kstreamName _io) {")
     out.inc
     out.puts("super(_io);")
     if (name == rootClassName)
@@ -83,7 +83,7 @@ class JavaCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
     out.puts("}")
 
     out.puts
-    out.puts(s"public ${type2class(name)}($kstreamName _io, ${type2class(parentClassName)} _parent) throws IOException {")
+    out.puts(s"public ${type2class(name)}($kstreamName _io, ${type2class(parentClassName)} _parent) {")
     out.inc
     out.puts("super(_io);")
     out.puts("this._parent = _parent;")
@@ -95,7 +95,7 @@ class JavaCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
     out.puts("}")
 
     out.puts
-    out.puts(s"public ${type2class(name)}($kstreamName _io, ${type2class(parentClassName)} _parent, ${type2class(rootClassName)} _root) throws IOException {")
+    out.puts(s"public ${type2class(name)}($kstreamName _io, ${type2class(parentClassName)} _parent, ${type2class(rootClassName)} _root) {")
     out.inc
     out.puts("super(_io);")
     out.puts("this._parent = _parent;")
@@ -110,7 +110,7 @@ class JavaCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
     } else {
       "private"
     }
-    out.puts(s"$readAccessAndType void _read() throws IOException {")
+    out.puts(s"$readAccessAndType void _read() {")
     out.inc
   }
 
@@ -352,7 +352,7 @@ class JavaCompiler(config: RuntimeConfig, out: LanguageOutputWriter)
   }
 
   override def instanceHeader(className: String, instName: InstanceIdentifier, dataType: BaseType): Unit = {
-    out.puts(s"public ${kaitaiType2JavaTypeBoxed(dataType)} ${idToStr(instName)}() throws IOException {")
+    out.puts(s"public ${kaitaiType2JavaTypeBoxed(dataType)} ${idToStr(instName)}() {")
     out.inc
   }
 


### PR DESCRIPTION
This pull request is related to the issues underneath: The runtime declares to throw a lot of `IOException` while it actually isn't, at least in current versions. The problem with those checked exceptions is that they propagate into users code and need to be handled in many different places, which is unnecessary work using try/catch or unnecessary changes for already available method signatures. Without all those exceptions the JavaCompiler can be cleaned up as well a lot and will only keep one of those exceptions where it actually makes sense.

In the integration task I'm currently facing, where I need to replace an old parser with a KS generated one, this makes a huge difference. And we don't even loose anything, because as said, most of those `IOExceptions` were only declared, not needed at all.

One exception is `processZlib` which replaced another checked exception with `IOException`, which make sense of course to not use too many different exception types. But in other places like `ensureFixedContents", @GreyCat decided to use a custom class extending `RuntimeException` as well, so I think it's reasonable to use such in this case, too.

I've tried various other implementations in the JavaCompiler to reduce the amount of `IOException` to the absolute minimum, but nothing is as easy as simply cleaning up the runtime and afterwards cleaning up the compiler.

https://github.com/kaitai-io/kaitai_struct_compiler/issues/57
https://github.com/kaitai-io/kaitai_struct_java_runtime/issues/3