### PR TITLE
WIP: remove src folder from generated structure

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -42,7 +42,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def indent: String = "    "
   override def outFileName(topClassName: String): String =
-    s"src/${config.javaPackage.replace('.', '/')}/${type2class(topClassName)}.java"
+    s"${config.javaPackage.replace('.', '/')}/${type2class(topClassName)}.java"
 
   override def outImports(topClass: ClassSpec) =
     "\n" + importList.toList.map((x) => s"import $x;").mkString("\n") + "\n"


### PR DESCRIPTION
You don't always want sources to be generated in /src folder, especially when you put --outdir parameter. It can be helpful if you want files to be directly generated to the project with project structure like `...src/java/io/kaitai/...`
If you approve, we should probably remove src from other languages as well.