### PR TITLE
use kaitai_struct_visualizer's ksdump

### DIFF
--- a/shared/do_not_read_exhausted_stream.patch
+++ b/shared/do_not_read_exhausted_stream.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/kaitai/struct/visualizer/parser.rb b/lib/kaitai/struct/visualizer/parser.rb
+index e109fd1..52e68e3 100644
+--- a/lib/kaitai/struct/visualizer/parser.rb
++++ b/lib/kaitai/struct/visualizer/parser.rb
+@@ -24,11 +24,11 @@ module Kaitai::Struct::Visualizer
+       main_class_name = @compiler.compile_formats_if(@formats_fn)
+ 
+       main_class = Kernel.const_get(main_class_name)
+-      @data = main_class.from_file(@bin_fn)
+ 
+       load_exc = nil
+       begin
+-        @data._read
++        @data = main_class.from_file(@bin_fn)
++        #@data._read
+       rescue EOFError => e
+         load_exc = e
+       rescue Kaitai::Struct::Stream::UnexpectedDataError => e

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -8,7 +8,8 @@ import io.kaitai.struct.precompile.{EnumNotFoundError, FieldNotFoundError, TypeN
 import io.kaitai.struct.translators.TypeProvider
 
 class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends TypeProvider {
-  var nowClass = topClass
+  var nowClass: ClassSpec = topClass
+  val allClasses: ClassSpecs = classSpecs
 
   var _currentIteratorType: Option[DataType] = None
   var _currentSwitchType: Option[DataType] = None

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -68,7 +68,7 @@ class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends
     * @param inClass type specification to search member in
     * @param attrName name of a member to search for
     * @return member spec if found, or throws an exception
-    * @throws format.InvalidIdentifier if attribute name is not a valid name for a member
+    * @throws InvalidIdentifier if attribute name is not a valid name for a member
     * @throws precompile.FieldNotFoundError if attribute with such name is not found
     */
   def resolveMember(inClass: ClassSpec, attrName: String): MemberSpec = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -33,8 +33,14 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def outFileName(topClassName: String): String = s"$topClassName.rb"
   override def indent: String = "  "
 
-  override def outImports(topClass: ClassSpec) =
+  override def outImports(topClass: ClassSpec) = {
+    import java.nio.file.Paths
+    val path = topClass.fileName.get
+    val fileName = java.nio.file.Paths.get(path).getFileName.toString.replace(".ksy", "")
+    val spec = typeProvider.allClasses.get(fileName).get
+    spec.meta.imports.foreach(path => importList.add(path))
     importList.toList.map((x) => s"require '$x'").mkString("\n") + "\n"
+  }
 
   override def fileHeader(topClassName: String): Unit = {
     outHeader.puts(s"# $headerComment")
@@ -478,7 +484,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"raise ${ksErrorName(err)}.new($errArgsStr) if not ${translator.translate(checkExpr)}")
   }
 
-  def types2class(names: List[String]) = names.map(type2class).mkString("::")
+  def types2class(names: List[String]) = type2class(names.last) //.map(type2class).mkString("::")
 }
 
 object RubyCompiler extends LanguageCompilerStatic


### PR DESCRIPTION
`RubyCompiler.scala` produces working code,  `shared/do_not_read_exhausted_stream.patch` corrects `lib/kaitai/struct/visualizer/parser.rb`