### PR TITLE
Fix constants generated in case of `parent: false` in Lua, Python and Ruby

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -348,6 +348,7 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         ""
       } else {
         val parent = t.forcedParent match {
+          case Some(USER_TYPE_NO_PARENT) => "nil"
           case Some(fp) => translator.translate(fp)
           case None => "self"
         }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -379,6 +379,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
           ""
         } else {
           val parent = t.forcedParent match {
+            case Some(USER_TYPE_NO_PARENT) => "None"
             case Some(fp) => translator.translate(fp)
             case None => "self"
           }

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -362,6 +362,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
           ""
         } else {
           val parent = t.forcedParent match {
+            case Some(USER_TYPE_NO_PARENT) => "nil"
             case Some(fp) => translator.translate(fp)
             case None => "self"
           }


### PR DESCRIPTION
- lua: false -> nil
- python: False -> None
- ruby: false -> nil

Perl probably also affected by this but I don't known what to use instead of `0`