### PR TITLE
Python properties, unreachable code removed

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -392,7 +392,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def instanceReturn(instName: InstanceIdentifier): Unit = {
     // not very efficient, probably should be some other way to do that, but for now it will do:
     // workaround to avoid Python generating an "AttributeError: instance has no attribute"
-    out.puts(s"return ${privateMemberName(instName)} if hasattr(self, '${idToStr(instName)}') else None")
+    out.puts(s"return ${privateMemberName(instName)}")
   }
 
   override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(Long, String)]): Unit = {


### PR DESCRIPTION
Since the private field gets assigned unconditionally, there is no point in checking if it exits. Its unreachable code.
```py
@property
def num2(self):
    if hasattr(self, '_m_num2'):
        return self._m_num2 if hasattr(self, '_m_num2') else None

    self._m_num2 = ((self.num2_hi << 16) | self.num2_lo)
    return self._m_num2 if hasattr(self, '_m_num2') else None
```
The PR would produce this, but we should make sure that other parts of the compiler only refer to the PUBLIC property.
```py
@property
def num2(self):
    if hasattr(self, '_m_num2'):
        return self._m_num2

    self._m_num2 = ((self.num2_hi << 16) | self.num2_lo)
    return self._m_num2
```
