### PR TITLE
Improve switch statement support in Go

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -318,22 +318,21 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 //    expr2
 //  }
 
-  override def switchStart(id: Identifier, on: Ast.expr): Unit =
+  override def switchStart(id: Identifier, on: Ast.expr): Unit = {
     out.puts(s"switch (${expression(on)}) {")
+  }
 
   override def switchCaseStart(condition: Ast.expr): Unit = {
-    out.puts(s"case ${expression(condition)}: {")
+    out.puts(s"case ${expression(condition)}:")
     out.inc
   }
 
   override def switchCaseEnd(): Unit = {
-    out.puts("break;")
     out.dec
-    out.puts("}")
   }
 
   override def switchElseStart(): Unit = {
-    out.puts("default: {")
+    out.puts("default:")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -5,7 +5,7 @@ import io.kaitai.struct.datatype.{DataType, FixedEndian, KSError}
 import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.format._
 import io.kaitai.struct.languages.components._
-import io.kaitai.struct.translators.{GoTranslator, TranslatorResult, TypeDetector}
+import io.kaitai.struct.translators.{GoTranslator, ResultString, TranslatorResult, TypeDetector}
 import io.kaitai.struct.{ClassTypeProvider, RuntimeConfig, Utils}
 
 class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
@@ -272,8 +272,33 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
+  private def castToType(r: TranslatorResult, dataType: DataType): TranslatorResult = {
+    dataType match {
+      case t @ (_: IntMultiType | _: FloatMultiType) =>
+        ResultString(s"${kaitaiType2NativeType(t)}(${translator.resToStr(r)})")
+      case _ =>
+        r
+    }
+  }
+
+  private def combinedType(dataType: DataType) = {
+    dataType match {
+      case st: SwitchType => st.combinedType
+      case _ => dataType
+    }
+  }
+
+  private def handleCompositeTypeCast(id: Identifier, r: TranslatorResult): TranslatorResult = {
+    id match {
+      case NamedIdentifier(name) =>
+        castToType(r, combinedType(typeProvider.determineType(name)))
+      case _ =>
+        r
+    }
+  }
+
   override def handleAssignmentSimple(id: Identifier, r: TranslatorResult): Unit = {
-    val expr = translator.resToStr(r)
+    val expr = translator.resToStr(handleCompositeTypeCast(id, r))
     out.puts(s"${privateMemberName(id)} = $expr")
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -364,6 +364,21 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def switchEnd(): Unit =
     out.puts("}")
 
+  override def switchShouldUseCompareFn(onType: DataType): Option[String] = {
+    onType match {
+      case _: BytesType =>
+        importList.add("bytes")
+        Some("bytes.Equal")
+      case _ =>
+        None
+    }
+  }
+
+  override def switchCaseStartCompareFn(compareFn: String, switchOn: Ast.expr, condition: Ast.expr): Unit = {
+    out.puts(s"case ${compareFn}(${expression(switchOn)}, ${expression(condition)}):")
+    out.inc
+  }
+
   override def instanceDeclaration(attrName: InstanceIdentifier, attrType: DataType, isNullable: Boolean): Unit = {
     out.puts(s"${calculatedFlagForName(attrName)} bool")
     out.puts(s"${idToStr(attrName)} ${kaitaiType2NativeType(attrType)}")

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GoSwitchOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GoSwitchOps.scala
@@ -1,0 +1,59 @@
+package io.kaitai.struct.languages.components
+
+import io.kaitai.struct.datatype.DataType
+import io.kaitai.struct.datatype.DataType.{BytesType, SwitchType}
+import io.kaitai.struct.exprlang.Ast
+import io.kaitai.struct.format.Identifier
+import io.kaitai.struct.translators.GoTranslator
+
+trait GoSwitchOps extends SwitchOps {
+  val translator: GoTranslator
+
+  def switchShouldUseCompareFn(onType: DataType): Option[String]
+  def switchCaseStartCompareFn(compareFn: String, switchOn: Ast.expr, condition: Ast.expr): Unit
+
+  override def switchCases[T](
+    id: Identifier,
+    on: Ast.expr,
+    cases: Map[Ast.expr, T],
+    normalCaseProc: (T) => Unit,
+    elseCaseProc: (T) => Unit
+  ): Unit = {
+    val onType = translator.detectType(on)
+    switchShouldUseCompareFn(onType) match {
+      case Some(compareFn: String) =>
+        switchCasesUsingCompareFn(id, on, compareFn, cases, normalCaseProc, elseCaseProc)
+      case None =>
+        switchCasesRender(id, on, cases, normalCaseProc, elseCaseProc)
+    }
+  }
+
+  protected def switchCasesUsingCompareFn[T](
+    id: Identifier,
+    on: Ast.expr,
+    compareFn: String,
+    cases: Map[Ast.expr, T],
+    normalCaseProc: (T) => Unit,
+    elseCaseProc: (T) => Unit
+  ): Unit = {
+    switchStart(id, Ast.expr.Bool(true))
+
+    cases.foreach { case (condition, result) =>
+      condition match {
+        case SwitchType.ELSE_CONST =>
+        case _ =>
+          switchCaseStartCompareFn(compareFn, on, condition)
+          normalCaseProc(result)
+          switchCaseEnd()
+      }
+    }
+
+    cases.get(SwitchType.ELSE_CONST).foreach { (result) =>
+      switchElseStart()
+      elseCaseProc(result)
+      switchElseEnd()
+    }
+
+    switchEnd()
+  }
+}


### PR DESCRIPTION
Another round of Go improvements. This time, various kinds of switch statements now work. None of the kst tests seem to rely on switch statements, so this time there is no change in tests passing or failing. However, more structs are successfully compiled.

Before:
`SUMMARY: {"kst"=>77, "passed"=>71, "failed"=>14}`

After:
`SUMMARY: {"kst"=>77, "passed"=>71, "failed"=>14}`

#### Examples of produced code
##### Switched type
```go
	this.Code = tmp1
	switch (this.Code) {
	case 1:
		tmp2, err := this._io.ReadU1()
		if err != nil {
			return err
		}
		this.Len = uint64(tmp2)
	case 2:
		tmp3, err := this._io.ReadU2le()
		if err != nil {
			return err
		}
		this.Len = uint64(tmp3)
...
```

##### Byte-slice switch
```go
	switch (true) {
	case bytes.Equal(this.Code, []uint8{73}):
		tmp4 := new(SwitchBytearray_Opcode_Intval)
		err = tmp4.Read(this._io, this, this._root)
		if err != nil {
			return err
		}
		this.Body = tmp4
	case bytes.Equal(this.Code, []uint8{83}):
		tmp5 := new(SwitchBytearray_Opcode_Strval)
		err = tmp5.Read(this._io, this, this._root)
		if err != nil {
			return err
		}
		this.Body = tmp5
	}
```

(Note: The `switch (true) {` can just be `switch {`, but to keep it simple I did not bother implementing this simplification. This code is semantically identical.)

#### Newly-working compilations
It's a little hard to quantify how this improves things since kst tests don't cover it. Instead, here is a diff of files that both compile and survive the recovery phase of unit testing. So, these are files that either failed to compile before, or contained errors, that now compile in this branch.

```diff
+nav_parent2.go
+nav_parent3.go
+nav_parent_switch.go
+non_standard.go
+process_coerce_switch.go
+recursive_one.go
+switch_bytearray.go
+switch_integers2.go
+switch_integers.go
+switch_manual_enum.go
+switch_manual_enum_invalid_else.go
+switch_manual_enum_invalid.go
+switch_manual_int_else.go
+switch_manual_int.go
+switch_manual_int_size_else.go
+switch_manual_int_size_eos.go
+switch_manual_int_size.go
+switch_manual_str_else.go
+switch_manual_str.go
+switch_multi_bool_ops.go
+switch_repeat_expr.go
```

It is a little frustrating that the Go compiler duplicates some functionality, but it doesn't seem like most of these customizations will be useful to other languages, and the Go compiler already deviates unusually far from the norm. So this trend is likely to continue, and maybe could be alleviated some day by trying to build better abstractions.