### PR TITLE
Fix wrong iterator handling for user types in repeat-until.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -389,7 +389,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)} = new ${kaitaiType2JavaType(ArrayType(dataType))}();")
     out.puts("{")
     out.inc
-    out.puts(s"${kaitaiType2JavaType(dataType)} ${translator.doName("_")};")
+    out.puts(s"${kaitaiType2JavaType(dataType)} ${translator.doName(Identifier.ITERATOR)} = null;")
     out.puts("int i = 0;")
     out.puts("do {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -308,6 +308,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     if (needRaw)
       out.puts(s"${privateMemberName(RawIdentifier(id))} = []")
     out.puts(s"${privateMemberName(id)} = []")
+    out.puts(s"${translator.doName(Identifier.ITERATOR)} = nil")
     out.puts("i = 0")
     out.puts("begin")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -29,6 +29,7 @@ class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
 
   override def doName(s: String) = {
     s match {
+      case Identifier.ITERATOR => "_it"
       case Identifier.INDEX => "i" // FIXME: probably would clash with attribute named "i"
       case _ => s
     }


### PR DESCRIPTION
I have the following KSY which broke in Ruby and Java because the special iterator `_` has not been processed properly. In Ruby it wasn't declared early enough and is therefore not known during user type invocation and in Java it wasn't initialized properly, leading to a compile time error. This PR fixes both.

I did the change in `RubyTranslator` because I wasn't sure if translating `_` is missing there by accident or purpose and came across it. Feel free to change that if it was wrong.

KSY:

      - id:       vdbs
        type:     fmt_oms_apl_full_vdb(vdbs.size - 1, _)
        repeat:       until
        repeat-until: _.next_isnt_vdb
        if:       not   next_isnt_vdb

Wrong Ruby:

      if !(next_isnt_vdb)
        (@_debug['vdbs'] ||= {})[:start] = @_io.pos
        @vdbs = []
        i = 0
        begin
          (@_debug['vdbs'][:arr] ||= [])[@vdbs.size] = {:start => @_io.pos}
          _t_vdbs = FmtOmsAplFullVdb.new(@_io, self, @_root, (vdbs.length - 1), _)
          _t_vdbs._read
          _ = _t_vdbs
          @vdbs << _
          @_debug['vdbs'][:arr][@vdbs.size - 1][:end] = @_io.pos
          i += 1
        end until _.next_isnt_vdb
        (@_debug['vdbs'] ||= {})[:end] = @_io.pos
      end

Wrong Java:

	FmtOmsAplFullVdb _it;
	int i = 0;
	do {
		_it = new FmtOmsAplFullVdb(this._io, this, _root, (vdbs().size() - 1), _it);
		this.vdbs.add(_it);
		i++;
	} while (!(_it.nextIsntVdb()));

Working Ruby:

      if !(next_isnt_vdb)
        (@_debug['vdbs'] ||= {})[:start] = @_io.pos
        @vdbs = []
        _it = nil
        i = 0
        begin
          (@_debug['vdbs'][:arr] ||= [])[@vdbs.size] = {:start => @_io.pos}
          _t_vdbs = FmtOmsAplFullVdb.new(@_io, self, @_root, (vdbs.length - 1), _it)
          _t_vdbs._read
          _it = _t_vdbs
          @vdbs << _it
          @_debug['vdbs'][:arr][@vdbs.size - 1][:end] = @_io.pos
          i += 1
        end until _it.next_isnt_vdb
        (@_debug['vdbs'] ||= {})[:end] = @_io.pos
      end

Working Java:

    FmtOmsAplFullVdb _it = null;
    int i = 0;
    do {
        _it = new FmtOmsAplFullVdb(this._io, this, _root, (vdbs().size() - 1), _it);
        this.vdbs.add(_it);
        i++;
    } while (!(_it.nextIsntVdb()));
