### PR TITLE
GoCompiler: Initialize endianness variable.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -114,6 +114,15 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         out.puts(s"${privateMemberName(IoIdentifier)} = io")
         out.puts(s"${privateMemberName(ParentIdentifier)} = parent")
         out.puts(s"${privateMemberName(RootIdentifier)} = root")
+        typeProvider.nowClass.meta.endian match {
+          case Some(_: CalcEndian) =>
+            out.puts(s"${privateMemberName(EndianIdentifier)} = -1")
+          case Some(InheritedEndian) =>
+            out.puts(s"${privateMemberName(EndianIdentifier)} = " +
+              s"${privateMemberName(ParentIdentifier)}." +
+              s"${idToStr(EndianIdentifier)}")
+          case _ =>
+        }
         out.puts
       case Some(e) =>
         out.puts


### PR DESCRIPTION
This is in preparation for adding 3 new tests:

- `default_endian_expr_inherited_test.go`
- `default_endian_expr_is_be_test.go`
- `default_endian_expr_is_le_test.go`

This PR fixes two issues:
- Calculated endian defaulting to big endian when it should return an error.
- Inherited endian not working.

Summary (with new tests included): `SUMMARY: {"kst"=>85, "passed"=>79, "failed"=>14}`