### PR TITLE
Stop generating empty constructor when autoRead

### DIFF
--- a/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala
@@ -58,7 +58,7 @@ object JavaMain {
       }
 
       opt[Unit]('w', "read-write")  action { (x, c) =>
-        c.copy(runtime = c.runtime.copy(readWrite = true))
+        c.copy(runtime = c.runtime.copy(readWrite = true, autoRead = false))
       } text("generate read-write support in classes (default: read-only)")
 
       opt[File]('d', "outdir") valueName("<directory>") action { (x, c) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -136,7 +136,7 @@ class JavaCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
       val paramsRelay = Utils.join(params.map((p) => paramName(p.id)), ", ", ", ", "")
 
-      if (config.readWrite) {
+      if (config.readWrite && !config.autoRead) {// when autoRead is true, it doesn't make sense to generate this constructor because there would be no _io to read from
         out.puts(s"public ${type2class(name)}(${paramsArg.stripPrefix(", ")}) {")
         out.inc
         out.puts(s"this(null, null, null$paramsRelay);")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -136,7 +136,7 @@ class JavaCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
       val paramsRelay = Utils.join(params.map((p) => paramName(p.id)), ", ", ", ", "")
 
-      if (config.readWrite && !config.autoRead) {// when autoRead is true, it doesn't make sense to generate this constructor because there would be no _io to read from
+      if (config.readWrite) {
         out.puts(s"public ${type2class(name)}(${paramsArg.stripPrefix(", ")}) {")
         out.inc
         out.puts(s"this(null, null, null$paramsRelay);")


### PR DESCRIPTION
If someone would compile KSY format with --read-write option only (without --no-auto-read), instancing any user-generated class with empty parameter list would immediately fail with an exception (because autoRead is enabled, but there is no _io to read from).