### PR TITLE
Fixes/standardizes the behavior of a repetition '_index' within a 'repeat-until' expression

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -339,7 +339,8 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       out.puts(s"${privateMemberName(RawIdentifier(id))} = make([][]byte, 0);")
     if (needRaw.level >= 2)
       out.puts(s"${privateMemberName(RawIdentifier(RawIdentifier(id)))} = make([][]byte, 0);")
-    out.puts(s"for i := 1;; i++ {")
+    out.puts("i := 0")
+	  out.puts("for {")
     out.inc
   }
 
@@ -352,6 +353,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: NeedRaw, untilExpr: Ast.expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
+    out.puts("i++")
     out.puts(s"if ${expression(untilExpr)} {")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -204,12 +204,12 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: NeedRaw, untilExpr: Ast.expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
+    out.puts("i = i + 1")
     out.puts(s"if ${expression(untilExpr)} then")
     out.inc
     out.puts("break")
     out.dec
     out.puts("end")
-    out.puts("i = i + 1")
     out.dec
     out.puts("end")
     out.dec

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -168,11 +168,11 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: NeedRaw, repeatExpr: Ast.expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
+    out.puts("inc i")
     out.puts(s"if ${expression(repeatExpr)}:")
     out.inc
     out.puts("break")
     out.dec
-    out.puts("inc i")
     out.dec
     out.dec
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -270,6 +270,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     if (needRaw.level >= 2)
       out.puts(s"${privateMemberName(RawIdentifier(RawIdentifier(id)))} = ();")
     out.puts(s"${privateMemberName(id)} = ();")
+    out.puts("my $i = 0;")
     out.puts("do {")
     out.inc
   }
@@ -286,6 +287,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: NeedRaw, untilExpr: expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
+    out.puts("$i++;")
     out.dec
     out.puts(s"} until (${expression(untilExpr)});")
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -345,11 +345,11 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: NeedRaw, untilExpr: expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
+    out.puts("i += 1")
     out.puts(s"if ${expression(untilExpr)}:")
     out.inc
     out.puts("break")
     out.dec
-    out.puts("i += 1")
     out.dec
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -291,6 +291,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     if (needRaw.level >= 2)
       out.puts(s"${privateMemberName(RawIdentifier(RawIdentifier(id)))} = vec!();")
     out.puts(s"${privateMemberName(id)} = vec!();")
+    out.puts("let mut i = 0;")
     out.puts("while {")
     out.inc
   }
@@ -307,6 +308,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, needRaw: NeedRaw, untilExpr: Ast.expr): Unit = {
     typeProvider._currentIteratorType = Some(dataType)
+    out.puts("i += 1;")
     out.puts(s"!(${expression(untilExpr)})")
     out.dec
     out.puts("} { }")


### PR DESCRIPTION
# Defines/Standardizes the Behavior of a Repetition `_index` within a `repeat-until` Expression

NOTE: This PR standardizes the previously-undefined behavior of `_index` within `repeat_until`.
Fixes [issue #958](https://github.com/kaitai-io/kaitai_struct/issues/958). Because this standardizes something that was previously undefined, this PR may 
warrant further discussion beyond the scope of a typical code review. 


# Standardizing this Behavior
## Need
[Issue #958](https://github.com/kaitai-io/kaitai_struct/issues/958) presents a basic scenario which warrants *using* (and therefore *defining* the behavior of)
`_index` within a `repeat-until` expression. Generally speaking, any data structure which contains
a list of entries of a variable-size `N` that is capable of terminating early (before `N` items have been processed),
benefits from this functionality. 

## Possible Behaviors
### Inclusive `_index` (Implemented in this PR)
'Inclusive' means that `_index` gives the total number of elements processed *plus* the current entry.
Thus, for the first item processed in a `repeat-until` block, `_index` will yield a value of 1.
This is in *contrast* to the typical evaluation of `_index` *outside* a `repeat-until` expression.
However, I believe this treatment of `_index` *within* a `repeat-until` expression is justified 
(and, in-general, the expected behavior) - see the **Reasoning for Inclusive Evaluation** section. 


### Exclusive `_index`
'Exclusive' means that `_index` gives the total number of elements processed *without counting* the current entry.
Thus, for the first item processed in a repeat-until block, `_index` will yield a value of 0.
This is the *typical* behavior of `_index` in expressions *outside* `repeat-until` blocks.


## Current Behavior
Currently, `_index` within `repeat-until` blocks is evaluated differently depending on the language target, see [issue #958](https://github.com/kaitai-io/kaitai_struct/issues/958).

- C++: `_index` is *inclusive*
- C#: `_index` is *inclusive*

- Go: `_index` is *inclusive* both *within* and *outside* `repeat-until` expressions.
  This is unlike every other language target where expressions (outside `repeat-until`) 
  treat `_index` as exclusive (as they should).

- Java: `_index` is *inclusive*
- Javascript: `_index` is *inclusive*
- Lua: `_index` is *exclusive*
- Nim: `_index` is *exclusive*
- Perl: Use of `_index` within `repeat-until` expressions results in code that does not compile
- PHP: `_index` is *inclusive*
- Python: `_index` is *exclusive*
- Ruby: `_index` is *inclusive*
- Rust: Use of `_index` within `repeat-until` expressions results in code that does not compile

## Reasoning for Inclusive Evaluation
Typically, `_index` is evaluated exclusively. This way, `_index` gives the current index of the
entry being processed. My argument, however, is that by the time the condition within a
`repeat-until` expression is being evaluated, the current item is *already* considered to be 
processed. 

This is supported by the fact that the contents of the current item
can be referred to by the `_` reference within a `repeat-until` expression - further reinforcing
that the current item is already be considered to have been 'processed' when evaluating 
`repeat-until` expression.

Inclusive evaluation is also consistent with most implementations of a 'do while' loop, a
structure to which a `repeat-until` block is roughly analogous. 

Finally, inclusive evaluation will provide coverage for the most common use case:
where the maximum number of repetitions (`N`) is known, but has the potential to terminate early. Exclusive evaluation would require that the condition `_index < N - 1` is tested, rather than the cleaner `_index < N`.