### PR TITLE
[WIP] Nim Compiler

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/Main.scala
+++ b/shared/src/main/scala/io/kaitai/struct/Main.scala
@@ -1,7 +1,7 @@
 package io.kaitai.struct
 
 import io.kaitai.struct.format.{ClassSpec, ClassSpecs, GenericStructClassSpec}
-import io.kaitai.struct.languages.{GoCompiler, RustCompiler}
+import io.kaitai.struct.languages.{GoCompiler, RustCompiler, NimCompiler}
 import io.kaitai.struct.languages.components.LanguageCompilerStatic
 import io.kaitai.struct.precompile._
 
@@ -65,6 +65,8 @@ object Main {
         new ConstructClassCompiler(specs, spec)
       case HtmlClassCompiler =>
         new HtmlClassCompiler(specs, spec)
+      case NimCompiler =>
+        new NimClassCompiler(specs, spec, config)
       case _ =>
         new ClassCompiler(specs, spec, config, lang)
     }

--- a/shared/src/main/scala/io/kaitai/struct/NimClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/NimClassCompiler.scala
@@ -1,0 +1,75 @@
+package io.kaitai.struct
+
+import io.kaitai.struct.CompileLog.FileSuccess
+import io.kaitai.struct.datatype.DataType.UserTypeInstream
+import io.kaitai.struct.datatype.{InheritedEndian, FixedEndian}
+import io.kaitai.struct.format._
+import io.kaitai.struct.languages.components.ExtraAttrs
+import io.kaitai.struct.languages.NimCompiler
+
+class NimClassCompiler(
+  classSpecs: ClassSpecs,
+  override val topClass: ClassSpec,
+  config: RuntimeConfig
+) extends ClassCompiler(classSpecs, topClass, config, NimCompiler) {
+  override def compile: CompileLog.SpecSuccess = {
+    lang.fileHeader(topClassName.head)
+    compileType(topClass)
+    compileProcs(topClass)
+
+    CompileLog.SpecSuccess(
+      lang.type2class(topClassName.head),
+      lang.results(topClass).map { case (fileName, contents) => FileSuccess(fileName, contents) }.toList
+    )
+  }
+
+  def compileType(curClass: ClassSpec): Unit = {
+    lang.classHeader(curClass.name)
+
+    val extraAttrs = List(
+      AttrSpec(List(), RootIdentifier, UserTypeInstream(topClassName, None)),
+      AttrSpec(List(), ParentIdentifier, curClass.parentType)
+    ) ++ ExtraAttrs.forClassSpec(curClass, lang)
+
+    compileAttrDeclarations(curClass.seq ++ extraAttrs)
+    lang.classFooter(curClass.name)
+    compileSubtypes(curClass)
+  }
+
+  def compileSubtypes(curClass: ClassSpec): Unit = {
+    curClass.types.foreach { case (_, subClass) => compileType(subClass) }
+  }
+
+  def compileProcs(curClass: ClassSpec): Unit = {
+    lang.classConstructorHeader(
+      curClass.name,
+      curClass.parentType,
+      topClassName,
+      curClass.meta.endian.contains(InheritedEndian),
+      curClass.params
+    )
+
+    // example: "result.one = readU4Be(stream)"
+    compileReads(curClass.seq)
+
+    lang.classConstructorFooter
+
+    lang.asInstanceOf[NimCompiler].fromFileProc(curClass.name)
+    compileSubprocs(curClass)
+  }
+
+  def compileSubprocs(curClass: ClassSpec): Unit = {
+    curClass.types.foreach { case (_, subClass) => compileSubprocs(subClass) }
+  }
+
+  // XXX
+  def compileReads(seq: List[AttrSpec]): Unit = {
+    lang.readHeader(None, false)
+
+    seq.foreach { (attr) =>
+      lang.asInstanceOf[NimCompiler].instanceCalculatePleb(attr.id.toString(), attr.dataType.toString())
+    }
+
+    lang.readFooter()
+  }
+}

--- a/shared/src/main/scala/io/kaitai/struct/NimClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/NimClassCompiler.scala
@@ -49,8 +49,13 @@ class NimClassCompiler(
       curClass.params
     )
 
-    // example: "result.one = readU4Be(stream)"
-    compileReads(curClass.seq)
+    // FIXME
+    val defEndian = curClass.meta.endian match {
+      case Some(fe: FixedEndian) => Some(fe)
+      case _ => None
+    }
+
+    compileReads(curClass)
 
     lang.classConstructorFooter
 
@@ -62,14 +67,11 @@ class NimClassCompiler(
     curClass.types.foreach { case (_, subClass) => compileSubprocs(subClass) }
   }
 
