### PR TITLE
Fix typo

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -262,7 +262,7 @@ class JavaScriptCompiler(val typeProvider: ClassTypeProvider, config: RuntimeCon
 
     val ioProps = io match {
       case None => ""
-      case Some(x) => s"start: $x.pos, ioOffset: $x._byteOffset"
+      case Some(x) => s"start: $x.pos, ioOffset: $x.byteOffset"
     }
 
     val enumNameProps = attrType match {


### PR DESCRIPTION
This changes the debug `ioOffset` from `KaitaiStream._byteOffset` (which is an implementation detail) to `KaitaiStream.byteOffset`. It's the same value (see [KaitaiStream.js#L85](https://github.com/kaitai-io/kaitai_struct_javascript_runtime/blob/7ea115fd84da0a459cde97d4cadd59a56d3df6c8/KaitaiStream.js#L85)) but with this change none of the underscore prefixed "internal" properties are used in the compiler. This makes writing other JS runtimes easier.