### PR TITLE
Generate docs in Construct compiler

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -4,7 +4,7 @@ import io.kaitai.struct.datatype.DataType._
 import io.kaitai.struct.datatype._
 import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.format._
-import io.kaitai.struct.languages.components.{LanguageCompiler, LanguageCompilerStatic}
+import io.kaitai.struct.languages.components.{LanguageCompiler, LanguageCompilerStatic, PythonOps}
 import io.kaitai.struct.translators.ConstructTranslator
 
 class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends AbstractCompiler {
@@ -54,7 +54,8 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
     }
 
     out.dec
-    out.puts(")")
+    val docStr = PythonOps.compileUniversalDocs(cs.doc)
+    out.puts(if (docStr.isEmpty) ")" else s") * '''$docStr'''")
     out.puts
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -37,7 +37,8 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
 
     cs.enums.foreach { case (_, enumSpec) => compileEnum(enumSpec) }
 
-    out.puts(s"${type2class(cs)} = Struct(")
+    val classname = type2class(cs)
+    out.puts(s"$classname = '$classname' / Struct(")
     out.inc
 
     provider.nowClass = cs

--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -60,7 +60,18 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
   }
 
   def compileAttr(attr: AttrLikeSpec): Unit = {
-    out.puts(s"'${idToStr(attr.id)}' / ${compileAttrBody(attr)},")
+    val attrStr = s"'${idToStr(attr.id)}' / ${compileAttrBody(attr)}"
+    val docStr = PythonOps.compileUniversalDocs(attr.doc)
+    if (docStr.isEmpty) {
+      out.puts(s"$attrStr,")
+    } else if (!docStr.contains('\n')) {
+      out.puts(s"$attrStr * '$docStr',")
+    } else {
+      out.puts(s"$attrStr * \\")
+      out.inc
+      out.putsLines("", s"'''$docStr''',")
+      out.dec
+    }
   }
 
   def compileValueInstance(id: Identifier, vis: ValueInstanceSpec): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -7,7 +7,7 @@ import io.kaitai.struct.exprlang.Ast.expr
 import io.kaitai.struct.format._
 import io.kaitai.struct.languages.components._
 import io.kaitai.struct.translators.PythonTranslator
-import io.kaitai.struct.{ClassTypeProvider, RuntimeConfig, StringLanguageOutputWriter, Utils}
+import io.kaitai.struct.{ClassTypeProvider, RuntimeConfig, Utils}
 
 class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   extends LanguageCompiler(typeProvider, config)
@@ -141,31 +141,8 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def attributeReader(attrName: Identifier, attrType: DataType, isNullable: Boolean): Unit = {}
 
   override def universalDoc(doc: DocSpec): Unit = {
-    val docStr = doc.summary match {
-      case Some(summary) =>
-        val lastChar = summary.last
-        if (lastChar == '.' || lastChar == '\n') {
-          summary
-        } else {
-          summary + "."
-        }
-      case None =>
-        ""
-    }
-
-    val extraNewline = if (docStr.isEmpty || docStr.last == '\n') "" else "\n"
-    val refStr = doc.ref.map {
-      case TextRef(text) =>
-        val seeAlso = new StringLanguageOutputWriter("")
-        seeAlso.putsLines("   ", text)
-        s"$extraNewline\n.. seealso::\n${seeAlso.result}"
-      case ref: UrlRef =>
-        val seeAlso = new StringLanguageOutputWriter("")
-        seeAlso.putsLines("   ", s"${ref.text} - ${ref.url}")
-        s"$extraNewline\n.. seealso::\n${seeAlso.result}"
-    }.mkString("\n")
-
-    out.putsLines("", "\"\"\"" + docStr + refStr + "\"\"\"")
+    val docStr = PythonOps.compileUniversalDocs(doc)
+    out.putsLines("", "\"\"\"" + docStr + "\"\"\"")
   }
 
   override def attrFixedContentsParse(attrName: Identifier, contents: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/PythonOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/PythonOps.scala
@@ -1,0 +1,34 @@
+package io.kaitai.struct.languages.components
+
+import io.kaitai.struct.StringLanguageOutputWriter
+import io.kaitai.struct.format.{DocSpec, TextRef, UrlRef}
+
+object PythonOps {
+  def compileUniversalDocs(doc: DocSpec): String = {
+    val docStr = doc.summary match {
+      case Some(summary) =>
+        val lastChar = summary.last
+        if (lastChar == '.' || lastChar == '\n') {
+          summary
+        } else {
+          summary + "."
+        }
+      case None =>
+        ""
+    }
+
+    val extraNewline = if (docStr.isEmpty || docStr.last == '\n') "" else "\n"
+    val refStr = doc.ref.map {
+      case TextRef(text) =>
+        val seeAlso = new StringLanguageOutputWriter("")
+        seeAlso.putsLines("   ", text)
+        s"$extraNewline\n.. seealso::\n${seeAlso.result}"
+      case ref: UrlRef =>
+        val seeAlso = new StringLanguageOutputWriter("")
+        seeAlso.putsLines("   ", s"${ref.text} - ${ref.url}")
+        s"$extraNewline\n.. seealso::\n${seeAlso.result}"
+    }.mkString("\n")
+
+    docStr + refStr
+  }
+}


### PR DESCRIPTION
This PR populates the `name` and `docs` attribute for top-level Construct Structs, and the `docs` attribute for fields. Since Construct is Python-based, I've pulled the now-common logic for Python out to a utility.

Example ksy:
```yaml
meta:
  id: docs
  endian: le
doc: |
  Example to show off Construct doc strings

  These can be multiline
  and have lots of info and stuff.
doc-ref: https://construct.readthedocs.io/en/latest/advanced.html?highlight=description#documenting-fields
seq:
  - id: field1
    type: u4
    doc: 'Short desc'
  - id: field2
    type: other
    doc: This is a cool field
    doc-ref: https://www.google.com
  - id: field3
    type: u1
types:
  other:
    seq:
      - id: sub1
        type: u4
```
Before this PR:
```python
from construct import *
from construct.lib import *

docs__other = Struct(
	'sub1' / Int32ul,
)

docs = Struct(
	'field1' / Int32ul,
	'field2' / LazyBound(lambda: docs__other),
	'field3' / Int8ub,
)

_schema = docs
```
After this PR:
```python
from construct import *
from construct.lib import *

docs__other = 'docs__other' / Struct(
	'sub1' / Int32ul,
)

docs = 'docs' / Struct(
	'field1' / Int32ul * 'Short desc.',
	'field2' / LazyBound(lambda: docs__other) * \
		'''This is a cool field.
		
		.. seealso::
		   Source - https://www.google.com
		''',
	'field3' / Int8ub,
) * '''Example to show off Construct doc strings

These can be multiline
and have lots of info and stuff.

.. seealso::
   Source - https://construct.readthedocs.io/en/latest/advanced.html?highlight=description#documenting-fields
'''

_schema = docs
```