### PR TITLE
Export Construct enums before types

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -33,9 +33,9 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
   }
 
   def compileClass(cs: ClassSpec): Unit = {
-    cs.types.foreach { case (_, typeSpec) => compileClass(typeSpec) }
-
     cs.enums.foreach { case (_, enumSpec) => compileEnum(enumSpec) }
+
+    cs.types.foreach { case (_, typeSpec) => compileClass(typeSpec) }
 
     out.puts(s"${type2class(cs)} = Struct(")
     out.inc


### PR DESCRIPTION
I described a bug with the Construct exporter here https://github.com/kaitai-io/kaitai_struct/issues/377?ts=4#issuecomment-1013707806

Using the example from that post, the compiler now outputs this Python:
```python
from construct import *
from construct.lib import *

# Now correctly outputs this first!
def example__quality_options(subcon):
	return Enum(subcon,
		low=0,
		medium=1,
		high=2,
	)

example__video_settings = Struct(
	'texture_quality' / example__quality_options(Int8ub),
)

example = Struct(
	'video' / LazyBound(lambda: example__video_settings),
)

_schema = example
```

tl;dr: I made the Construct exporter export enums before types, since types can depend on enums. This is important for Python because it reads top to bottom.