### PR TITLE
Add ObjectOrientedLanguage.localTemporaryName

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -521,6 +521,8 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       case _ => s"_${idToStr(id)}"
     }
   }
+
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
 }
 
 object CSharpCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -754,6 +754,8 @@ class CppCompiler(
 
   override def publicMemberName(id: Identifier): String = idToStr(id)
 
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
+
   def declareNullFlag(attrName: Identifier, condSpec: ConditionalSpec) = {
     if (condSpec.ifExpr.nonEmpty) {
       outHdr.puts(s"bool ${nullFlagForName(attrName)};")

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -419,6 +419,8 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     }
   }
 
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
+
   def calculatedFlagForName(id: Identifier) = s"_f_${idToStr(id)}"
 }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -628,6 +628,8 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def privateMemberName(id: Identifier): String = s"this.${idToStr(id)}"
 
   override def publicMemberName(id: Identifier) = idToStr(id)
+
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
 }
 
 object JavaCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -541,6 +541,8 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     }
   }
 
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
+
   private
   def attrDebugNeeded(attrId: Identifier) = attrId match {
     case _: NamedIdentifier | _: NumberedIdentifier | _: InstanceIdentifier => true

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -389,6 +389,8 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def publicMemberName(id: Identifier) = idToStr(id)
 
+  override def localTemporaryName(id: Identifier): String = s"$$_t_${idToStr(id)}"
+
   /**
     * Determine PHP data type corresponding to a KS data type. Currently unused due to
     * problems with nullable types (which were introduced only in PHP 7.1).

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -395,6 +395,8 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def publicMemberName(id: Identifier): String = idToStr(id)
 
+  override def localTemporaryName(id: Identifier): String = s"$$_t_${idToStr(id)}"
+
   def boolLiteral(b: Boolean): String = translator.doBoolLiteral(b)
 
   def types2class(t: List[String]) = t.map(type2class).mkString("::")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -398,6 +398,8 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       case RawIdentifier(innerId) => s"_raw_${publicMemberName(innerId)}"
     }
   }
+
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
 }
 
 object PythonCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -436,6 +436,8 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def privateMemberName(id: Identifier): String = s"@${idToStr(id)}"
 
   override def publicMemberName(id: Identifier): String = idToStr(id)
+
+  override def localTemporaryName(id: Identifier): String = s"_t_${idToStr(id)}"
 }
 
 object RubyCompiler extends LanguageCompilerStatic

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -128,7 +128,7 @@ trait EveryReadIsExpression
           handleAssignmentSimple(id, expr)
           userTypeDebugRead(privateMemberName(id))
         case _ =>
-          val tempVarName = s"_t_${idToStr(id)}"
+          val tempVarName = localTemporaryName(id)
           handleAssignmentTempVar(dataType, tempVarName, expr)
           userTypeDebugRead(tempVarName)
           handleAssignment(id, tempVarName, rep, false)

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/ObjectOrientedLanguage.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/ObjectOrientedLanguage.scala
@@ -39,5 +39,15 @@ trait ObjectOrientedLanguage extends LanguageCompiler {
     */
   def publicMemberName(id: Identifier): String
 
+  /**
+    * Renders identifier as a proper reference to a local temporary
+    * variable appropriately named to hold a temporary reference to
+    * this field.
+    *
+    * @param id identifier to render
+    * @return identifier as string
+    */
+  def localTemporaryName(id: Identifier): String
+
   override def normalIO: String = privateMemberName(IoIdentifier)
 }


### PR DESCRIPTION
In the process of supporting debug mode for Perl, but wanted sign-off on
this before proceeding. Previously,
EveryReadIsExpression.attrUserTypeParse generated the name of the
temporary variable as s"_t_${idToStr(id)}" but this won't work for Perl
because it lacked the sigil. This change introduces a new method called
localTemporaryName to ObjectOrientedLanguage to allow for
language-specific generation of the name of a temporary variable meant
to store a value for a given Identifier.

If you're not happy with this way of addressing the issue, please provide some guidance on how I should proceed. Thanks!