### PR TITLE
Added the operation "reverse" on strings.

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -300,6 +300,17 @@ class TranslatorSpec extends FunSuite with TableDrivenPropertyChecks {
       RubyCompiler -> "\"str\".size"
     )),
 
+    full("\"str\".reverse", CalcIntType, CalcStrType, Map[LanguageCompilerStatic, String](
+        CppCompiler -> "std::reverse(...)",
+        CSharpCompiler -> "new string(Array.Reverse(\"str\".ToCharArray()))",
+        JavaCompiler -> "new StringBuilder(\"str\").reverse().toString()",
+        JavaScriptCompiler -> "Array.from(\"str\").reverse().join('')",
+        PerlCompiler -> "scalar(reverse(\"str\"))",
+        PHPCompiler -> "strrev(\"str\")",
+        PythonCompiler -> "u\"str\"[::-1]",
+        RubyCompiler -> "\"str\".reverse"
+      )),
+
     full("\"12345\".to_i", CalcIntType, CalcIntType, Map[LanguageCompilerStatic, String](
       CppCompiler -> "std::stoi(std::string(\"12345\"))",
       CSharpCompiler -> "Convert.ToInt64(\"12345\", 10)",

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -301,7 +301,7 @@ class TranslatorSpec extends FunSuite with TableDrivenPropertyChecks {
     )),
 
     full("\"str\".reverse", CalcIntType, CalcStrType, Map[LanguageCompilerStatic, String](
-        CppCompiler -> "std::reverse(...)",
+        CppCompiler -> "kaitai::kstream::reverse(std::string(\"str\"))",
         CSharpCompiler -> "new string(Array.Reverse(\"str\".ToCharArray()))",
         JavaCompiler -> "new StringBuilder(\"str\").reverse().toString()",
         JavaScriptCompiler -> "Array.from(\"str\").reverse().join('')",

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -81,6 +81,7 @@ abstract class BaseTranslator(val provider: TypeProvider) {
           case _: StrType =>
             attr.name match {
               case "length" => strLength(value)
+              case "reverse" => strReverse(value)
               case "to_i" => strToInt(value, Ast.expr.IntNum(10))
             }
           case _: IntType =>
@@ -217,6 +218,7 @@ abstract class BaseTranslator(val provider: TypeProvider) {
   def strToInt(s: Ast.expr, base: Ast.expr): String
   def intToStr(i: Ast.expr, base: Ast.expr): String
   def strLength(s: Ast.expr): String
+  def strReverse(s: Ast.expr): String
   def strSubstring(s: Ast.expr, from: Ast.expr, to: Ast.expr): String
 
   def arrayFirst(a: Ast.expr): String
@@ -325,6 +327,7 @@ abstract class BaseTranslator(val provider: TypeProvider) {
           case _: StrType =>
             attr.name match {
               case "length" => CalcIntType
+              case "reverse" => CalcStrType
               case "to_i" => CalcIntType
               case _ => throw new TypeMismatchError(s"called invalid attribute '${attr.name}' on expression of type $valType")
             }

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -63,6 +63,12 @@ class CSharpTranslator(provider: TypeProvider) extends BaseTranslator(provider) 
     s"Convert.ToString(${translate(i)}, ${translate(base)})"
   override def strLength(s: expr): String =
     s"${translate(s)}.Length"
+
+  // FIXME: This is not fully Unicode aware, but might be better than nothing.
+  // http://stackoverflow.com/a/228060/2055163
+  override def strReverse(s: expr): String =
+    s"new string(Array.Reverse(${translate(s)}.ToCharArray()))"
+
   override def strSubstring(s: expr, from: expr, to: expr): String =
     s"${translate(s)}.Substring(${translate(from)}, ${translate(to)} - ${translate(from)})"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -73,6 +73,13 @@ class CppTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
   }
   override def strLength(s: expr): String =
     s"${translate(s)}.length()"
+
+  // TODO std::reverse seems the proper thing to do, but needs a local variable to work properly and
+  // the additional header <algorithm>. Maybe there's a better solution?
+  override def strReverse(s: expr): String =
+    //s"std::reverse(${translate(s)}.begin(), ${translate(s)}.end());"
+    throw new RuntimeException("Reversing strings is not implemented yet in C++.")
+
   override def strSubstring(s: expr, from: expr, to: expr): String =
     s"${translate(s)}.substr(${translate(from)}, (${translate(to)}) - (${translate(from)}))"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -73,13 +73,8 @@ class CppTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
   }
   override def strLength(s: expr): String =
     s"${translate(s)}.length()"
-
-  // TODO std::reverse seems the proper thing to do, but needs a local variable to work properly and
-  // the additional header <algorithm>. Maybe there's a better solution?
   override def strReverse(s: expr): String =
-    //s"std::reverse(${translate(s)}.begin(), ${translate(s)}.end());"
-    throw new RuntimeException("Reversing strings is not implemented yet in C++.")
-
+    s"${CppCompiler.kstreamName}::reverse(${translate(s)})"
   override def strSubstring(s: expr, from: expr, to: expr): String =
     s"${translate(s)}.substr(${translate(from)}, (${translate(to)}) - (${translate(from)}))"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -53,6 +53,10 @@ class JavaScriptTranslator(provider: TypeProvider) extends BaseTranslator(provid
   override def strLength(s: expr): String =
     s"${translate(s)}.length"
 
+  // http://stackoverflow.com/a/36525647/2055163
+  override def strReverse(s: expr): String =
+    s"Array.from(${translate(s)}).reverse().join('')"
+
   override def strSubstring(s: expr, from: expr, to: expr): String =
     s"${translate(s)}.substring(${translate(from)}, ${translate(to)})"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -73,6 +73,8 @@ class JavaTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
     s"Long.toString(${translate(i)}, ${translate(base)})"
   override def strLength(s: expr): String =
     s"${translate(s)}.length()"
+  override def strReverse(s: expr): String =
+    s"new StringBuilder(${translate(s)}).reverse().toString()"
   override def strSubstring(s: expr, from: expr, to: expr): String =
     s"${translate(s)}.substring(${translate(from)}, ${translate(to)})"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
@@ -65,7 +65,8 @@ class PHPTranslator(provider: TypeProvider, lang: PHPCompiler) extends BaseTrans
 
   override def strLength(s: expr): String =
     s"strlen(${translate(s)})"
-
+  override def strReverse(s: expr): String =
+    s"strrev(${translate(s)})"
   override def strSubstring(s: expr, from: expr, to: expr): String =
     s"${translate(s)}.substring(${translate(from)}, ${translate(to)})"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -93,6 +93,8 @@ class PerlTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
   }
   override def strLength(value: Ast.expr): String =
     s"length(${translate(value)})"
+  override def strReverse(value: Ast.expr): String =
+    s"scalar(reverse(${translate(value)}))"
   override def strSubstring(s: Ast.expr, from: Ast.expr, to: Ast.expr): String =
     s"${translate(s)}[${translate(from)}:${translate(to)}]"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -71,6 +71,8 @@ class PythonTranslator(provider: TypeProvider) extends BaseTranslator(provider) 
   }
   override def strLength(value: Ast.expr): String =
     s"len(${translate(value)})"
+  override def strReverse(value: Ast.expr): String =
+    s"${translate(value)}[::-1]"
   override def strSubstring(s: Ast.expr, from: Ast.expr, to: Ast.expr): String =
     s"${translate(s)}[${translate(from)}:${translate(to)}]"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -32,6 +32,8 @@ class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
   }
   override def strLength(s: Ast.expr): String =
     s"${translate(s)}.size"
+  override def strReverse(s: Ast.expr): String =
+    s"${translate(s)}.reverse"
   override def strSubstring(s: Ast.expr, from: Ast.expr, to: Ast.expr): String =
     s"${translate(s)}[${translate(from)}, (${translate(to)} - 1)]"
 


### PR DESCRIPTION
Only C++ is not implemented currently, because I don't know how to deal with locally needed temp instances of data. We need something like the following, but I didn't find how to temporarily generate the `str` part.

> std::reverse(str.begin(), str.end());

https://github.com/kaitai-io/kaitai_struct_compiler/issues/65