### PR TITLE
Normalize path handling, so that / only is used.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/JSON.scala
+++ b/shared/src/main/scala/io/kaitai/struct/JSON.scala
@@ -25,7 +25,7 @@ object JSON {
 
   // FIXME: do proper string handling
   def stringToJson(str: String): String =
-    "\"%s\"".format(str)
+    "\"%s\"".format(str.replaceAll("\\\\", "/"))
 
   def listToJson(obj: List[_]): String =
     "[" + obj.map((x) => stringify(x)).mkString(",") + "]"


### PR DESCRIPTION
Makes interaction with ksv easier and fixes escape problems with `\`.

https://github.com/kaitai-io/kaitai_struct_compiler/issues/80