### PR TITLE
CanonicalizeEncodingNames: fix locale-sensitive `toUpperCase`

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/precompile/CanonicalizeEncodingNames$Test.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/precompile/CanonicalizeEncodingNames$Test.scala
@@ -32,6 +32,8 @@ class CanonicalizeEncodingNames$Test extends AnyFunSpec {
     }
 
     it("reports warning and fixes bad capitalization for 'iSo-8859-1' even in Turkish locale") {
+      // This test only covers the case conversion in the `canonicalizeName` implementation,
+      // not the case conversions used when initializing the `aliasToCanonical` map.
       val oldLocale = Locale.getDefault
       Locale.setDefault(new Locale("tr"))
       try {

--- a/jvm/src/test/scala/io/kaitai/struct/precompile/CanonicalizeEncodingNames$Test.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/precompile/CanonicalizeEncodingNames$Test.scala
@@ -3,6 +3,7 @@ package io.kaitai.struct.precompile
 import io.kaitai.struct.problems._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
+import java.util.Locale
 
 class CanonicalizeEncodingNames$Test extends AnyFunSpec {
   describe("CanonicalizeEncodingNames.") {
@@ -28,6 +29,18 @@ class CanonicalizeEncodingNames$Test extends AnyFunSpec {
       val (newEncoding, problem) = CanonicalizeEncodingNames.canonicalizeName("iSo-8859-1")
       newEncoding should be("ISO-8859-1")
       problem should be(Some(EncodingNameWarning("ISO-8859-1", "iSo-8859-1")))
+    }
+
+    it("reports warning and fixes bad capitalization for 'iSo-8859-1' even in Turkish locale") {
+      val oldLocale = Locale.getDefault
+      Locale.setDefault(new Locale("tr"))
+      try {
+        val (newEncoding, problem) = CanonicalizeEncodingNames.canonicalizeName("iSo-8859-1")
+        newEncoding should be("ISO-8859-1")
+        problem should be(Some(EncodingNameWarning("ISO-8859-1", "iSo-8859-1")))
+      } finally {
+        Locale.setDefault(oldLocale)
+      }
     }
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/precompile/CanonicalizeEncodingNames.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/CanonicalizeEncodingNames.scala
@@ -5,6 +5,7 @@ import io.kaitai.struct.datatype.DataType.StrFromBytesType
 import io.kaitai.struct.format._
 import io.kaitai.struct.precompile.CanonicalizeEncodingNames._
 import io.kaitai.struct.problems._
+import io.kaitai.struct.Platform
 
 class CanonicalizeEncodingNames(specs: ClassSpecs) extends PrecompileStep {
   override def run(): Iterable[CompilationProblem] = specs.mapRec(canonicalize)
@@ -48,7 +49,7 @@ object CanonicalizeEncodingNames {
       (original, None)
     } else {
       // See if any aliases match
-      aliasToCanonical.get(original.toUpperCase) match {
+      aliasToCanonical.get(Platform.toUpperLocaleInsensitive(original)) match {
         case Some(canonical) =>
           (
             canonical,
@@ -65,7 +66,7 @@ object CanonicalizeEncodingNames {
 
   private val aliasToCanonical: Map[String, String] =
     EncodingList.canonicalToAlias.flatMap { case (canonical, aliases) =>
-      aliases.map(alias => (alias.toUpperCase, canonical))
+      aliases.map(alias => (Platform.toUpperLocaleInsensitive(alias), canonical))
     } ++
-      EncodingList.canonicalToAlias.keys.map(x => x.toUpperCase -> x)
+      EncodingList.canonicalToAlias.keys.map(x => Platform.toUpperLocaleInsensitive(x) -> x)
 }


### PR DESCRIPTION
Avoid the problem with the Turkish locale that we have encountered in the past, see https://github.com/kaitai-io/kaitai_struct/issues/708.