### PR TITLE
Golang: fix enum type for large values

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -513,8 +513,13 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val fullEnumName: List[String] = curClass ++ List(enumName)
     val fullEnumNameStr = types2class(fullEnumName)
 
+    var enumType = "int"
+    if (enumColl.last._1 > Int.MaxValue) {
+        enumType = "int64"
+    }
+
     out.puts
-    out.puts(s"type $fullEnumNameStr int")
+    out.puts(s"type $fullEnumNameStr $enumType")
     out.puts("const (")
     out.inc
 


### PR DESCRIPTION
When using 32bit Golang, the standard `int` type only holds 32 bits. This is a problem when the enum keys are larger than `Int.MaxValue`. This fix should solve the problem for Golang. However, I cannot tell whether this issue also affects other languages which then need a fix as well. Maybe, there is a more thorough solution for this anyway - I'm not at all used to Scala so my fix might be not the ideal way of doing this.