### PR TITLE
Fix npm publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-buildimport java.io.File
+import java.io.File
 import java.nio.charset.Charset
 import java.nio.file.Files
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import java.io.File
+buildimport java.io.File
 import java.nio.charset.Charset
 import java.nio.file.Files
 
@@ -235,7 +235,7 @@ lazy val buildNpmPackageTask = Def.task {
   val packageJsonTmpl = IO.read(new File("js/package.json"), UTF8)
   val packageJsonContents = packageJsonTmpl.replaceFirst(
     "\"version\": \".*?\"",
-    "\"version\": \"" + version.value + "\""
+    "\"version\": \"" + version.value.replace("-SNAPSHOT", ".0-SNAPHSOT") + "\""
   )
 
   IO.write(packageJsonFile, packageJsonContents, UTF8)

--- a/publish_js_to_npm.sh
+++ b/publish_js_to_npm.sh
@@ -6,5 +6,5 @@
 
 cd js/npm
 echo "//registry.npmjs.org/:_authToken=$NPM_API_KEY" >$HOME/.npmrc
-npm publish --tag next
+npm publish --tag next || exit 1
 rm ~/.npmrc


### PR DESCRIPTION
Currently no new versions are published to npm because npm versions must follow semver and Travis didn't catch the error. This pull request fixes both these issues.