-  // XXX
-  def compileReads(seq: List[AttrSpec]): Unit = {
-    lang.readHeader(None, false)
-
-    seq.foreach { (attr) =>
-      lang.asInstanceOf[NimCompiler].instanceCalculatePleb(attr.id.toString(), attr.dataType.toString())
+  def compileReads(curClass: ClassSpec): Unit = {
+    val defEndian = curClass.meta.endian match {
+      case Some(fe: FixedEndian) => Some(fe)
+      case _ => None
     }
-
-    lang.readFooter()
+    curClass.seq.foreach { (attr) => lang.asInstanceOf[NimCompiler].readInstance(attr.id, attr.dataType, defEndian) }
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -39,7 +39,10 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def attributeReader(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = ()
+
   override def classConstructorFooter: Unit = {
+    out.puts("result.root = root")
+    out.puts("result.parent = parent")
     out.dec
   }
 
@@ -53,8 +56,6 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
     out.puts(s"result = new(${current})")
     out.puts("let root = if root == nil: result else: root")
-    out.puts("result.root = root")
-    out.puts("result.parent = parent")
   }
 
   override def classFooter(name: List[String]): Unit = {
@@ -128,8 +129,13 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
   }
 
-  def instanceCalculatePleb(left: String, right: String): Unit = {
-    out.puts(left + " = " + right)
+  def readInstance(instName: Identifier, dataType: DataType, endian: Option[FixedEndian]): Unit = {
+    val api = dataType match {
+      case rt: ReadableType => rt.apiCall(endian)
+      case _ => dataType.toString
+    }
+
+    out.puts("result." + idToStr(instName) + " = read" + Utils.capitalize(api) + "(stream)")
   }
 
   // Slightly different implementation than io.kaitai.struct.Utils

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -31,11 +31,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def attributeDeclaration(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = {
     val name = idToStr(attrName)
-    val typePrefix = attrType match {
-      case _: UserType if (name == "root" || name == "parent") => "ref "
-      case _ => ""
-    }
-    out.puts(s"${name}*: ${typePrefix}${kaitaiType2NimType(attrType)}")
+    out.puts(s"${name}*: ${kaitaiType2NimType(attrType)}")
   }
 
   override def attributeReader(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = ()
@@ -52,7 +48,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val root = types2class(rootClassName)
     val parent = kaitaiType2NimType(parentType)
     out.puts
-    out.puts(s"proc read*(_: typedesc[${current}], stream: KaitaiStream, root: ref ${root}, parent: ${parent}): owned ${current} =")
+    out.puts(s"proc read*(_: typedesc[${current}], stream: KaitaiStream, root: ${root}, parent: ${parent}): owned ${current} =")
     out.inc
     out.puts(s"result = new(${current})")
     out.puts("let root = if root == nil: result else: root")
@@ -64,7 +60,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def classHeader(name: List[String]): Unit = {
-    out.puts(s"${upperCamelCase(name.mkString(""))}* = object")
+    out.puts(s"${upperCamelCase(name.mkString(""))}* = ref object")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -1,0 +1,164 @@
+package io.kaitai.struct.languages
+
+import io.kaitai.struct._
+import io.kaitai.struct.datatype.DataType._
+import io.kaitai.struct.datatype._
+import io.kaitai.struct.exprlang.Ast
+import io.kaitai.struct.exprlang.Ast.expr
+import io.kaitai.struct.format._
+import io.kaitai.struct.languages.components._
+
+import io.kaitai.struct.translators.{CppTranslator, TypeDetector}
+
+class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
+  extends LanguageCompiler(typeProvider, config)
+    with SingleOutputFile
+    with UpperCamelCaseClasses {
+  import NimCompiler._
+
+  // Members declared in io.kaitai.struct.languages.components.ExceptionNames
+  override def ksErrorName(err: KSError): String = "" // XXX
+
+  // Members declared in io.kaitai.struct.languages.components.ExtraAttrs
+  override def extraAttrForIO(id: Identifier, rep: RepeatSpec): List[AttrSpec] = List() // XXX
+
+  // Members declared in io.kaitai.struct.languages.components.LanguageCompiler
+  override def alignToByte(io: String): Unit = () // XXX
+  override def attrFixedContentsParse(attrName: Identifier, contents: Array[Byte]): Unit = Array() // XXX
+  override def attrParse(attr: AttrLikeSpec, id: Identifier, defEndian: Option[Endianness]): Unit = Option() // XXX
+  override def attrParseHybrid(leProc: () => Unit, beProc: () => Unit): Unit = () // XXX
+  override def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit = () // XXX
+  override def attributeDeclaration(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = {
+    val name = idToStr(attrName)
+    val typePrefix = attrType match {
+      case _: UserType if (name == "root" || name == "parent") => "ref "
+      case _ => ""
+    }
+    out.puts(s"${name}*: ${typePrefix}${kaitaiType2NimType(attrType)}")
+  }
+  override def attributeReader(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = () // XXX
+  override def classConstructorFooter: Unit = () // XXX
+  override def classConstructorHeader(name: List[String], parentType: DataType, rootClassName: List[String], isHybrid: Boolean, params: List[ParamDefSpec]): Unit = () // XXX
+  override def classFooter(name: List[String]): Unit = {
+    out.dec
+  }
+  override def classHeader(name: List[String]): Unit = {
+    out.puts(s"type ${upperCamelCase(name.mkString(""))}* = object")
+    out.inc
+  }
+  override def condIfFooter(expr: Ast.expr): Unit = () // XXX
+  override def condIfHeader(expr: Ast.expr): Unit = () // XXX
+  override def condRepeatEosFooter: Unit = () // XXX
+  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean): Unit = () // XXX
+  override def condRepeatExprFooter: Unit = () // XXX
+  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: Ast.expr): Unit = () // XXX
+  override def condRepeatUntilFooter(id: Identifier, io: String,dataType: DataType,needRaw: Boolean, repeatExpr: Ast.expr): Unit = () // XXX
+  override def condRepeatUntilHeader(id: Identifier, io: String,dataType: DataType,needRaw: Boolean, repeatExpr: Ast.expr): Unit = () // XXX
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(Long, EnumValueSpec)]): Unit = () // XXX
+  override def fileHeader(topClassName: String): Unit = {
+    outHeader.puts(s"# $headerComment")
+    importList.add(s"../kaitai_struct_nim_runtime/kaitai")
+    out.puts
+  }
+  override def indent: String = "  "
+  override def instanceCalculate(instName: Identifier, dataType: DataType, value: Ast.expr): Unit = () // XXX
+  override def instanceCheckCacheAndReturn(instName: InstanceIdentifier, dataType: DataType): Unit = () // XXX
+  override def instanceFooter: Unit = () // XXX
+  override def instanceHeader(className: List[String], instName: InstanceIdentifier, dataType: DataType, isNullable: Boolean): Unit = () // XXX
+  override def instanceReturn(instName: InstanceIdentifier, attrType: DataType): Unit = () // XXX
+  override def normalIO: String = "" // XXX
+  override def outFileName(topClassName: String): String = "parser.nim" // XXX
+  override def popPos(io: String): Unit = () // XXX
+  override def pushPos(io: String): Unit = () // XXX
+  override def readFooter(): Unit = () // XXX
+  override def readHeader(endian: Option[FixedEndian], isEmpty: Boolean): Unit = () // XXX
+  override def runRead(): Unit = () // XXX
+  override def runReadCalc(): Unit = () // XXX
+  override def seek(io: String, pos: Ast.expr): Unit = () // XXX
+
+  val importListSrc = new ImportList
+  override val translator: io.kaitai.struct.translators.AbstractTranslator = new CppTranslator(typeProvider, importListSrc, config) // XXX
+
+  override def useIO(ioEx: Ast.expr): String = "" // XXX
+
+  // Members declared in io.kaitai.struct.languages.components.SwitchOps
+  override def switchCaseEnd(): Unit = () // XXX
+  override def switchCaseStart(condition: Ast.expr): Unit = () // XXX
+  override def switchElseStart(): Unit = () // XXX
+  override def switchEnd(): Unit = () // XXX
+  override def switchStart(id: Identifier, on: Ast.expr): Unit = () // XXX
+
+  // Members declared in io.kaitai.struct.languages.components.SingleOutputFile
+  override def outImports(topClass: ClassSpec) =
+    "\n" + importList.toList.map((x) => s"import $x").mkString("\n") + "\n"
+
+  // Slightly different implementation than io.kaitai.struct.Utils
+  // This is necessary because identifiers cannot start with "_" in Nim
+  def lowerCamelCase(s: String): String = {
+    if (s.startsWith("_")) {
+      lowerCamelCase(s.substring(1))
+    } else {
+      val firstWord :: restWords = s.split("_").toList
+      (firstWord :: restWords.map(Utils.capitalize)).mkString
+    }
+  }
+  def upperCamelCase(s: String): String = {
+    if (s.startsWith("_")) {
+      upperCamelCase(s.substring(1))
+    } else {
+      s.split("_").map(Utils.capitalize).mkString
+    }
+  }
+
+  def headerComment = "This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild"
+
+  def idToStr(id: Identifier): String = {
+    id match {
+      case SpecialIdentifier(name) => lowerCamelCase(name)
+      case NamedIdentifier(name) => lowerCamelCase(name)
+      case NumberedIdentifier(idx) => s"_${NumberedIdentifier.TEMPLATE}$idx"
+      case InstanceIdentifier(name) => lowerCamelCase(name)
+      case RawIdentifier(innerId) => "_raw_" + idToStr(innerId)
+    }
+  }
+}
+
+object NimCompiler extends LanguageCompilerStatic
+  with UpperCamelCaseClasses {
+  override def getCompiler(
+    tp: ClassTypeProvider,
+    config: RuntimeConfig
+  ): LanguageCompiler = new NimCompiler(tp, config)
+
+  def kaitaiType2NimType(attrType: DataType): String = {
+    attrType match {
+      case Int1Type(false) => "uint8"
+      case IntMultiType(false, Width2, _) => "uint16"
+      case IntMultiType(false, Width4, _) => "uint32"
+      case IntMultiType(false, Width8, _) => "uint64"
+
+      case Int1Type(true) => "int8"
+      case IntMultiType(true, Width2, _) => "int16"
+      case IntMultiType(true, Width4, _) => "int32"
+      case IntMultiType(true, Width8, _) => "int"
+
+      case FloatMultiType(Width4, _) => "float32"
+      case FloatMultiType(Width8, _) => "float64"
+
+      case BitsType(_) => "uint64"
+
+      case _: BooleanType => "bool"
+      case CalcIntType => "int"
+      case CalcFloatType => "float64"
+
+      case _: StrType => "string"
+      case _: BytesType => "seq[byte]"
+
+      case KaitaiStructType | CalcKaitaiStructType => "type(nil)"
+
+      case t: UserType => types2class(t.name)
+    }
+  }
+
+  def types2class(names: List[String]) = names.map(x => type2class(x)).mkString("_")
+}

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -57,7 +57,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(Long, EnumValueSpec)]): Unit = () // XXX
   override def fileHeader(topClassName: String): Unit = {
     outHeader.puts(s"# $headerComment")
-    importList.add(s"../kaitai_struct_nim_runtime/kaitai")
+    importList.add(s"../../../runtime/nim/kaitai")
     out.puts
   }
   override def indent: String = "  "
@@ -67,7 +67,8 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def instanceHeader(className: List[String], instName: InstanceIdentifier, dataType: DataType, isNullable: Boolean): Unit = () // XXX
   override def instanceReturn(instName: InstanceIdentifier, attrType: DataType): Unit = () // XXX
   override def normalIO: String = "" // XXX
-  override def outFileName(topClassName: String): String = "parser.nim" // XXX
+  override def outFileName(topClassName: String): String =
+    s"$topClassName.nim"
   override def popPos(io: String): Unit = () // XXX
   override def pushPos(io: String): Unit = () // XXX
   override def readFooter(): Unit = () // XXX
@@ -154,7 +155,7 @@ object NimCompiler extends LanguageCompilerStatic
       case _: StrType => "string"
       case _: BytesType => "seq[byte]"
 
-      case KaitaiStructType | CalcKaitaiStructType => "type(nil)"
+      case KaitaiStructType | CalcKaitaiStructType => "ref RootObj"
 
       case t: UserType => types2class(t.name)
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompilerStatic.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompilerStatic.scala
@@ -18,6 +18,7 @@ object LanguageCompilerStatic {
     "java" -> JavaCompiler,
     "javascript" -> JavaScriptCompiler,
     "lua" -> LuaCompiler,
+    "nim" -> NimCompiler,
     "perl" -> PerlCompiler,
     "php" -> PHPCompiler,
     "python" -> PythonCompiler,


### PR DESCRIPTION
```
meta:
  id: hello_world
seq:
  - id: one
    type: u1
```

``` nim
# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild

import ../../runtime/nim/kaitai

type
  HelloWorld* = ref object
    one*: uint8
    root*: HelloWorld
    parent*: ref RootObj

proc read*(_: typedesc[HelloWorld], stream: KaitaiStream, root: HelloWorld, parent: ref RootObj): owned HelloWorld =
  result = new(HelloWorld)
  let root = if root == nil: result else: root
  result.one = readU1(stream)
  result.root = root
  result.parent = parent

proc fromFile*(_: typedesc[HelloWorld], filename: string): owned HelloWorld =
  var stream = newKaitaiStream(filename)
  HelloWorld.read(stream, nil, nil)
```

I think this pattern is flexible and neat:
- The user will be able to create objects of any type (subsections of a format) by simply providing the type and a file path (fromFile()). In this case the object returned will be a root object. For example he will be able to create a Png Chunks object like this: `Chunks.fromFile("path/to/partial/file")`
- read() is mostly for internal use, but it's also exposed to the user in case he needs to do something more involved (for example construct a png from partial png files).