### PR TITLE
Fix initialisation of arrays in PerlCompiler

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -238,10 +238,10 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatCommonInit(id: Identifier, dataType: DataType, needRaw: NeedRaw): Unit = {
     if (needRaw.level >= 1)
-      out.puts(s"${privateMemberName(RawIdentifier(id))} = ();")
+      out.puts(s"${privateMemberName(RawIdentifier(id))} = [];")
     if (needRaw.level >= 2)
-      out.puts(s"${privateMemberName(RawIdentifier(RawIdentifier(id)))} = ();")
-    out.puts(s"${privateMemberName(id)} = ();")
+      out.puts(s"${privateMemberName(RawIdentifier(RawIdentifier(id)))} = [];")
+    out.puts(s"${privateMemberName(id)} = [];")
   }
 
   override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {


### PR DESCRIPTION
The perl compiler currently initialises member variables for conditionally repeating types to an empty array.  When parsing elements, it treats the variable as an arrayref, which results in the variable type being automatically changed to an arrayref.  However, this causes breakages in cases where no items are added to the array, since the variable type remains as an array rather than an arrayref.  The proper behaviour should be to initialise the member variable as an empty arrayref (i.e. `[]`) rather than an array (`()`).

For example, consider the following example code generated by kaitai-struct-compiler:

```perl
sub _read {
    my ($self) = @_;

    $self->{array} = ();
    while (!$self->{_io}->is_eof()) {
        push @{$self->{array}}, ChildElement->new($self->{_io}, $self, $self->{_root});
    }
}
```

If the `while` condition evaluates to true at least one time, then `push` statement will execute, which changes the type of `$self->{array}` from an array to an arrayref.  But if the `while` condition never evaluates to true, then `$self->{array}` will remain an an array type.

The correct code to generate should be:

```perl
sub _read {
    my ($self) = @_;

    $self->{array} = [];
    while (!$self->{_io}->is_eof()) {
        push @{$self->{array}}, ChildElement->new($self->{_io}, $self, $self->{_root});
    }
}
```

The following test-case demonstrates how the current approach causes an `Can't use an undefined value as an ARRAY reference` error and how it is fixed by using the proposed change:

```perl
#!/usr/bin/perl -w
use strict;

my $self = {};

sub try_print() {
    eval { print "\t", @{$self->{array}}, "\n" };
    warn $@ if $@;
}

print "current behaviour -> works if at least one item is pushed\n";
$self->{array} = ();
push @{$self->{array}}, "test";
try_print();

print "current behaviour -> broken if no item is pushed\n";
$self->{array} = ();
try_print();

print "new behaviour -> works when one item is pushed\n";
$self->{array} = [];
push @{$self->{array}}, "test";
try_print();

print "new behaviour -> works when no item is pushed\n";
$self->{array} = [];
try_print();
```