### PR TITLE
Generate imports for Construct

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -33,6 +33,14 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
   }
 
   def compileClass(cs: ClassSpec): Unit = {
+    TypeProcessor.getOpaqueClasses(cs).foreach(import_cs =>
+      if (import_cs != cs) {
+        val name = import_cs.name.head
+        out.puts(s"from $name import *")
+      }
+    )
+    out.puts
+
     cs.types.foreach { case (_, typeSpec) => compileClass(typeSpec) }
 
     cs.enums.foreach { case (_, enumSpec) => compileEnum(enumSpec) }

--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -7,7 +7,9 @@ import io.kaitai.struct.format._
 import io.kaitai.struct.languages.components.{LanguageCompiler, LanguageCompilerStatic}
 import io.kaitai.struct.translators.ConstructTranslator
 
-class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends AbstractCompiler {
+class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec, config: RuntimeConfig)
+  extends AbstractCompiler {
+
   val out = new StringLanguageOutputWriter(indent)
   val importList = new ImportList
 
@@ -35,7 +37,10 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
   def compileClass(cs: ClassSpec): Unit = {
     TypeProcessor.getOpaqueClasses(cs).foreach(import_cs =>
       if (import_cs != cs) {
-        val name = import_cs.name.head
+        var name = import_cs.name.head
+        if (config.pythonPackage.nonEmpty) {
+          name = s"${config.pythonPackage}.$name"
+        }
         out.puts(s"from $name import *")
       }
     )

--- a/shared/src/main/scala/io/kaitai/struct/Main.scala
+++ b/shared/src/main/scala/io/kaitai/struct/Main.scala
@@ -90,7 +90,7 @@ object Main {
       case RustCompiler =>
         new RustClassCompiler(specs, spec, config)
       case ConstructClassCompiler =>
-        new ConstructClassCompiler(specs, spec)
+        new ConstructClassCompiler(specs, spec, config)
       case NimCompiler =>
         new NimClassCompiler(specs, spec, config)
       case HtmlClassCompiler =>


### PR DESCRIPTION
This causes imports to be generated for the Construct target. This **does not** fix https://github.com/kaitai-io/kaitai_struct/issues/703, but it does make Construct behave the same as Python (for imports, anyway).

Given this ksy
```yaml
meta:
  id: example3
  endian: le
  imports:
    - common/other
seq:
  - id: field1
    type: other
```

We get this Construct (Python) output:
```python
from construct import *
from construct.lib import *

from other import *

example3 = Struct(
	'field1' / LazyBound(lambda: other),
)

_schema = example3
```