### PR TITLE
Use common loop for all repetitions

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryWriteIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryWriteIsExpression.scala
@@ -17,17 +17,17 @@ trait EveryWriteIsExpression extends LanguageCompiler with ObjectOrientedLanguag
 
     attr.cond.repeat match {
       case RepeatEos =>
-        condRepeatEosHeader2(id, io, attr.dataType, needRaww(attr.dataType))
+        condRepeatCommonHeader(id, io, attr.dataType, needRaww(attr.dataType))
         attrWrite2(id, attr.dataType, io, attr.cond.repeat, false, defEndian)
-        condRepeatEosFooter2
+        condRepeatCommonFooter
       case RepeatExpr(repeatExpr: Ast.expr) =>
-        condRepeatExprHeader2(id, io, attr.dataType, needRaww(attr.dataType), repeatExpr)
+        condRepeatCommonHeader(id, io, attr.dataType, needRaww(attr.dataType))
         attrWrite2(id, attr.dataType, io, attr.cond.repeat, false, defEndian)
-        condRepeatExprFooter
+        condRepeatCommonFooter
       case RepeatUntil(untilExpr: Ast.expr) =>
-        condRepeatUntilHeader(id, io, attr.dataType, needRaww(attr.dataType), untilExpr)
+        condRepeatCommonHeader(id, io, attr.dataType, needRaww(attr.dataType))
         attrWrite2(id, attr.dataType, io, attr.cond.repeat, false, defEndian)
-        condRepeatUntilFooter(id, io, attr.dataType, needRaww(attr.dataType), untilExpr)
+        condRepeatCommonFooter
       case NoRepeat =>
         attrWrite2(id, attr.dataType, io, attr.cond.repeat, false, defEndian)
     }
@@ -267,8 +267,4 @@ trait EveryWriteIsExpression extends LanguageCompiler with ObjectOrientedLanguag
       case _ => false
     }
   }
-
-  def condRepeatEosHeader2(id: Identifier, io: String, dataType: DataType, needRaw: Boolean): Unit
-  def condRepeatEosFooter2: Unit
-  def condRepeatExprHeader2(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: Ast.expr): Unit
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
@@ -12,18 +12,18 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression with Eve
 
     attr.cond.repeat match {
       case RepeatEos =>
-        condRepeatEosHeader2(id, io, attr.dataType, needRaw(attr.dataType))
+        condRepeatCommonHeader(id, io, attr.dataType, needRaw(attr.dataType))
         attrCheck2(id, attr.dataType, io, attr.cond.repeat, false)
-        condRepeatEosFooter2
+        condRepeatCommonFooter
       case RepeatExpr(repeatExpr: Ast.expr) =>
         attrArraySizeCheck(id, repeatExpr)
-        condRepeatExprHeader2(id, io, attr.dataType, needRaw(attr.dataType), repeatExpr)
+        condRepeatCommonHeader(id, io, attr.dataType, needRaw(attr.dataType))
         attrCheck2(id, attr.dataType, io, attr.cond.repeat, false)
-        condRepeatExprFooter
+        condRepeatCommonFooter
       case RepeatUntil(untilExpr: Ast.expr) =>
-        condRepeatUntilHeader(id, io, attr.dataType, needRaw(attr.dataType), untilExpr)
+        condRepeatCommonHeader(id, io, attr.dataType, needRaw(attr.dataType))
         attrCheck2(id, attr.dataType, io, attr.cond.repeat, false)
-        condRepeatUntilFooter(id, io, attr.dataType, needRaww(attr.dataType), untilExpr)
+        condRepeatCommonFooter
       case NoRepeat =>
         attrCheck2(id, attr.dataType, io, attr.cond.repeat, false)
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -120,6 +120,9 @@ abstract class LanguageCompiler(
   def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: Ast.expr): Unit
   def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: Boolean, repeatExpr: Ast.expr): Unit
 
+  def condRepeatCommonHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean): Unit = {}
+  def condRepeatCommonFooter: Unit = {}
+
   def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier): Unit
 
   def normalIO: String

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/UniversalFooter.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/UniversalFooter.scala
@@ -20,7 +20,7 @@ trait UniversalFooter extends LanguageCompiler {
   override def checkFooter: Unit = universalFooter
   def condRepeatExprFooter = universalFooter
   def condRepeatEosFooter: Unit = universalFooter
-  def condRepeatEosFooter2: Unit = universalFooter
+  override def condRepeatCommonFooter: Unit = universalFooter
   def condIfFooter(expr: expr): Unit = universalFooter
   def instanceFooter: Unit = universalFooter
 }


### PR DESCRIPTION
I realized that we don't need **special loops** for each repetition type, because in case of writing, we iterate some array of known size and write them consecutively in the order they appear in the array, so deriving the number of repetitions (repeat-expr) or checking a condition for each element (repeat-until) isn't necessary.