### PR TITLE
Partial fix for #249

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -174,7 +174,9 @@ trait EveryReadIsExpression
       (dataType) => if (switchBytesOnlyAsRaw) {
         dataType match {
           case t: BytesType =>
-            attrParse2(RawIdentifier(id), dataType, io, extraAttrs, rep, false, defEndian, Some(assignType))
+            val rawId = RawIdentifier(id)
+            Utils.addUniqueAttr(extraAttrs, AttrSpec(List(), rawId, dataType))
+            attrParse2(rawId, dataType, io, extraAttrs, rep, false, defEndian, Some(assignType))
           case _ =>
             attrParse2(id, dataType, io, extraAttrs, rep, false, defEndian, Some(assignType))
         }


### PR DESCRIPTION
 (Incorrect code when using "size" with "switch-on" without a default case): It adds one missing property declaration.