### PR TITLE
Show test results in console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,9 @@ lazy val compiler = crossProject.in(file(".")).
     ),
 
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/test_out"),
+    // o - causes test results to be written back to sbt, which usually displays it on the standard output
+    // Suppress all other notification events except failures so it is easy to see only failures
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oNCXELOPQRM"),
 
     // Universal: add extra files (formats repo) for distribution, removing
     // .git special files and various dirty/backup files that git normally


### PR DESCRIPTION
Another attempt to fix https://github.com/kaitai-io/kaitai_struct/issues/830 (the other one is #218).

Just output test result to the console, but you will also see it when you run `sbt test` locally. I do not think that this is a big problem, on the contrary, it seems like a plus, but I am not a Scala developer and do not know how it will be convenient for Scala developers, and also I did not find how to override the output settings from the command line.

So feel free to close this PR if it is unwanted behavior.