### PR TITLE
Java: a more precise check for when switch statements can be used.

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -545,10 +545,39 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     }
   }
 
+  // Java switch statements can accept byte, short, char, int, enums and Strings.
   override def switchRequiresIfs(onType: DataType): Boolean = onType match {
-    case _: IntType | _: EnumType | _: StrType => false
-    case _ => true
-  }
+      case Int1Type(false) => false
+      case IntMultiType(false, Width2, _) => false
+
+      case Int1Type(true) => false  // byte
+      case IntMultiType(true, Width2, _) => false  // short
+      case IntMultiType(true, Width4, _) => false  // int
+      case IntMultiType(true, Width8, _) => true   // long
+
+      case FloatMultiType(Width4, _) => true
+      case FloatMultiType(Width8, _) => true
+
+      case BitsType(_, _) => true
+
+      case _: BooleanType => true
+      case CalcIntType => false
+      case CalcFloatType => true
+
+      case _: StrType => false
+      case _: BytesType => true
+
+      case AnyType => true
+      case KaitaiStreamType | OwnedKaitaiStreamType => true
+      case KaitaiStructType | CalcKaitaiStructType => true
+
+      case t: UserType => true
+      case EnumType(name, _) => false
+
+      case ArrayTypeInStream(_) | CalcArrayType(_) => true
+
+      case _ => true
+    }
 
   //<editor-fold desc="switching: true version">
 
@@ -567,8 +596,9 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         // If switch is over a enum, only literal enum values are supported,
         // and they must be written as "MEMBER", not "SomeEnum.MEMBER".
         value2Const(enumByLabel.label.name)
-      case _ =>
+      case _ => {
         expression(condition)
+      }
     }
 
     out.puts(s"case $condStr: {")


### PR DESCRIPTION
This change should fix #599 and #922

I ran the tests and no additional tests failed. Also, this fixes the output of macho.ksy which otherwise fails to compile. I haven't tested anything else.