### PR TITLE
Fix repetitions in 'serialization', add repeat-until last element check

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -106,6 +106,8 @@ object Ast {
     case class Subscript(value: expr, idx: expr) extends expr
     case class Name(id: identifier) extends expr
     case class List(elts: Seq[expr]) extends expr
+
+    case class CodeLiteral(code: String) extends expr
   }
 
   sealed trait boolop

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -9,7 +9,7 @@ import io.kaitai.struct.format._
 import io.kaitai.struct.languages.components._
 import io.kaitai.struct.translators.{CSharpTranslator, TypeDetector}
 
-class CSharpCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
+class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   extends LanguageCompiler(typeProvider, config)
     with UpperCamelCaseClasses
     with ObjectOrientedLanguage

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -11,7 +11,7 @@ import io.kaitai.struct.languages.components._
 import io.kaitai.struct.translators.{CppTranslator, TypeDetector}
 
 class CppCompiler(
-  val typeProvider: ClassTypeProvider,
+  typeProvider: ClassTypeProvider,
   config: RuntimeConfig
 ) extends LanguageCompiler(typeProvider, config)
     with ObjectOrientedLanguage

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -9,7 +9,7 @@ import io.kaitai.struct.languages.components._
 import io.kaitai.struct.translators.JavaScriptTranslator
 import io.kaitai.struct.{ClassTypeProvider, RuntimeConfig, Utils}
 
-class JavaScriptCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
+class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   extends LanguageCompiler(typeProvider, config)
     with ObjectOrientedLanguage
     with UpperCamelCaseClasses

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -9,7 +9,7 @@ import io.kaitai.struct.{ClassTypeProvider, RuntimeConfig}
 import scala.collection.mutable.ListBuffer
 
 abstract class LanguageCompiler(
-  typeProvider: ClassTypeProvider,
+  val typeProvider: ClassTypeProvider,
   val config: RuntimeConfig
 ) extends SwitchOps with ValidateOps
   with ExtraAttrs {
@@ -119,6 +119,9 @@ abstract class LanguageCompiler(
 
   def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: Ast.expr): Unit
   def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: Ast.expr): Unit
+
+  def condRepeatCommonHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean): Unit = {}
+  def condRepeatCommonFooter: Unit = {}
 
   def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/UniversalFooter.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/UniversalFooter.scala
@@ -20,7 +20,7 @@ trait UniversalFooter extends LanguageCompiler {
   override def checkFooter: Unit = universalFooter
   def condRepeatExprFooter = universalFooter
   def condRepeatEosFooter: Unit = universalFooter
-  def condRepeatEosFooter2: Unit = universalFooter
+  override def condRepeatCommonFooter: Unit = universalFooter
   def condIfFooter(expr: expr): Unit = universalFooter
   def instanceFooter: Unit = universalFooter
 }

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -141,6 +141,8 @@ abstract class BaseTranslator(val provider: TypeProvider)
         doByteSizeOfType(typeName)
       case Ast.expr.BitSizeOfType(typeName) =>
         doBitSizeOfType(typeName)
+      case Ast.expr.CodeLiteral(code) =>
+        code
     }
   }
 


### PR DESCRIPTION
See https://github.com/kaitai-io/kaitai_struct/issues/27

I realized that we don't need **special loops** for each repetition type, because in case of writing, we iterate some array of known size and write them consecutively in the order they appear in the array, so deriving the number of repetitions (repeat-expr) or checking a condition for each element (repeat-until) isn't necessary.

I added a check if the last value of array satisfies the condition of **repeat-until** to ensure format consistency.