### PR TITLE
Remove warning about unused i in Java.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -362,7 +362,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatEosFooter: Unit = {
-    out.puts("i++;")
+    out.puts("i = i + 1;")
     out.dec
     out.puts("}")
     out.dec
@@ -409,7 +409,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, untilExpr: expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
-    out.puts("i++;")
+    out.puts("i = i + 1;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")
     out.dec


### PR DESCRIPTION
This fixes https://github.com/kaitai-io/kaitai_struct/issues/365 in a somewhat easy manner and can be improved in future if needed at all.