### PR TITLE
Allow "import-path" more than once to not necessarily use OS-specific…

### DIFF
--- a/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala
@@ -62,7 +62,7 @@ object JavaMain {
       } text("output directory (filenames will be auto-generated)")
 
       val importPathExample = List("<directory>", "<directory>", "...").mkString(File.pathSeparator)
-      opt[String]('I', "import-path") valueName(importPathExample) action { (x, c) =>
+      opt[String]('I', "import-path") optional() unbounded() valueName(importPathExample) action { (x, c) =>
         c.copy(importPaths = c.importPaths ++ x.split(File.pathSeparatorChar))
       } text(".ksy library search path(s) for imports (see also KSPATH env variable)")
 


### PR DESCRIPTION
… path separator. The used args parser already supports everything needed, so this should be the easiest solution.

https://github.com/scopt/scopt#occurrence
This fixes https://github.com/kaitai-io/kaitai_struct/issues/557.