### PR TITLE
doArrayLiteral used classes without importing the necessary packages.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -23,6 +23,9 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def doArrayLiteral(t: DataType, value: Seq[expr]): String = {
     val javaType = JavaCompiler.kaitaiType2JavaTypeBoxed(t)
     val commaStr = value.map((v) => translate(v)).mkString(", ")
+
+    importList.add("java.util.ArrayList")
+    importList.add("java.util.Arrays")
     s"new ArrayList<$javaType>(Arrays.asList($commaStr))"
   }
 


### PR DESCRIPTION
KSY like the following:

    instances:
      hex_chars:
        value:  |
                ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']

lead to the following Java:

	import io.kaitai.struct.ByteBufferKaitaiStream;
	import io.kaitai.struct.KaitaiStruct;
	import io.kaitai.struct.KaitaiStream;
	import java.io.IOException;

[...]

    public ArrayList<String> hexChars() {
        if (this.hexChars != null)
            return this.hexChars;
        this.hexChars = new ArrayList<String>(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"));
        return this.hexChars;
    }

Which resulted in compiler errors. With this PR, the import list looks properly like the following:

	import io.kaitai.struct.ByteBufferKaitaiStream;
	import io.kaitai.struct.KaitaiStruct;
	import io.kaitai.struct.KaitaiStream;
	import java.io.IOException;
	import java.util.ArrayList;
	import java.util.Arrays;
