### PR TITLE
Fix enum generation for values with id bigger than Int.MAX_VALUE

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -661,12 +661,12 @@ class JavaCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
     if (enumColl.size > 1) {
       enumColl.dropRight(1).foreach { case (id, label) =>
-        out.puts(s"${value2Const(label)}($id),")
+        out.puts(s"${value2Const(label)}(${long2str(id)}),")
       }
     }
     enumColl.last match {
       case (id, label) =>
-        out.puts(s"${value2Const(label)}($id);")
+        out.puts(s"${value2Const(label)}(${long2str(id)});")
     }
 
     out.puts
@@ -696,6 +696,14 @@ class JavaCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   def value2Const(s: String) = s.toUpperCase
+
+  def long2str(l: Long): String = {
+    if (l.isValidInt) {
+      l.toString()
+    } else {
+      l.toString() + "L"
+    }
+  }
 
   def idToStr(id: Identifier): String = {
     id match {


### PR DESCRIPTION
This fix allow to compile Java-classes with enum with `id` which value is bigger than `Int.MAX_VALUE`.

This PR is inspired by https://github.com/valery1707/kaitai-gradle-plugin/issues/17.

If `*.ksy` has code with something like
```
enums:
  profile_ids:
    0x00000003: defaults                # Known default value is used.
    0xFFFFFFFF: not_found               # Value not found.
```

in generated Java-class will be generated something like
```java
public enum PROFILE_IDS {
  DEFAULTS(3),
  NOT_FOUND(4294967295);

  private final long id;

  PROFILE_IDS(long id) {
    this.id = id;
  }
}
```

But in this case argument will be interpreted as `Int`, and value `4294967295` is not valid for integer range and on compilation user receive error `integer number too large`.
With this fix ids for enums will be generated in valid long-safe mode:
```java
public enum PROFILE_IDS {
  DEFAULTS(3),
  NOT_FOUND(4294967295L);

  private final long id;

  PROFILE_IDS(long id) {
    this.id = id;
  }
}
```

P.S.
Is this project has some test of generation results?