### PR TITLE
Publish unit test results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,20 @@ name: test
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 jobs:
-  test:
+  build-and-test:
     runs-on: ubuntu-latest
+    # always run on push events, but only run on pull_request_target event when
+    # pull request pulls from fork repository for pull requests within the same
+    # repository, the pull event is sufficient
+    # See also https://github.com/marketplace/actions/publish-unit-test-results
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target'
+        && github.event.pull_request.head.repo.full_name != github.repository
+
     strategy:
       matrix:
         java: [1.8, 11, 14, 15]
@@ -19,3 +28,29 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Run tests
       run: sbt test
+    - name: Upload Unit Test Results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        # name should be different for each matrix build
+        # See https://github.com/marketplace/actions/upload-a-build-artifact#uploading-to-the-same-artifact
+        name: Unit Test Results (Java ${{ matrix.java-version }})
+        path: target/test_out/
+
+  publish-test-results:
+    name: Publish Unit Tests Results
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    # the build-and-test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.5
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: target/test_out/**/*.xml


### PR DESCRIPTION
This is attempt to show results of test runs in the PRs. I don't know how it will look, because can't test it due to nature of the `pull_request_target` event: it will use workflow file from the base repository (i.e. unmodified from `master` branch). And without `pull_request_target` event PRs `GITHUB_TOKEN`s have no permissions to comment on PRs. So feel free to close this PR if it is unwanted behaviour.

Fixes https://github.com/kaitai-io/kaitai_struct/issues/830