### PR TITLE
needRaw didn't properly work for SwitchType...

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -200,7 +200,7 @@ trait EveryReadIsExpression extends LanguageCompiler with ObjectOrientedLanguage
 
   def needRaw(switchType: SwitchType): Boolean = {
     val byCase = switchType.cases.mapValues(v => needRaw(v))
-    val byBool = byCase.groupBy(pair => pair._2)
+    val byBool = byCase.groupBy({ case (k, v) => v })
     val retVal = byBool.contains(true)
 
     retVal

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -193,8 +193,17 @@ trait EveryReadIsExpression extends LanguageCompiler with ObjectOrientedLanguage
   def needRaw(dataType: DataType): Boolean = {
     dataType match {
       case t: UserTypeFromBytes => true
+      case t: SwitchType => needRaw(t)
       case _ => false
     }
+  }
+
+  def needRaw(switchType: SwitchType): Boolean = {
+    val byCase = switchType.cases.mapValues(v => needRaw(v))
+    val byBool = byCase.groupBy(pair => pair._2)
+    val retVal = byBool.contains(true)
+
+    retVal
   }
 
   def attrSwitchTypeParse(id: Identifier, on: Ast.expr, cases: Map[Ast.expr, DataType], io: String, extraAttrs: ListBuffer[AttrSpec], rep: RepeatSpec): Unit = {


### PR DESCRIPTION
...which might consist of different types for all cases. It should be sufficient to test if one of those cases fullfills needRaw to get the overall result for needRaw for the whole switch.

https://github.com/kaitai-io/kaitai_struct_compiler/issues/78