### PR TITLE
Generation of Java getter methods to support serialization

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -202,6 +202,9 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def attributeReader(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = {
+    if (!attrName.toAstIdentifier.name.startsWith("_")) {
+      out.puts(s"public ${kaitaiType2JavaType(attrType, isNullable)} get${idToStrCap(attrName)}() { return ${idToStr(attrName)}(); }")
+    }
     out.puts(s"public ${kaitaiType2JavaType(attrType, isNullable)} ${idToStr(attrName)}() { return ${idToStr(attrName)}; }")
   }
 
@@ -725,6 +728,10 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   def value2Const(s: String) = Utils.upperUnderscoreCase(s)
+
+  def idToStrCap(id: Identifier): String = {
+    idToStr(id).capitalize
+  }
 
   def idToStr(id: Identifier): String = {
     id match {


### PR DESCRIPTION
Hello, 

thanks for the great project, really impressive.


To serialize instances of generated Java classes, Java Beans getter methods (public T **get**Xy..) are required for data class fields / members.

Here [JavaBeans](https://docstore.mik.ua/orelly/java-ent/jnut/ch06_02.htm) spec description
Here some [information](https://www.baeldung.com/jackson-field-serializable-deserializable-or-not) about JSON Serialization
