### PR TITLE
Fix writing enums in repetitions

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -106,6 +106,8 @@ object Ast {
     case class Subscript(value: expr, idx: expr) extends expr
     case class Name(id: identifier) extends expr
     case class List(elts: Seq[expr]) extends expr
+
+    case class CodeLiteral(code: String) extends expr
   }
 
   sealed trait boolop

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryWriteIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryWriteIsExpression.scala
@@ -59,7 +59,7 @@ trait EveryWriteIsExpression extends LanguageCompiler with ObjectOrientedLanguag
       case t: StrFromBytesType =>
         attrStrTypeWrite(id, t, io, rep, isRaw)
       case t: EnumType =>
-        val expr = translator.enumToInt(Ast.expr.Name(Ast.identifier(idToStr(id))), t)
+        val expr = translator.enumToInt(Ast.expr.CodeLiteral(writeExprAsString(id, rep, isRaw)), t)
         val exprType = internalEnumIntType(t.basedOn)
         attrPrimitiveWrite(io, expr, t.basedOn, defEndian, Some(exprType))
       case _ =>
@@ -76,19 +76,6 @@ trait EveryWriteIsExpression extends LanguageCompiler with ObjectOrientedLanguag
       case _ =>
         translator.arraySubscript(
           Ast.expr.Name(Ast.identifier(idToStr(id))),
-          Ast.expr.Name(Ast.identifier(Identifier.INDEX))
-        )
-    }
-  }
-
-  def writeExprAsExpr(id: Identifier, rep: RepeatSpec, isRaw: Boolean): Ast.expr = {
-    val astId = Ast.expr.Name(Ast.identifier(idToStr(id)))
-    rep match {
-      case NoRepeat =>
-        astId
-      case _ =>
-        Ast.expr.Subscript(
-          astId,
           Ast.expr.Name(Ast.identifier(Identifier.INDEX))
         )
     }
@@ -123,7 +110,7 @@ trait EveryWriteIsExpression extends LanguageCompiler with ObjectOrientedLanguag
   }
 
   def attrStrTypeWrite(id: Identifier, t: StrFromBytesType, io: String, rep: RepeatSpec, isRaw: Boolean) = {
-    val expr = translator.strToBytes(writeExprAsExpr(id, rep, isRaw), Ast.expr.Str(t.encoding))
+    val expr = translator.strToBytes(Ast.expr.CodeLiteral(writeExprAsString(id, rep, isRaw)), Ast.expr.Str(t.encoding))
     attrPrimitiveWrite(io, expr, t.bytes, None)
 
     t.bytes match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -141,6 +141,8 @@ abstract class BaseTranslator(val provider: TypeProvider)
         doByteSizeOfType(typeName)
       case Ast.expr.BitSizeOfType(typeName) =>
         doBitSizeOfType(typeName)
+      case Ast.expr.CodeLiteral(code) =>
+        code
     }
   }
 


### PR DESCRIPTION
When you want to write enum value, you need to call method `translator.enumToInt`, which expects its arguments of type `Ast.expr`.

So we need a way to convert `Identifier` to `Ast.expr.Name`. I thought that method Identifier.toAstIdentifier would serve this purpose, but it doesn't work and I don't know how it was supposed to work. Anyway, the conversion had been done as `Ast.expr.Name(Ast.identifier(idToStr(id)))`. However, this simple conversion is wrong. The `Identifier` is language-agnostic object, but `idToStr(id)` converts it to language-dependent name.

So when you try to call
```scala
translator.translate(
  Ast.expr.Subscript(
    Ast.expr.Name(Ast.identifier(idToStr(id))),
    Ast.expr.Name(Ast.identifier(Identifier.INDEX))
  )
)
```
with `id = NamedIdentifier('some_array')`, `idToStr(id)` will return `'someArray'` for Java, and the execution will fail when detecting type of the container you try to subscript, because there is no field with name 'someArray' (actualy, the `ClassTypeProvider.determineType` method internally creates `NamedIdentifier(attrName)`, so it fails on constraint `^[a-z][a-z0-9_]*$`).

Hence I felt the need to inject language-specific code to AST object, so I created class `Ast.expr.CodeLiteral(code)` for this purpose. The BaseTranslator for it just returns the `code` itself. In the future, we may need also specify the DataType of the code literal, so that detecting type on it doesn't fail, but I haven't needed it yet.