### PR TITLE
doIntLiteral couldn't handle >32 Bit signed int

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -19,6 +19,11 @@ class TranslatorSpec extends FunSuite with TableDrivenPropertyChecks {
     everybody("1234", "1234"),
     everybody("-456", "-456"),
     everybody("0x1234", "4660"),
+    // less and more than 32 Bit signed int
+    everybody("1000000000", "1000000000"),
+    everybodyExcept("100000000000", "100000000000", Map[LanguageCompilerStatic, String](
+        JavaCompiler -> "100000000000L"
+    )),
 
     // Float literals
     everybody("1.0", "1.0", CalcFloatType),

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -197,7 +197,7 @@ abstract class BaseTranslator(val provider: TypeProvider) {
   def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String
 
   // Literals
-  def doIntLiteral(n: Any): String = n.toString
+  def doIntLiteral(n: BigInt): String = n.toString
   def doFloatLiteral(n: Any): String = n.toString
   def doStringLiteral(s: String): String = "\"" + s + "\""
   def doBoolLiteral(n: Boolean): String = n.toString

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -7,6 +7,13 @@ import io.kaitai.struct.exprlang.DataType.{BaseType, IntType}
 import io.kaitai.struct.languages.JavaCompiler
 
 class JavaTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
+  override def doIntLiteral(n: BigInt): String = {
+    val literal = n.toString
+    val suffix = if (n > Int.MaxValue) "L" else ""
+
+    s"${literal}${suffix}"
+  }
+
   override def doArrayLiteral(t: BaseType, value: Seq[expr]): String = {
     val javaType = JavaCompiler.kaitaiType2JavaTypeBoxed(t)
     val commaStr = value.map((v) => translate(v)).mkString(", ")


### PR DESCRIPTION
I had to deal with int literals of less and more than 32 Bit signed int and in the latter case the generated code for Java didn't compile, because the compiler provided the error message that the number is too large to be an int. I needs the suffix "L" in such cases and that is now added for Java only.