### PR TITLE
Fix URL to Web IDE

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -27,7 +27,7 @@ is generally suited for developers of tools that use Kaitai Struct
 the compiler). If you:
 
 * just look for a way to try out Kaitai Struct => try
-  [Kaitai Struct Web IDE](https://ide.kaitai/io/), which uses this
+  [Kaitai Struct Web IDE](https://ide.kaitai.io/), which uses this
   compiler internally
 * want to load .ksy file transparently in your JavaScript code
   (compiling it on the fly) => use


### PR DESCRIPTION
The target URL used a `/` in place of a `.` causing the TLD that is looked up to be `kaitai` which is not a TLD.