### PR TITLE
JavaScriptCompiler: fix debug output

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -100,14 +100,8 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
     if (debug) {
       out.puts("this._debug = {};")
-      out.dec
-      out.puts("}")
-      out.puts
-      out.puts(s"${type2class(name.last)}.prototype._read = function() {")
-      out.inc
-    } else {
-      out.puts
     }
+    out.puts
   }
 
   override def classConstructorFooter: Unit = {


### PR DESCRIPTION
In the calculated endianess branch, the compiler was changed to always
emit the _read function instead of only when debug was enabled. The
readHeader method was introduced to emit the header of this function.
The JavaScriptCompiler still had code in the classConstructorHeader
method to emit the _read header if debug.