### PR TITLE
Fix invocation of nested types with parameters

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -294,7 +294,7 @@ object DataType {
   private val ReIntType = """([us])(2|4|8)(le|be)?""".r
   private val ReFloatType = """f(4|8)(le|be)?""".r
   private val ReBitType = """b(\d+)""".r
-  private val ReUserTypeWithArgs = """^([a-z][a-z0-9_]*)\((.*)\)$""".r
+  private val ReUserTypeWithArgs = """^((?:[a-z][a-z0-9_]*(?:::)?)+)\((.*)\)$""".r
 
   def fromYaml(
     dto: Option[String],


### PR DESCRIPTION
Closes kaitai-io/kaitai_struct#724

done by changing the `ReUserTypeWithArgs` regex from `^([a-z][a-z0-9_]*)\((.*)\)$` to `^((?:[a-z][a-z0-9_]*(?:::)?)+)\((.*)\)$`

for a visual representation of what this regex does, see here:
https://regex101.com/r/3VY3DV/1