### PR TITLE
Trim expressions to parse or user type invocations with attributes…

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
@@ -175,7 +175,7 @@ object Expressions {
   def parseList(src: String): Seq[Ast.expr] = realParse(src, topExprList)
 
   private def realParse[T](src: String, parser: P[T]): T = {
-    val r = parser.parse(src)
+    val r = parser.parse(src.trim)
     r match {
       case Parsed.Success(value, _) => value
       case f: Parsed.Failure =>


### PR DESCRIPTION
…can't start with spaces. Seems like an unnecessary restriction and prevents proper column based indentation of long attribute names. Have a look at the following example:

      - id:   apl
        type: fmt_oms_apl_full( tpl.tpl_short.config_field.apl_starts_decrypted_with_enc_mode,
                                tpl.tpl_short.config_field.enc_bytes_cnt)

Recognize the leading space after the opening `(`. Without trim this leads to the following error:

	Compilation OK
	... processing record\fmt_clt_recs.ksy 0
	Error: [{"file"=>"fmt_clt_rec", "path"=>["meta", "imports", "0"], "message"=>"/types/fmt_oms_tpl_long_with_apl_full/seq/1: parsing expression ' tpl.tpl_short.config_field.apl_starts_decrypted_with_enc_mode, tpl.tpl_short.config_field.enc_bytes_cnt' failed on 1:1, expected \"not\" ~ not_test | comparison"}]
	Fatal errors encountered, cannot continue

The same white-space is used in the error message and the problem can easily be resolved if the string to parse is trimmed. I don't see any downsides of this, so are providing this PR.