### PR TITLE
Fix some Perl array tests

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -520,7 +520,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "Long.parseLong(\"12345\", 10)",
     JavaScriptCompiler -> "Number.parseInt(\"12345\", 10)",
     LuaCompiler -> "tonumber(\"12345\")",
-    PerlCompiler -> "\"12345\"",
+    PerlCompiler -> "\"12345\" + 0",
     PHPCompiler -> "intval(\"12345\", 10)",
     PythonCompiler -> "int(u\"12345\")",
     RubyCompiler -> "\"12345\".to_i"

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -297,7 +297,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "new ArrayList<Integer>(Arrays.asList(0, 1, 100500))",
     JavaScriptCompiler -> "[0, 1, 100500]",
     LuaCompiler -> "{0, 1, 100500}",
-    PerlCompiler -> "(0, 1, 100500)",
+    PerlCompiler -> "[0, 1, 100500]",
     PHPCompiler -> "[0, 1, 100500]",
     PythonCompiler -> "[0, 1, 100500]",
     RubyCompiler -> "[0, 1, 100500]"
@@ -601,7 +601,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "new ArrayList<Integer>(Arrays.asList())",
     JavaScriptCompiler -> "[]",
     LuaCompiler -> "{}",
-    PerlCompiler -> "()",
+    PerlCompiler -> "[]",
     PHPCompiler -> "[]",
     PythonCompiler -> "[]",
     RubyCompiler -> "[]"
@@ -614,7 +614,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "new ArrayList<Double>(Arrays.asList())",
     JavaScriptCompiler -> "[]",
     LuaCompiler -> "{}",
-    PerlCompiler -> "()",
+    PerlCompiler -> "[]",
     PHPCompiler -> "[]",
     PythonCompiler -> "[]",
     RubyCompiler -> "[]"
@@ -641,7 +641,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "new ArrayList<Integer>(Arrays.asList(0, 1, 2))",
     JavaScriptCompiler -> "[0, 1, 2]",
     LuaCompiler -> "{0, 1, 2}",
-    PerlCompiler -> "(0, 1, 2)",
+    PerlCompiler -> "[0, 1, 2]",
     PHPCompiler -> "[0, 1, 2]",
     PythonCompiler -> "[0, 1, 2]",
     RubyCompiler -> "[0, 1, 2]"

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -396,7 +396,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaScriptCompiler -> "this.a.length",
     LuaCompiler -> "#self.a",
     PHPCompiler -> "count($this->a())",
-    PerlCompiler -> "scalar($self->a())",
+    PerlCompiler -> "scalar(@{$self->a()})",
     PythonCompiler -> "len(self.a)",
     RubyCompiler -> "a.length"
   ))

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -347,6 +347,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "a().get((int) 42)",
     JavaScriptCompiler -> "this.a[42]",
     LuaCompiler -> "self.a[43]",
+    PerlCompiler -> "@{$self->a()}[42]",
     PHPCompiler -> "$this->a()[42]",
     PythonCompiler -> "self.a[42]",
     RubyCompiler -> "a[42]"
@@ -359,6 +360,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "a().get((42 - 2))",
     JavaScriptCompiler -> "this.a[(42 - 2)]",
     LuaCompiler -> "self.a[(43 - 2)]",
+    PerlCompiler -> "@{$self->a()}[(42 - 2)]",
     PHPCompiler -> "$this->a()[(42 - 2)]",
     PythonCompiler -> "self.a[(42 - 2)]",
     RubyCompiler -> "a[(42 - 2)]"
@@ -371,6 +373,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "a().get(0)",
     JavaScriptCompiler -> "this.a[0]",
     LuaCompiler -> "self.a[1]",
+    PerlCompiler -> "@{$self->a()}[0]",
     PHPCompiler -> "$this->a()[0]",
     PythonCompiler -> "self.a[0]",
     RubyCompiler -> "a.first"
@@ -383,6 +386,7 @@ class TranslatorSpec extends AnyFunSuite {
     JavaCompiler -> "a().get(a().size() - 1)",
     JavaScriptCompiler -> "this.a[this.a.length - 1]",
     LuaCompiler -> "self.a[#self.a]",
+    PerlCompiler -> "@{$self->a()}[-1]",
     PHPCompiler -> "$this->a()[count($this->a()) - 1]",
     PythonCompiler -> "self.a[-1]",
     RubyCompiler -> "a.last"


### PR DESCRIPTION
This PR fixes the following tests from the [latest](https://github.com/kaitai-io/kaitai_struct_compiler/actions/runs/6617138800/job/17972853486) run
```
[info] - perl:[0, 1, 100500] *** FAILED ***
[info]   "[[0, 1, 100500]]" was not equal to "[(0, 1, 100500)]" (TranslatorSpec.scala:718)
[info]   Analysis:
[info]   "[[0, 1, 100500]]" -> "[(0, 1, 100500)]"
...
[info] - perl:a[42] *** FAILED ***
[info]   no expected result, but actual result is @{$self->a()}[42] (TranslatorSpec.scala:720)
...
[info] - perl:a[42 - 2] *** FAILED ***
[info]   no expected result, but actual result is @{$self->a()}[(42 - 2)] (TranslatorSpec.scala:720)
...
[info] - perl:a.first *** FAILED ***
[info]   no expected result, but actual result is @{$self->a()}[0] (TranslatorSpec.scala:720)
...
[info] - perl:a.last *** FAILED ***
[info]   no expected result, but actual result is @{$self->a()}[-1] (TranslatorSpec.scala:720)
[info] - perl:a.size *** FAILED ***
[info]   "scalar([@{$self->a()}])" was not equal to "scalar([$self->a()])" (TranslatorSpec.scala:718)
[info]   Analysis:
[info]   "scalar([@{$self->a()}])" -> "scalar([$self->a()])"
...
[info] - perl:"12345".to_i *** FAILED ***
[info]   ""12345"[ + 0]" was not equal to ""12345"[]" (TranslatorSpec.scala:718)
[info]   Analysis:
[info]   ""12345"[ + 0]" -> ""12345"[]"
...
[info] - perl:[].as<u1[]> *** FAILED ***
[info]   "[[]]" was not equal to "[()]" (TranslatorSpec.scala:718)
[info]   Analysis:
[info]   "[[]]" -> "[()]"
...
[info] - perl:[].as<f8[]> *** FAILED ***
[info]   "[[]]" was not equal to "[()]" (TranslatorSpec.scala:718)
[info]   Analysis:
[info]   "[[]]" -> "[()]"
...
[info] - perl:[0, 1, 2].as<u1[]> *** FAILED ***
[info]   "[[0, 1, 2]]" was not equal to "[(0, 1, 2)]" (TranslatorSpec.scala:718)
[info]   Analysis:
[info]   "[[0, 1, 2]]" -> "[(0, 1, 2)]"
```
Note: I do not known Perl, but those issues seems easy to fix