### PR TITLE
fix several issues with perl compiler

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -56,7 +56,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def doLocalName(s: String) = {
     s match {
       case "_" | "_on" => "$" + s
-      case Identifier.INDEX => "$i"
+      case Identifier.INDEX => doName(s)
       case _ => s"$$self->${doName(s)}"
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -56,6 +56,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def doLocalName(s: String) = {
     s match {
       case "_" | "_on" => "$" + s
+      case Identifier.INDEX => "$i"
       case _ => s"$$self->${doName(s)}"
     }
   }
@@ -91,7 +92,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     doStrCompareOp(left, op, right)
 
   override def doSubscript(container: Ast.expr, idx: Ast.expr): String =
-    s"${translate(container)}[${translate(idx)}]"
+    s"@{${translate(container)}}[${translate(idx)}]"
   override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String =
     s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
 


### PR DESCRIPTION
* add a case in doLocalName for INDEX to $i. Otherwise, it returned
$self->{$i}. This fixes the error in IndexSizes test
* Perl doesn't support an indexing directly on the return value of a
function (e.g. foo()[3]), and since we always deal with array refs, in
doSubscript, always explicitly dereference the container as a list with
circumfix operator (e.g. @{foo()}[3]). This fixes the SwitchCast test