### PR TITLE
add utf16 string types to golang generator

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -277,9 +277,8 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
     "iso8859-4" -> ("charmap.ISO8859_4", IMPORT_CHARMAP),
     "sjis" -> ("japanese.ShiftJIS", "golang.org/x/text/encoding/japanese"),
     "big5" -> ("traditionalchinese.Big5", "golang.org/x/text/encoding/traditionalchinese"),
-    "utf16-auto" -> ("unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)", "golang.org/x/text/encoding/unicode"),
-    "utf16-le" -> ("unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)", "golang.org/x/text/encoding/unicode"),
-    "utf16-be" -> ("unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)", "golang.org/x/text/encoding/unicode")
+    "utf-16le" -> ("unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)", "golang.org/x/text/encoding/unicode"),
+    "utf-16be" -> ("unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)", "golang.org/x/text/encoding/unicode")
   )
 
   override def bytesToStr(value: Ast.expr, expr: Ast.expr): TranslatorResult =

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -276,7 +276,10 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
     "iso8859-3" -> ("charmap.ISO8859_3", IMPORT_CHARMAP),
     "iso8859-4" -> ("charmap.ISO8859_4", IMPORT_CHARMAP),
     "sjis" -> ("japanese.ShiftJIS", "golang.org/x/text/encoding/japanese"),
-    "big5" -> ("traditionalchinese.Big5", "golang.org/x/text/encoding/traditionalchinese")
+    "big5" -> ("traditionalchinese.Big5", "golang.org/x/text/encoding/traditionalchinese"),
+    "utf16-auto" -> ("unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)", "golang.org/x/text/encoding/unicode"),
+    "utf16-le" -> ("unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)", "golang.org/x/text/encoding/unicode"),
+    "utf16-be" -> ("unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)", "golang.org/x/text/encoding/unicode")
   )
 
   override def bytesToStr(value: Ast.expr, expr: Ast.expr): TranslatorResult =


### PR DESCRIPTION
I needed UTF16 strings for some Kaitai structs and since Golang supports them similarly to the other encoding, I just added them to the generator.