### PR TITLE
Fix invalid Java code generation when using repeat-expr with optional u4 field

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -371,8 +371,8 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: expr): Unit = {
     if (needRaw)
-      out.puts(s"${privateMemberName(RawIdentifier(id))} = new ArrayList<byte[]>((int) (${expression(repeatExpr)}));")
-    out.puts(s"${idToStr(id)} = new ${kaitaiType2JavaType(ArrayType(dataType))}((int) (${expression(repeatExpr)}));")
+      out.puts(s"${privateMemberName(RawIdentifier(id))} = new ArrayList<byte[]>(((Number) (${expression(repeatExpr)})).intValue());")
+    out.puts(s"${idToStr(id)} = new ${kaitaiType2JavaType(ArrayType(dataType))}(((Number) (${expression(repeatExpr)})).intValue());")
     out.puts(s"for (int i = 0; i < ${expression(repeatExpr)}; i++) {")
     out.inc
 


### PR DESCRIPTION
Kaitai compiler generates invalid Java code when processing KSY specification like this:
```
seq:
  - id: flag
    type: u1
  - id: num
    type: u4
    if: flag == 1
  - id: array
    type: u4
    repeat: expr
    repeat-expr: num
    if: flag == 1
```
`num` field is compiled to `Long` type (int is too small and it needs to handle null because field is optional). When Kaitai compiler tries to create array it casts `num` field value to `int`. Its not possible in Java to cast `Long` value to `int` like that.
```
Long x = 10;
int y  = (int) x; // compiler error
```
One way would be to first cast to `long` (primitive `long`, not `Long`) and then to `int` but that would require knowledge what type the expression produces. My solution is to first cast to `Number` (primitive type would get boxed into object type) and then use `intValue()` method which is implemented for all `Number` subclasses (Byte, Short, Integer, Long). 
Please note new code works the same way as old one when handling a `null` value - it throws `NullPointerException`.