### PR TITLE
Output comment explaining code generation to Construct compiler

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -15,6 +15,7 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
   val translator = new ConstructTranslator(provider, importList)
 
   override def compile: CompileLog.SpecSuccess = {
+    out.puts("# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild")
     out.puts("from construct import *")
     out.puts("from construct.lib import *")
     out.puts


### PR DESCRIPTION
Add comment to the top of Construct source files explaining to edit the ksy and recompile.
Other targets already have this, so Construct should too.

Sample output with this change:
```python
# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
from construct import *
from construct.lib import *

example = Struct(
	'field1' / LazyBound(lambda: shared__thing),
)

_schema = example
```