### PR TITLE
Adding GHI #287 to release notes, because it breaks builds.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,11 @@
 * Expression language:
   * New methods:
     * byte arrays: `length`
+* General compilation improvements:
+  * Support Maven-like directory trees by not adding subdir `src` for outputs of Go+Java anymore,
+    see [#287](https://github.com/kaitai-io/kaitai_struct/issues/287). While this breaks existing
+    builds most likely, it puts those languages in line with all others and adding subdirs is easier
+    for the user than removing some added by Kaitai automatically.
 
 # 0.8 (2018-02-05)
 


### PR DESCRIPTION
I've forgot about that in #193 and feel free to change wording of course. It just [shouldn't be missed](https://github.com/kaitai-io/kaitai_struct_compiler/pull/147#issuecomment-432764193) entirely.