### PR TITLE
Give a more natural names to the Enum-related AST nodes

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/exprlang/ExpressionsSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/exprlang/ExpressionsSpec.scala
@@ -133,12 +133,12 @@ class ExpressionsSpec extends AnyFunSpec {
 
     // Enums
     it("parses port::http") {
-      Expressions.parse("port::http") should be (EnumByLabel(identifier("port"), identifier("http")))
+      Expressions.parse("port::http") should be (EnumVariant(identifier("port"), identifier("http")))
     }
 
     it("parses some_type::port::http") {
       Expressions.parse("some_type::port::http") should be (
-        EnumByLabel(
+        EnumVariant(
           identifier("port"),
           identifier("http"),
           typeId(absolute = false, Seq("some_type"))
@@ -148,7 +148,7 @@ class ExpressionsSpec extends AnyFunSpec {
 
     it("parses parent_type::child_type::port::http") {
       Expressions.parse("parent_type::child_type::port::http") should be (
-        EnumByLabel(
+        EnumVariant(
           identifier("port"),
           identifier("http"),
           typeId(absolute = false, Seq("parent_type", "child_type"))
@@ -158,7 +158,7 @@ class ExpressionsSpec extends AnyFunSpec {
 
     it("parses ::parent_type::child_type::port::http") {
       Expressions.parse("::parent_type::child_type::port::http") should be (
-        EnumByLabel(
+        EnumVariant(
           identifier("port"),
           identifier("http"),
           typeId(absolute = true, Seq("parent_type", "child_type"))
@@ -171,7 +171,7 @@ class ExpressionsSpec extends AnyFunSpec {
         Compare(
           BinOp(
             Attribute(
-              EnumByLabel(identifier("port"),identifier("http")),
+              EnumVariant(identifier("port"),identifier("http")),
               identifier("to_i")
             ),
             Add,

--- a/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
@@ -347,7 +347,7 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
         List()
       case Ast.expr.InterpolatedStr(exprs) =>
         exprs.flatMap(affectedVars).toList
-      case _: Ast.expr.EnumByLabel =>
+      case _: Ast.expr.EnumVariant =>
         List()
       case Ast.expr.EnumById(_, id, _) =>
         affectedVars(id)

--- a/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
@@ -349,8 +349,8 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
         exprs.flatMap(affectedVars).toList
       case _: Ast.expr.EnumVariant =>
         List()
-      case Ast.expr.EnumById(_, id, _) =>
-        affectedVars(id)
+      case Ast.expr.EnumCast(_, value, _) =>
+        affectedVars(value)
       case Ast.expr.Attribute(value, attr) =>
         if (attr.name == Identifier.SIZEOF) {
           val vars = value match {

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -84,7 +84,13 @@ object Ast {
       * KSY file.
       */
     case class EnumVariant(enumName: identifier, variant: identifier, inType: typeId = EmptyTypeId) extends expr
-    case class EnumById(enumName: identifier, id: expr, inType: typeId = EmptyTypeId) extends expr
+    /**
+      * Transformation of the `value` expression into the `enumName` type,
+      * defined in the type `inType`. Unlike other nodes this node never
+      * parsed from the expression language, because at parse time any
+      * identifier can represent an enum and actual resolution performed later
+      */
+    case class EnumCast(enumName: identifier, value: expr, inType: typeId = EmptyTypeId) extends expr
 
     case class Attribute(value: expr, attr: identifier) extends expr
     case class CastToType(value: expr, typeName: typeId) extends expr

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -76,7 +76,14 @@ object Ast {
     case class FloatNum(n: BigDecimal) extends expr
     case class Str(s: String) extends expr
     case class Bool(n: Boolean) extends expr
-    case class EnumByLabel(enumName: identifier, label: identifier, inType: typeId = EmptyTypeId) extends expr
+    /**
+      * Reference to the enum variant `variant` in the enumeration `enumName`,
+      * defined in the type `inType`. In expression language represented as
+      * `enumName::variant` or `<type-path>::enumName::variant` where `<type-path>`
+      * can be an absolute or a relative path to the type, defined in the current
+      * KSY file.
+      */
+    case class EnumVariant(enumName: identifier, variant: identifier, inType: typeId = EmptyTypeId) extends expr
     case class EnumById(enumName: identifier, id: expr, inType: typeId = EmptyTypeId) extends expr
 
     case class Attribute(value: expr, attr: identifier) extends expr

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
@@ -130,7 +130,7 @@ object Expressions {
     "(" ~ test ~ ")" |
     "[" ~ list ~ "]" |
     // "{" ~ dictorsetmaker ~ "}" |
-    enumByName |
+    enumVariant |
     byteSizeOfType |
     bitSizeOfType |
     fstring |
@@ -172,17 +172,18 @@ object Expressions {
 
   def testlist1[$: P]: P[Seq[Ast.expr]] = P( test.rep(1, sep = ",") )
 
-  def enumByName[$: P]: P[Ast.expr.EnumByLabel] = P("::".!.? ~ NAME.rep(2, "::")).map {
+  /** Parses reference to an enumeration variant. */
+  def enumVariant[$: P]: P[Ast.expr.EnumVariant] = P("::".!.? ~ NAME.rep(2, "::")).map {
     case (first, names: Seq[Ast.identifier]) =>
       val isAbsolute = first.nonEmpty
-      val (enumName, enumLabel) = names.takeRight(2) match {
+      val (enumName, variant) = names.takeRight(2) match {
         case Seq(a, b) => (a, b)
       }
       val typePath = names.dropRight(2)
       if (typePath.isEmpty) {
-        Ast.expr.EnumByLabel(enumName, enumLabel, Ast.EmptyTypeId)
+        Ast.expr.EnumVariant(enumName, variant, Ast.EmptyTypeId)
       } else {
-        Ast.expr.EnumByLabel(enumName, enumLabel, Ast.typeId(isAbsolute, typePath.map(_.name)))
+        Ast.expr.EnumVariant(enumName, variant, Ast.typeId(isAbsolute, typePath.map(_.name)))
       }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/format/InstanceSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/InstanceSpec.scala
@@ -56,12 +56,12 @@ object InstanceSpec {
         // value instance
         ParseUtils.ensureLegalKeys(srcMap, LEGAL_KEYS_VALUE_INST, path, Some("value instance"))
 
-        // Wrap everything in EnumById if "enum" is used
+        // Wrap everything in EnumCast if "enum" is used
         val value2 = ParseUtils.getOptValueStr(srcMap, "enum", path) match {
           case None =>
             value
           case Some(enumName) =>
-            Ast.expr.EnumById(Ast.identifier(enumName), value)
+            Ast.expr.EnumCast(Ast.identifier(enumName), value)
         }
 
         val ifExpr = ParseUtils.getOptValueExpression(srcMap, "if", path)

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -814,10 +814,10 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     // Java is very specific about what can be used as "condition" in "case
     // condition:".
     val condStr = condition match {
-      case enumByLabel: Ast.expr.EnumByLabel =>
+      case variant: Ast.expr.EnumVariant =>
         // If switch is over a enum, only literal enum values are supported,
         // and they must be written as "MEMBER", not "SomeEnum.MEMBER".
-        value2Const(enumByLabel.label.name)
+        value2Const(variant.variant.name)
       case _ =>
         expression(condition)
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/EveryReadIsExpression.scala
@@ -51,7 +51,7 @@ trait EveryReadIsExpression
         val expr = translator.bytesToStr(parseExprBytes(t.bytes, io), t.encoding)
         handleAssignment(id, expr, rep, isRaw, dataType, assignType)
       case t: EnumType =>
-        val expr = translator.doEnumById(t.enumSpec.get, parseExpr(t.basedOn, io, defEndian))
+        val expr = translator.doEnumCast(t.enumSpec.get, parseExpr(t.basedOn, io, defEndian))
         handleAssignment(id, expr, rep, isRaw, dataType, assignType)
       case _ =>
         val expr = parseExpr(dataType, io, defEndian)

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
@@ -68,7 +68,7 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression {
       case _: Ast.expr.Bool => false
       case Ast.expr.EnumById(_, id, _) =>
         userExprDependsOnIo(id)
-      case _: Ast.expr.EnumByLabel => false
+      case _: Ast.expr.EnumVariant => false
       case n: Ast.expr.Name =>
         val t = getArrayItemType(translator.detectType(n))
         if (t == KaitaiStreamType || t == OwnedKaitaiStreamType) {

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
@@ -66,8 +66,8 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression {
       case Ast.expr.InterpolatedStr(values: Seq[Ast.expr]) =>
         values.exists(v => userExprDependsOnIo(v))
       case _: Ast.expr.Bool => false
-      case Ast.expr.EnumById(_, id, _) =>
-        userExprDependsOnIo(id)
+      case Ast.expr.EnumCast(_, value, _) =>
+        userExprDependsOnIo(value)
       case _: Ast.expr.EnumVariant => false
       case n: Ast.expr.Name =>
         val t = getArrayItemType(translator.detectType(n))

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GoReads.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GoReads.scala
@@ -77,7 +77,7 @@ trait GoReads extends CommonReads with ObjectOrientedLanguage with GoSwitchOps {
       case t: EnumType =>
         val r1 = translator.outVarCheckRes(parseExpr(t.basedOn, io, defEndian))
         val enumSpec = t.enumSpec.get
-        val expr = translator.trEnumById(enumSpec.name, translator.resToStr(r1))
+        val expr = translator.trEnumCast(enumSpec.name, translator.resToStr(r1))
         handleAssignment(id, expr, rep, isRaw)
       case _: BitsType1 =>
         val expr = parseExpr(dataType, io, defEndian)

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -63,9 +63,9 @@ abstract class BaseTranslator(val provider: TypeProvider)
         doInterpolatedStringLiteral(s)
       case Ast.expr.Bool(n) =>
         doBoolLiteral(n)
-      case Ast.expr.EnumById(enumType, id, inType) =>
+      case Ast.expr.EnumCast(enumType, value, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
-        doEnumById(enumSpec, translate(id))
+        doEnumCast(enumSpec, translate(value))
       case Ast.expr.EnumVariant(enumType, variant, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
         doEnumVariant(enumSpec, variant.name)
@@ -199,7 +199,15 @@ abstract class BaseTranslator(val provider: TypeProvider)
     * @return String in the target language with reference to the enum variant
     */
   def doEnumVariant(enumSpec: EnumSpec, variant: String): String
-  def doEnumById(enumSpec: EnumSpec, id: String): String
+  /**
+    * Translates cast of expression to the enumeration type.
+    *
+    * @param enumSpec An enum definition
+    * @param value Translated expression which should have enum type
+    *
+    * @return String in the target language that transforms of the expression result into the enumeration type
+    */
+  def doEnumCast(enumSpec: EnumSpec, value: String): String
 
   // Predefined methods of various types
   def strConcat(left: Ast.expr, right: Ast.expr, extPrec: Int) =

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -66,9 +66,9 @@ abstract class BaseTranslator(val provider: TypeProvider)
       case Ast.expr.EnumById(enumType, id, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
         doEnumById(enumSpec, translate(id))
-      case Ast.expr.EnumByLabel(enumType, label, inType) =>
+      case Ast.expr.EnumVariant(enumType, variant, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
-        doEnumByLabel(enumSpec, label.name)
+        doEnumVariant(enumSpec, variant.name)
       case Ast.expr.Name(name: Ast.identifier) =>
         if (name.name == Identifier.SIZEOF) {
           byteSizeOfClassSpec(provider.nowClass)
@@ -190,7 +190,15 @@ abstract class BaseTranslator(val provider: TypeProvider)
   def kaitaiStructField(value: Ast.expr, name: String): String =
     anyField(value, name)
 
-  def doEnumByLabel(enumSpec: EnumSpec, label: String): String
+  /**
+    * Translates reference to the enum variant into target language
+    *
+    * @param enumSpec An enum definition
+    * @param variant Enum variant
+    *
+    * @return String in the target language with reference to the enum variant
+    */
+  def doEnumVariant(enumSpec: EnumSpec, variant: String): String
   def doEnumById(enumSpec: EnumSpec, id: String): String
 
   // Predefined methods of various types

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -77,8 +77,8 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
   override def doInternalName(id: Identifier): String =
     CSharpCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String =
-    s"${enumClass(enumSpec.name)}.${Utils.upperCamelCase(label)}"
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
+    s"${enumClass(enumSpec.name)}.${Utils.upperCamelCase(variant)}"
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     s"((${enumClass(enumSpec.name)}) $id)"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -79,8 +79,8 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
 
   override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
     s"${enumClass(enumSpec.name)}.${Utils.upperCamelCase(variant)}"
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
-    s"((${enumClass(enumSpec.name)}) $id)"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
+    s"((${enumClass(enumSpec.name)}) $value)"
 
   def enumClass(enumTypeAbs: List[String]): String = {
     val enumTypeRel = Utils.relClass(enumTypeAbs, provider.nowClass.name)

--- a/shared/src/main/scala/io/kaitai/struct/translators/ConstructTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ConstructTranslator.scala
@@ -23,8 +23,8 @@ class ConstructTranslator(provider: TypeProvider, importList: ImportList) extend
     }
   }
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String =
-    s"'$label'"
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
+    s"'$variant'"
 
   override def kaitaiStreamSize(value: Ast.expr): String =
     s"stream_size(${translate(value)})"

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -161,8 +161,8 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     CppCompiler.types2class(enumSpec.name.dropRight(1)) + "::" +
       Utils.upperUnderscoreCase(enumSpec.name.last + "_" + variant)
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
-    s"static_cast<${CppCompiler.types2class(enumSpec.name)}>($id)"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
+    s"static_cast<${CppCompiler.types2class(enumSpec.name)}>($value)"
 
   override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int) = {
     if (op == Ast.cmpop.Eq || op == Ast.cmpop.NotEq) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -153,13 +153,13 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
   override def doInternalName(id: Identifier): String =
     CppCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = {
     val isExternal = enumSpec.isExternal(provider.nowClass)
     if (isExternal) {
       importListHdr.addLocal(CppCompiler.outFileNameHeader(enumSpec.name.head))
     }
     CppCompiler.types2class(enumSpec.name.dropRight(1)) + "::" +
-      Utils.upperUnderscoreCase(enumSpec.name.last + "_" + label)
+      Utils.upperUnderscoreCase(enumSpec.name.last + "_" + variant)
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     s"static_cast<${CppCompiler.types2class(enumSpec.name)}>($id)"

--- a/shared/src/main/scala/io/kaitai/struct/translators/ExpressionValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ExpressionValidator.scala
@@ -31,9 +31,9 @@ class ExpressionValidator(val provider: TypeProvider)
            _: Ast.expr.FloatNum |
            _: Ast.expr.Str |
            _: Ast.expr.Bool => // all simple literals are good and valid
-      case Ast.expr.EnumById(enumType, id, inType) =>
+      case Ast.expr.EnumCast(enumType, value, inType) =>
         provider.resolveEnum(inType, enumType.name)
-        validate(id)
+        validate(value)
       case Ast.expr.EnumVariant(enumType, variant, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
         if (!enumSpec.map.values.exists(_.name == variant.name)) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/ExpressionValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ExpressionValidator.scala
@@ -34,10 +34,10 @@ class ExpressionValidator(val provider: TypeProvider)
       case Ast.expr.EnumById(enumType, id, inType) =>
         provider.resolveEnum(inType, enumType.name)
         validate(id)
-      case Ast.expr.EnumByLabel(enumType, label, inType) =>
+      case Ast.expr.EnumVariant(enumType, variant, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
-        if (!enumSpec.map.values.exists(_.name == label.name)) {
-          throw new EnumMemberNotFoundError(label.name, enumType.name, enumSpec.path.mkString("/"))
+        if (!enumSpec.map.values.exists(_.name == variant.name)) {
+          throw new EnumMemberNotFoundError(variant.name, enumType.name, enumSpec.path.mkString("/"))
         }
       case Ast.expr.Name(name: Ast.identifier) =>
         if (name.name == Identifier.SIZEOF) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -72,9 +72,9 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
       case Ast.expr.EnumById(enumType, id, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
         trEnumById(enumSpec.name, translate(id))
-      case Ast.expr.EnumByLabel(enumType, label, inType) =>
+      case Ast.expr.EnumVariant(enumType, variant, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
-        trEnumByLabel(enumSpec.name, label.name)
+        trEnumVariant(enumSpec.name, variant.name)
       case Ast.expr.Name(name: Ast.identifier) =>
         if (name.name == Identifier.SIZEOF) {
           byteSizeOfClassSpec(provider.nowClass)
@@ -275,8 +275,8 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
     ResultLocalVar(v1)
   }
 
-  def trEnumByLabel(enumTypeAbs: List[String], label: String) =
-    ResultString(GoCompiler.enumToStr(enumTypeAbs, label))
+  def trEnumVariant(enumTypeAbs: List[String], variant: String) =
+    ResultString(GoCompiler.enumToStr(enumTypeAbs, variant))
   def trEnumById(enumTypeAbs: List[String], id: String) =
     ResultString(s"${types2class(enumTypeAbs)}($id)")
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -69,9 +69,9 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
         trInterpolatedStringLiteral(s)
       case Ast.expr.Bool(n) =>
         trBoolLiteral(n)
-      case Ast.expr.EnumById(enumType, id, inType) =>
+      case Ast.expr.EnumCast(enumType, value, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
-        trEnumById(enumSpec.name, translate(id))
+        trEnumCast(enumSpec.name, translate(value))
       case Ast.expr.EnumVariant(enumType, variant, inType) =>
         val enumSpec = provider.resolveEnum(inType, enumType.name)
         trEnumVariant(enumSpec.name, variant.name)
@@ -277,8 +277,8 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
 
   def trEnumVariant(enumTypeAbs: List[String], variant: String) =
     ResultString(GoCompiler.enumToStr(enumTypeAbs, variant))
-  def trEnumById(enumTypeAbs: List[String], id: String) =
-    ResultString(s"${types2class(enumTypeAbs)}($id)")
+  def trEnumCast(enumTypeAbs: List[String], value: String) =
+    ResultString(s"${types2class(enumTypeAbs)}($value)")
 
   override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = {
     op match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -66,9 +66,9 @@ class JavaScriptTranslator(provider: TypeProvider, importList: ImportList) exten
     }
     s"${JavaScriptCompiler.types2class(enumSpec.name, isExternal)}.${Utils.upperUnderscoreCase(variant)}"
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
     // Just an integer, without any casts / resolutions - one would have to look up constants manually
-    id
+    value
 
   override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
     s"(${JavaScriptCompiler.kstreamName}.byteArrayCompare(${translate(left)}, ${translate(right)}) ${cmpOp(op)} 0)"

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -58,13 +58,13 @@ class JavaScriptTranslator(provider: TypeProvider, importList: ImportList) exten
   override def doInternalName(id: Identifier): String =
     JavaScriptCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = {
     val isExternal = enumSpec.isExternal(provider.nowClass)
     if (isExternal) {
       val className = JavaScriptCompiler.type2class(enumSpec.name.head)
       importList.add(s"./$className")
     }
-    s"${JavaScriptCompiler.types2class(enumSpec.name, isExternal)}.${Utils.upperUnderscoreCase(label)}"
+    s"${JavaScriptCompiler.types2class(enumSpec.name, isExternal)}.${Utils.upperUnderscoreCase(variant)}"
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     // Just an integer, without any casts / resolutions - one would have to look up constants manually

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -68,8 +68,8 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList, config: Run
 
   override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
     s"${enumClass(enumSpec.name)}.${Utils.upperUnderscoreCase(variant)}"
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
-    s"${enumClass(enumSpec.name)}.byId($id)"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
+    s"${enumClass(enumSpec.name)}.byId($value)"
 
   def enumClass(enumTypeAbs: List[String]): String = {
     val enumTypeRel = Utils.relClass(enumTypeAbs, provider.nowClass.name)

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -66,8 +66,8 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList, config: Run
   override def doInternalName(id: Identifier): String =
     JavaCompiler.privateMemberName(id, inSubIOWriteBackHandler)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String =
-    s"${enumClass(enumSpec.name)}.${Utils.upperUnderscoreCase(label)}"
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
+    s"${enumClass(enumSpec.name)}.${Utils.upperUnderscoreCase(variant)}"
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     s"${enumClass(enumSpec.name)}.byId($id)"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -110,8 +110,8 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
 
   override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
     s"${LuaCompiler.types2class(enumSpec.name)}.$variant"
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
-    s"${LuaCompiler.types2class(enumSpec.name)}($id)"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
+    s"${LuaCompiler.types2class(enumSpec.name)}($value)"
 
   override def strConcat(left: Ast.expr, right: Ast.expr, extPrec: Int): String =
     s"${translate(left)} .. ${translate(right)}"

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -108,8 +108,8 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def doInternalName(id: Identifier): String =
     LuaCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String =
-    s"${LuaCompiler.types2class(enumSpec.name)}.$label"
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
+    s"${LuaCompiler.types2class(enumSpec.name)}.$variant"
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     s"${LuaCompiler.types2class(enumSpec.name)}($id)"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -38,8 +38,8 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
     s"""encode($bytesExpr, ${doStringLiteral(encoding)})"""
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String = s"${namespaced(enumSpec.name)}($id)"
-//  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = s"${namespaced(enumSpec.name)}($label)"
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = s"${enumSpec.name.head}.$label"
+//  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = s"${namespaced(enumSpec.name)}($variant)"
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = s"${enumSpec.name.head}.$variant"
   override def doName(s: String): String =
     s match {
       case Identifier.ROOT => "root"

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -37,7 +37,7 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def bytesToStr(bytesExpr: String, encoding: String): String = {
     s"""encode($bytesExpr, ${doStringLiteral(encoding)})"""
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String = s"${namespaced(enumSpec.name)}($id)"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String = s"${namespaced(enumSpec.name)}($value)"
 //  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = s"${namespaced(enumSpec.name)}($variant)"
   override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = s"${enumSpec.name.head}.$variant"
   override def doName(s: String): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
@@ -74,9 +74,9 @@ class PHPTranslator(provider: TypeProvider, config: RuntimeConfig) extends BaseT
     val enumClass = types2classAbs(enumSpec.name)
     s"$enumClass::${Utils.upperUnderscoreCase(variant)}"
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
     // Just an integer, without any casts / resolutions - one would have to look up constants manually
-    id
+    value
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}[${translate(idx)}]"

--- a/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
@@ -70,9 +70,9 @@ class PHPTranslator(provider: TypeProvider, config: RuntimeConfig) extends BaseT
   override def doInternalName(id: Identifier): String =
     PHPCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = {
     val enumClass = types2classAbs(enumSpec.name)
-    s"$enumClass::${Utils.upperUnderscoreCase(label)}"
+    s"$enumClass::${Utils.upperUnderscoreCase(variant)}"
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     // Just an integer, without any casts / resolutions - one would have to look up constants manually

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -107,9 +107,9 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     val enumName = Utils.upperUnderscoreCase(enumSpec.name.last)
     s"$$$enumClassWithScope${enumName}_${Utils.upperUnderscoreCase(variant)}"
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
     // Just an integer, without any casts / resolutions - one would have to look up constants manually
-    id
+    value
 
   def enumClass(enumTypeAbs: List[String]): String = {
     val enumTypeRel = Utils.relClass(enumTypeAbs, provider.nowClass.name)

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -97,7 +97,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def doInternalName(id: Identifier): String =
     PerlCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = {
     val isExternal = enumSpec.isExternal(provider.nowClass)
     if (isExternal) {
       importList.add(PerlCompiler.type2class(enumSpec.name.head))
@@ -105,7 +105,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     val enumClass = PerlCompiler.types2class(enumSpec.name.init)
     val enumClassWithScope = if (enumClass.isEmpty) "" else s"$enumClass::"
     val enumName = Utils.upperUnderscoreCase(enumSpec.name.last)
-    s"$$$enumClassWithScope${enumName}_${Utils.upperUnderscoreCase(label)}"
+    s"$$$enumClassWithScope${enumName}_${Utils.upperUnderscoreCase(variant)}"
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     // Just an integer, without any casts / resolutions - one would have to look up constants manually

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -109,9 +109,9 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList, config: R
     }
     s"${PythonCompiler.types2class(enumSpec.name, isExternal)}.$variant"
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String = {
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String = {
     val isExternal = enumSpec.isExternal(provider.nowClass)
-    s"${PythonCompiler.kstreamName}.resolve_enum(${PythonCompiler.types2class(enumSpec.name, isExternal)}, $id)"
+    s"${PythonCompiler.kstreamName}.resolve_enum(${PythonCompiler.types2class(enumSpec.name, isExternal)}, $value)"
   }
 
   override def booleanOp(op: Ast.boolop) = op match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -102,12 +102,12 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList, config: R
   override def doInternalName(id: Identifier): String =
     PythonCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String = {
     val isExternal = enumSpec.isExternal(provider.nowClass)
     if (isExternal) {
       PythonCompiler.externalTypeDeclaration(ExternalEnum(enumSpec), importList, config)
     }
-    s"${PythonCompiler.types2class(enumSpec.name, isExternal)}.$label"
+    s"${PythonCompiler.types2class(enumSpec.name, isExternal)}.$variant"
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String = {
     val isExternal = enumSpec.isExternal(provider.nowClass)

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -83,8 +83,8 @@ class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
 
   override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
     RubyCompiler.enumValue(enumSpec.name.last, variant)
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
-    s"${RubyCompiler.kstreamName}::resolve_enum(${enumDirectMap(enumSpec.name)}, $id)"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
+    s"${RubyCompiler.kstreamName}::resolve_enum(${enumDirectMap(enumSpec.name)}, $value)"
 
   def enumDirectMap(enumTypeAndName: List[String]): String = {
     val enumTypeAbs = enumTypeAndName.dropRight(1)

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -81,8 +81,8 @@ class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider) {
   override def doInternalName(id: Identifier): String =
     RubyCompiler.privateMemberName(id)
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String =
-    RubyCompiler.enumValue(enumSpec.name.last, label)
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
+    RubyCompiler.enumValue(enumSpec.name.last, variant)
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     s"${RubyCompiler.kstreamName}::resolve_enum(${enumDirectMap(enumSpec.name)}, $id)"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
@@ -359,8 +359,8 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig)
   override def doInternalName(id: Identifier): String =
     s"${doLocalName(idToStr(id))}"
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String =
-    s"${RustCompiler.types2class(enumSpec.name)}::${Utils.upperCamelCase(label)}"
+  override def doEnumVariant(enumSpec: EnumSpec, variant: String): String =
+    s"${RustCompiler.types2class(enumSpec.name)}::${Utils.upperCamelCase(variant)}"
 
   override def doNumericCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = {
     val lt = detectType(left)

--- a/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
@@ -394,8 +394,8 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig)
     // FIXME: figure out a better solution
     super.genericBinOp(left, op, right, extPrec)
 
-  override def doEnumById(enumSpec: EnumSpec, id: String): String =
-    s"($id as i64).try_into()?"
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String =
+    s"($value as i64).try_into()?"
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${remove_deref(translate(container))}[${translate(idx)} as usize]"
@@ -438,7 +438,7 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig)
 
   override def translate(v: Ast.expr): String = {
     v match {
-      case Ast.expr.EnumById(enumType, id, inType) =>
+      case Ast.expr.EnumCast(enumType, id, inType) =>
         id match {
           case ifExp: Ast.expr.IfExp =>
             val enumSpec = provider.resolveEnum(inType, enumType.name)

--- a/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
@@ -47,7 +47,7 @@ class TypeDetector(provider: TypeProvider) {
       case Ast.expr.Str(_) => CalcStrType
       case Ast.expr.InterpolatedStr(_) => CalcStrType
       case Ast.expr.Bool(_) => CalcBooleanType
-      case Ast.expr.EnumByLabel(enumType, _, inType) =>
+      case Ast.expr.EnumVariant(enumType, _, inType) =>
         val t = EnumType(enumType.name, inType.names.toList, CalcIntType)
         t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
         t

--- a/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
@@ -51,7 +51,7 @@ class TypeDetector(provider: TypeProvider) {
         val t = EnumType(enumType.name, inType.names.toList, CalcIntType)
         t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
         t
-      case Ast.expr.EnumById(enumType, _, inType) =>
+      case Ast.expr.EnumCast(enumType, _, inType) =>
         val t = EnumType(enumType.name, List(), CalcIntType)
         t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
         t

--- a/shared/src/main/scala/io/kaitai/struct/translators/ZigTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ZigTranslator.scala
@@ -115,7 +115,7 @@ class ZigTranslator(provider: TypeProvider, importList: ImportList, config: Runt
     }
   }
 
-  override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
+  override def doEnumVariant(enumSpec: EnumSpec, label: String): String = {
     val et = EnumType(enumSpec.name.last, enumSpec.name.dropRight(1), CalcIntType)
     et.enumSpec = Some(enumSpec)
     s"${ZigCompiler.kaitaiType2NativeType(et, importList, provider.nowClass)}.$label"

--- a/shared/src/main/scala/io/kaitai/struct/translators/ZigTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ZigTranslator.scala
@@ -120,10 +120,10 @@ class ZigTranslator(provider: TypeProvider, importList: ImportList, config: Runt
     et.enumSpec = Some(enumSpec)
     s"${ZigCompiler.kaitaiType2NativeType(et, importList, provider.nowClass)}.$label"
   }
-  override def doEnumById(enumSpec: EnumSpec, id: String): String = {
+  override def doEnumCast(enumSpec: EnumSpec, value: String): String = {
     val et = EnumType(enumSpec.name.last, enumSpec.name.dropRight(1), CalcIntType)
     et.enumSpec = Some(enumSpec)
-    s"@as(${ZigCompiler.kaitaiType2NativeType(et, importList, provider.nowClass)}, @enumFromInt($id))"
+    s"@as(${ZigCompiler.kaitaiType2NativeType(et, importList, provider.nowClass)}, @enumFromInt($value))"
   }
 
   override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =


### PR DESCRIPTION
Also document that nodes and related `AbstractTranslator` methods.

Renames:
|Before|After|
|------|-----|
|`Ast.expr.EnumById`|`Ast.expr.EnumCast`|
|`Ast.expr.EnumByLabel`|`Ast.expr.EnumVariant`|