### PR TITLE
Replace octal constants with unicode constants.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Lexical.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Lexical.scala
@@ -46,17 +46,17 @@ object Lexical {
   val escapeseq = P( "\\" ~/ (quotedchar | quotedoctal | quotedhex) )
 
   val QUOTED_CC = Map(
-    "a" -> "\7",  // bell, ASCII code 7
-    "b" -> "\b",  // backspace, ASCII code 8
-    "t" -> "\t",  // horizontal tab, ASCII code 9
-    "n" -> "\n",  // newline, ASCII code 10
-    "v" -> "\13", // vertical tab, ASCII code 11 = 0o13
-    "f" -> "\14", // form feed, ASCII code 12 = 0o14
-    "r" -> "\r",  // carriage return, ASCII code 13
-    "e" -> "\33", // escape, ASCII code 27 = 0o33
-    "'" -> "'",   // single quote
-    "\"" -> "\"", // double quote
-    "\\" -> "\\"  // backslash
+    "a" -> "\u0007", // bell, ASCII code 7
+    "b" -> "\b",     // backspace, ASCII code 8
+    "t" -> "\t",     // horizontal tab, ASCII code 9
+    "n" -> "\n",     // newline, ASCII code 10
+    "v" -> "\u000b", // vertical tab, ASCII code 11 = 0o13
+    "f" -> "\u000c", // form feed, ASCII code 12 = 0o14
+    "r" -> "\r",     // carriage return, ASCII code 13
+    "e" -> "\u001b", // escape, ASCII code 27 = 0o33
+    "'" -> "'",      // single quote
+    "\"" -> "\"",    // double quote
+    "\\" -> "\\"     // backslash
   )
   val VALID_QUOTED = QUOTED_CC.keys.toList.sorted.mkString
   val quotedchar = P( CharIn(VALID_QUOTED).! ).map(QUOTED_CC)

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -29,10 +29,10 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
     '"' -> "\\\"",
     '\\' -> "\\\\",
 
-    '\0' -> "\\0",
-    '\7' -> "\\a",
+    '\u0000' -> "\\0",
+    '\u0007' -> "\\a",
     '\f' -> "\\f",
-    '\13' -> "\\v",
+    '\u000b' -> "\\v",
     '\b' -> "\\b"
   )
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -79,7 +79,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     * @return string as C++ string literal
     */
   override def doStringLiteral(s: String): String = {
-    val lenSuffix = if (s.contains("\0")) {
+    val lenSuffix = if (s.contains("\u0000")) {
       ", " + s.getBytes(CHARSET_UTF8).length
     } else {
       ""
@@ -97,9 +97,9 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     '"' -> "\\\"",
     '\\' -> "\\\\",
 
-    '\7' -> "\\a",
+    '\u0007' -> "\\a",
     '\f' -> "\\f",
-    '\13' -> "\\v",
+    '\u000b' -> "\\v",
     '\b' -> "\\b"
   )
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -15,11 +15,11 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
     '"' -> "\\\"",
     '\\' -> "\\\\",
 
-    '\7' -> "\\a",
+    '\u0007' -> "\\a",
     '\b' -> "\\b",
-    '\13' -> "\\v",
+    '\u000b' -> "\\v",
     '\f' -> "\\f",
-    '\33' -> "\\027"
+    '\u001b' -> "\\027"
   )
 
   override def strLiteralUnicode(code: Char): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
@@ -25,8 +25,8 @@ class PHPTranslator(provider: TypeProvider, config: RuntimeConfig) extends BaseT
     '$' -> "\\$",
 
     '\f' -> "\\f",
-    '\13' -> "\\v",
-    '\33' -> "\\e"
+    '\u000b' -> "\\v",
+    '\u001b' -> "\\e"
   )
 
   override def strLiteralUnicode(code: Char): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -21,9 +21,9 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     '@' -> "\\@",
     '%' -> "\\%",
 
-    '\7' -> "\\a",
+    '\u0007' -> "\\a",
     '\f' -> "\\f",
-    '\33' -> "\\e",
+    '\u001b' -> "\\e",
     '\b' -> "\\b"
 
     // \v is available since 5.10, but according to documentation

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -30,9 +30,9 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList) extends B
     '"' -> "\\\"",
     '\\' -> "\\\\",
 
-    '\7' -> "\\a",
+    '\u0007' -> "\\a",
     '\f' -> "\\f",
-    '\13' -> "\\v",
+    '\u000b' -> "\\v",
     '\b' -> "\\b"
   )
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -23,10 +23,10 @@ class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider)
     '\\' -> "\\\\",
 
     '#' -> "\\#",
-    '\7' -> "\\a",
+    '\u0007' -> "\\a",
     '\f' -> "\\f",
-    '\13' -> "\\v",
-    '\33' -> "\\e",
+    '\u000b' -> "\\v",
+    '\u001b' -> "\\e",
     '\b' -> "\\b"
   )
 


### PR DESCRIPTION
Using octal constants is the hard error at least in the Scala 2.13.3