### PR TITLE
Go: Support padding and termination on bytes.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -413,6 +413,11 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
     ResultLocalVar(v1)
   }
 
+  def outTransform(id: ResultLocalVar, expr: String): ResultLocalVar = {
+    out.puts(s"${resToStr(id)} = $expr")
+    id
+  }
+
   private
   var localVarNum = 0
 


### PR DESCRIPTION
This PR depends on https://github.com/kaitai-io/kaitai_struct_go_runtime/pull/18.

Mostly straight-forward; however, we do need to do a bit of mucking around because of the fact that the read functions in Go return multiple values. To work around this, a new function `translator.outTransform` is added to make it easier to apply additional transformations on an expression that is read.

This does not impact what structs will successfully compile; the same structs should compile as they did before. It just fixes the incorrect behavior (currently, padding and termination is ignored. This happens because `parseExprBytes` ended in `expr`, throwing away the generated expression, presumably because of the multiple value problem.)

This PR depends on the implementations of the pad/term utility functions, which are currently missing. They are implemented in https://github.com/kaitai-io/kaitai_struct_go_runtime/pull/18.

Before:
```
SUMMARY: {"kst"=>95, "passed"=>85, "failed"=>18}
```

After:
```
SUMMARY: {"kst"=>95, "passed"=>88, "failed"=>15}
```