### PR TITLE
Simplify generation of fully-qualified class names in Python

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -534,12 +534,5 @@ object PythonCompiler extends LanguageCompilerStatic
     case _ => s"kaitaistruct.${err.name}"
   }
 
-  def types2class(name: List[String]): String = {
-    if (name.size > 1) {
-      val path = name.drop(1).map(x => type2class(x)).mkString(".")
-      s"self._root.$path"
-    } else {
-      type2class(name.head)
-    }
-  }
+  def types2class(name: List[String]): String = name.map(x => type2class(x)).mkString(".")
 }


### PR DESCRIPTION
The generated names now look like `TopLevelType.MiddleType.NestedType` rather than `self._root.MiddleType.NestedType`.

It's not clear what the special case with `self._root` was meant to do. According to some old commit messages, it fixed some tests involving nested types, but these tests still pass without the special case.

This simplification has multiple advantages. Normal qualified class names (rather than strange `self._root` hacks) are more readable to humans and more understandable by IDEs and other tools. It also removes many unnecessary references to `self._root`, which allows parsing starting with a non-top-level type, e. g.:

```python
struct = TopLevelType.MiddleType.NestedType.from_io(stream)
```

With the old class name generation, this did not work, because the generated code expected that `_root` would always be an instance of the top-level type and not of a nested type.

(I discussed this issue on Gitter a few days ago: https://gitter.im/kaitai_struct/Lobby?at=5e64d8618011bb652afdc030)