### PR TITLE
Don't prepend "src" to output dirs of Java and Go.

### DIFF
--- a/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/JavaMain.scala
@@ -294,8 +294,13 @@ class JavaMain(config: CLIConfig) {
   }
 
   def compileAllLangs(specs: ClassSpecs, config: CLIConfig): Map[String, Map[String, SpecEntry]] = {
-    config.targets.map { lang =>
-      lang -> compileOneLang(specs, lang, s"${config.outDir}/$lang")
+    config.targets.map { langStr =>
+      langStr match {
+        case "go" | "java" =>
+          langStr -> compileOneLang(specs, langStr, s"${config.outDir}/${langStr}/src")
+        case _ =>
+          langStr -> compileOneLang(specs, langStr, s"${config.outDir}/${langStr}")
+      }
     }.toMap
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -30,7 +30,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def indent: String = "\t"
   override def outFileName(topClassName: String): String =
-    s"src/${config.goPackage}/$topClassName.go"
+    s"${config.goPackage}/$topClassName.go"
 
   override def outImports(topClass: ClassSpec): String = {
     val imp = importList.toList

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -45,7 +45,7 @@ class JavaCompiler(val typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def indent: String = "    "
   override def outFileName(topClassName: String): String =
-    s"src/${config.java.javaPackage.replace('.', '/')}/${type2class(topClassName)}.java"
+    s"${config.java.javaPackage.replace('.', '/')}/${type2class(topClassName)}.java"
 
   override def outImports(topClass: ClassSpec) =
     "\n" + importList.toList.map((x) => s"import $x;").mkString("\n") + "\n"


### PR DESCRIPTION
Java and Go seem to be the only languages prepending "src" to their output directories, which make them fail in case a Maven-like directory tree with "src/main/java" is used. "java" itself needs to be the source folder already, not "java/src". Additionally, its easy for users to add paths on their own, but difficult to remove those added by KS.

Like has been discussed in the corresponding issue, "src" keeps getting added in case "--target all" is given, which is most likely only the case for tests and those use a dir structure of "java/bin|src", where that makes sense.

This fixes https://github.com/kaitai-io/kaitai_struct/issues/287.