### PR TITLE
#241 fixed: true.to_i becomes now (true)?1:0 to both avoid errors due…

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -109,7 +109,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: ImportList) extends B
   override def enumToInt(v: expr, et: EnumType): String =
     translate(v)
   override def boolToInt(v: expr): String =
-    translate(v)
+    s"((${translate(v)})?1:0)"
   override def floatToInt(v: expr): String =
     s"static_cast<int>(${translate(v)})"
   override def intToStr(i: expr, base: expr): String = {


### PR DESCRIPTION
… to missing parentheses and avoid warnings due to using bool values in an int expression.