### PR TITLE
Fix byte array operations in Python

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -101,8 +101,21 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList) extends B
   }
   override def bytesToStr(bytesExpr: String, encoding: Ast.expr): String =
     s"($bytesExpr).decode(${translate(encoding)})"
+
   override def bytesLength(value: Ast.expr): String =
     s"len(${translate(value)})"
+  override def bytesSubscript(container: Ast.expr, idx: Ast.expr): String =
+    s"${PythonCompiler.kstreamName}.byte_array_index(${translate(container)}, ${translate(idx)})"
+  override def bytesFirst(a: Ast.expr): String =
+    bytesSubscript(a, Ast.expr.IntNum(0))
+  override def bytesLast(a: Ast.expr): String =
+    bytesSubscript(a, Ast.expr.IntNum(-1))
+  override def bytesMin(b: Ast.expr): String =
+    s"${PythonCompiler.kstreamName}.byte_array_min(${translate(b)})"
+  override def bytesMax(b: Ast.expr): String =
+    s"${PythonCompiler.kstreamName}.byte_array_max(${translate(b)})"
+
+
   override def strLength(value: Ast.expr): String =
     s"len(${translate(value)})"
   override def strReverse(value: Ast.expr): String =


### PR DESCRIPTION
Solves kaitai-io/kaitai_struct#633 and satisfies test expr_bytes_ops for Python 2
Requires merging https://github.com/kaitai-io/kaitai_struct_python_runtime/pull/37

The behavior of byte array had changed between Python 2 and 3. In Python 2, the byte array is the same as the string, so indexing it yields the character itself, not the numerical value of the byte as in Python 3.
For example this code:
```python
buf = b'data'
print(buf[2])
```
prints `t` in Python 2 and `116` in Python 3.

This means that it's either necessary to generate different code for Python 2 than for Python 3 (and some option `--python-version` for switching), or generate same code but detect the version in runtime library. That's what I do because it makes the generated code portable between the versions.