### PR TITLE
Fix generation of the negative long literals

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -10,12 +10,23 @@ import io.kaitai.struct.languages.JavaCompiler
 
 class JavaTranslator(provider: TypeProvider, importList: ImportList) extends BaseTranslator(provider) {
   override def doIntLiteral(n: BigInt): String = {
+    // Java's integer parsing behaves differently depending on whether you use decimal or hex syntax.
+    // With decimal syntax, the parser/compiler rejects any number that cannot be stored in a long
+    // (signed 64-bit integer) without overflow. With hexadecimal syntax, it allows anything that
+    // would fit in an unsigned 64-bit integer. Java's `long` is always signed, so if you use this
+    // trick to enter a number that is too large for a signed 64-bit integer, it will overflow into
+    // negative. But this can still be useful if you don't perform any arithmetic that cares about
+    // the sign (e. g. you pass the value unmodified to something else, or you use only bit operations
+    // or Long's "unsigned" methods).
+    //
+    // Of course, if `n > Long.MaxValue * 2 + 1` we'll still get out of range error
+    // TODO: Convert real big numbers to BigInteger
     val literal = if (n > Long.MaxValue) {
       "0x" + n.toString(16)
     } else {
       n.toString
     }
-    val suffix = if (n > Int.MaxValue) "L" else ""
+    val suffix = if (n < Int.MinValue || n > Int.MaxValue) "L" else ""
 
     s"$literal$suffix"
   }


### PR DESCRIPTION
This change fixes at least the https://github.com/kaitai-io/kaitai_struct_tests/blob/master/formats/enum_long_range_s.ksy test

Also, @GreyCat, what the trick that you have done in the dbda9b765e1c57f8e2e5dcfcf7d33dc7b1e8e48e?
https://github.com/kaitai-io/kaitai_struct_compiler/blob/f19304de3ce0ef6504dcb241e7847aa303684381/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala#L13-L17

I would appreciate if you can drop a comment explaining this to the codebase