### PR TITLE
Normalize node paths in errors

### DIFF
--- a/jvm/src/main/scala/io/kaitai/struct/formats/JavaClassSpecs.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/formats/JavaClassSpecs.scala
@@ -55,7 +55,7 @@ class JavaClassSpecs(relPath: String, absPaths: Seq[String], firstSpec: ClassSpe
         }
       }
     }
-    throw new FileNotFoundException(s"Unable to find '$name' in import search paths, using: $absPaths")
+    throw new FileNotFoundException(s"unable to find '$name.ksy' in import search paths, using: $absPaths")
   }
 }
 

--- a/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
@@ -167,14 +167,13 @@ object AttrSpec {
       fromYaml2(srcMap, path, metaDef, id)
     } catch {
       case (epe: Expressions.ParseException) =>
-        throw KSYParseError.expression(epe, path)
+        throw KSYParseError.expression(epe, path ++ List("type"))
     }
   }
 
   def fromYaml2(srcMap: Map[String, Any], path: List[String], metaDef: MetaSpec, id: Identifier): AttrSpec = {
     val doc = DocSpec.fromYaml(srcMap, path)
-    val process = ProcessExpr.fromStr(ParseUtils.getOptValueStr(srcMap, "process", path), path)
-    // TODO: add proper path propagation
+    val process = ProcessExpr.fromStr(ParseUtils.getOptValueStr(srcMap, "process", path), path ++ List("process"))
     val contents = srcMap.get("contents").map(parseContentSpec(_, path ++ List("contents")))
     val size = ParseUtils.getOptValueExpression(srcMap, "size", path)
     val sizeEos = ParseUtils.getOptValueBool(srcMap, "size-eos", path).getOrElse(false)

--- a/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
@@ -222,7 +222,7 @@ object AttrSpec {
             )
           case switchMap: Map[Any, Any] =>
             val switchMapStr = ParseUtils.anyMapToStrMap(switchMap, path)
-            parseSwitch(switchMapStr, path, metaDef, yamlAttrArgs)
+            parseSwitch(switchMapStr, path ++ List("type"), metaDef, yamlAttrArgs)
           case unknown =>
             throw KSYParseError.withText(s"expected map or string, found $unknown", path ++ List("type"))
         }

--- a/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
@@ -181,7 +181,7 @@ object ClassSpec {
     if (path.isEmpty) {
       explicitMeta.id match {
         case None =>
-          throw KSYParseError.withText("no `meta/id` encountered in top-level class spec", path ++ List("meta", "id"))
+          throw KSYParseError.withText("no `meta/id` encountered in top-level class spec", path ++ List("meta"))
         case Some(id) =>
           cs.name = List(id)
       }

--- a/shared/src/main/scala/io/kaitai/struct/format/ParseUtils.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ParseUtils.scala
@@ -26,7 +26,7 @@ object ParseUtils {
       case Some(value) =>
         asStr(value, path ++ List(field))
       case None =>
-        throw KSYParseError.noKey(path ++ List(field))
+        throw KSYParseError.noKey(field, path)
     }
   }
 
@@ -35,7 +35,7 @@ object ParseUtils {
       case Some(value) =>
         asMapStrStr(value, path ++ List(field))
       case None =>
-        throw KSYParseError.noKey(path ++ List(field))
+        throw KSYParseError.noKey(field, path)
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/format/ParseUtils.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ParseUtils.scala
@@ -90,7 +90,7 @@ object ParseUtils {
       Expressions.parse(getValueStr(src, field, path))
     } catch {
       case epe: Expressions.ParseException =>
-        throw KSYParseError.expression(epe, path)
+        throw KSYParseError.expression(epe, path ++ List(field))
     }
   }
 
@@ -99,7 +99,7 @@ object ParseUtils {
       getOptValueStr(src, field, path).map(Expressions.parse)
     } catch {
       case epe: Expressions.ParseException =>
-        throw KSYParseError.expression(epe, path)
+        throw KSYParseError.expression(epe, path ++ List(field))
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -46,13 +46,13 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
   def resolveUserType(curClass: ClassSpec, dataType: DataType, path: List[String]): Iterable[CompilationProblem] = {
     dataType match {
       case ut: UserType =>
-        val (resClassSpec, problems) = resolveUserType(curClass, ut.name, path)
+        val (resClassSpec, problems) = resolveUserType(curClass, ut.name, path ++ List("type"))
         ut.classSpec = resClassSpec
         problems
       case et: EnumType =>
         et.enumSpec = resolveEnumSpec(curClass, et.name)
         if (et.enumSpec.isEmpty) {
-          Some(EnumNotFoundErr(et.name, curClass, path))
+          Some(EnumNotFoundErr(et.name, curClass, path ++ List("enum")))
         } else {
           None
         }

--- a/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
@@ -168,7 +168,11 @@ class TypeValidator(specs: ClassSpecs) extends PrecompileStep {
       } else {
         None
       }
-      val problems2 = validateDataType(caseType, casePath)
+      // All properties of types is declared on the common level for all variants so
+      // we don't use `casePath` here
+      // FIXME: We need to filter repeated errors here, because some errors influences
+      // many cases
+      val problems2 = validateDataType(caseType, path)
       problems1 ++ problems2
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
+++ b/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
@@ -69,8 +69,8 @@ object KSYParseError {
   def withText(text: String, path: List[String]): CompilationProblemException =
     KSYParseError(text, path).toException
 
-  def noKey(path: List[String]) =
-    withText(s"missing mandatory argument `${path.last}`", path)
+  def noKey(field: String, path: List[String]) =
+    withText(s"missing mandatory argument `$field`", path)
 
   def noKeys(path: List[String], expectedKeys: Set[String]) =
     withText(s"expected any of ${expectedKeys.toList.sorted.mkString(", ")}, found none", path)


### PR DESCRIPTION
After this change all paths in errors will point to existing nodes in KSY file and node, where error is originated

This PR introduces 10 new failures (76 vs 66) because it changes error messages which is it purpose. So, this PR should be merged together with https://github.com/kaitai-io/kaitai_struct_tests/pull/92 which is fixes test data accordingly.