### PR TITLE
Add repeat-until last element check

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
@@ -115,7 +115,7 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression with Eve
         }
         blt.padRight.foreach { (padByte) =>
           if (blt.terminator.map(term => padByte != term).getOrElse(true)) {
-            val lastByte = exprByteArrayLastByte(bytes)
+            val lastByte = exprByteArrayLast(bytes)
             attrBasicCheck(
               Ast.expr.BoolOp(
                 Ast.boolop.And,
@@ -177,7 +177,7 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression with Eve
       Ast.identifier("size")
     )
 
-  def exprByteArrayLastByte(name: Ast.expr) =
+  def exprByteArrayLast(name: Ast.expr) =
     Ast.expr.Attribute(
       name,
       Ast.identifier("last")
@@ -194,17 +194,14 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression with Eve
 
   def exprArraySize(name: Ast.expr) = exprByteArraySize(name)
 
+  def exprArrayLast(name: Ast.expr) = exprByteArrayLast(name)
+
   def attrAssertUntilCond(name: Ast.expr, dataType: DataType, untilExpr: Ast.expr, msg: String): Unit = {
     blockScopeHeader
     handleAssignmentTempVar(
       dataType,
       translator.doName(Identifier.ITERATOR),
-      translator.translate(
-        Ast.expr.Attribute(
-          name,
-          Ast.identifier("last")
-        )
-      )
+      translator.translate(exprArrayLast(name))
     )
     typeProvider._currentIteratorType = Some(dataType)
     attrBasicCheck(


### PR DESCRIPTION
I need to access `typeProvider` property of LanguageCompiler from trait GenericChecks, so I made it public with `val`.

I reuse ConsistencyError for throwing if the last element of array doesn't satisfy repeat-until condition, but I'm not sure what should be present in the error message. Maybe it should throw a special type of Exception deriving from ConsistencyError, but I don't know.

I also add methods `blockScopeHeader` and `blockScopeFooter`, because in case there are multiple seq fields with repeat-until, I need to redeclare `_it` variable, every time with a different type. Java doesn't allow redeclaring variables in the same scope, so I wrap each check in its own.

For example, these are the generated repeat-until checks in the test format repeat_until_complex:
```java
        {
            TypeU1 _it = first().get(first().size() - 1);
            if (!(_it.count() == 0))
                throw new ConsistencyError("first", "UserTypeInstream(List(type_u1),None,List())", "_it.count() == 0");
        }
        {
            TypeU2 _it = second().get(second().size() - 1);
            if (!(_it.count() == 0))
                throw new ConsistencyError("second", "UserTypeInstream(List(type_u2),None,List())", "_it.count() == 0");
        }
        {
            int _it = third().get(third().size() - 1);
            if (!(_it == 0))
                throw new ConsistencyError("third", "Int1Type(false)", "_it == 0");
        }
```