### PR TITLE
Fix `ks-opaque-types: true` and duplicate warnings if imports are used

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -10,8 +10,9 @@ import io.kaitai.struct.problems._
   * A collection of methods that resolves user types and enum types, i.e.
   * converts names into ClassSpec / EnumSpec references.
   */
-class ResolveTypes(specs: ClassSpecs, opaqueTypes: Boolean) extends PrecompileStep {
-  override def run(): Iterable[CompilationProblem] = specs.mapRec(resolveUserTypes)
+class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean) extends PrecompileStep {
+  override def run(): Iterable[CompilationProblem] =
+    topClass.mapRec(resolveUserTypes).map(problem => problem.localizedInType(topClass))
 
   /**
     * Resolves user types and enum types recursively starting from a certain

--- a/shared/src/main/scala/io/kaitai/struct/precompile/StyleCheckIds.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/StyleCheckIds.scala
@@ -6,11 +6,14 @@ import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.format._
 import io.kaitai.struct.problems._
 
-class StyleCheckIds(specs: ClassSpecs, topClass: ClassSpec) extends PrecompileStep {
-  val provider = new ClassTypeProvider(specs, topClass)
+class StyleCheckIds(specs: ClassSpecs) extends PrecompileStep {
+  val provider = new ClassTypeProvider(specs, specs.firstSpec)
 
   override def run(): Iterable[CompilationProblem] =
-    specs.mapRec(processType)
+    specs.mapTopLevel((_, typeSpec) => {
+      provider.topClass = typeSpec
+      typeSpec.mapRec(processType)
+    })
 
   def processType(spec: ClassSpec): Iterable[CompilationProblem] = {
     provider.nowClass = spec

--- a/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
@@ -17,8 +17,8 @@ import scala.reflect.ClassTag
   * @param specs bundle of class specifications (used only to find external references)
   * @param topClass class to start check with
   */
-class TypeValidator(specs: ClassSpecs, topClass: ClassSpec) extends PrecompileStep {
-  val provider = new ClassTypeProvider(specs, topClass)
+class TypeValidator(specs: ClassSpecs) extends PrecompileStep {
+  val provider = new ClassTypeProvider(specs, specs.firstSpec)
   val detector = new ExpressionValidator(provider)
 
   /**


### PR DESCRIPTION
Fixes https://github.com/kaitai-io/kaitai_struct/issues/295

Fixes duplication of warnings and non-fatal errors as shown in https://github.com/kaitai-io/kaitai_struct/issues/1063

The existing code structure hinted that the `precompile(classSpecs: ClassSpecs, topClass: ClassSpec)` overload should precompile only the `topClass` specified, but its actual implementation for the most part didn't use `topClass` at all and only passed `classSpecs` to all precompilation steps, which processed all types in the given `ClassSpecs`. Given that the `precompile(classSpecs: ClassSpecs, topClass: ClassSpec)` overload is called from the `precompile(specs: ClassSpecs)` overload for each type in `ClassSpecs`, this resulted in unnecessary repeated precompilation of all types when imports are used (because then there is more than 1 type in `ClassSpecs`).

If there are `N` top-level types in `ClassSpecs`, instead of running the precompile phase only once for each top-level type, it was run `N` times per each top-level type, resulting in `N**2` total precompilations of top-level types. This is not only unnecessary, but it also had some observable negative effects, e.g. a single warning being reported to the console `N` times (and `N >= 2` any time you use imports) instead of just once (see https://github.com/kaitai-io/kaitai_struct/issues/1063).

Another problem was caused by the only actual use of `topClass` in the `precompile(classSpecs: ClassSpecs, topClass: ClassSpec)` overload, namely for checking if opaque types are enabled or not (according to the `/meta/ks-opaque-types` key) and passing the setting to the `ResolveTypes` precompile step. This meant that if one spec had opaque types enabled and the other disabled, they would be rejected even in the spec where they should be enabled (because `ResolveTypes` processed all specs first with opaque types enabled and then once more with them disabled), as reported in https://github.com/kaitai-io/kaitai_struct/issues/295.

This commit ensures that each `ClassSpec` of `ClassSpecs` is precompiled only once, eliminating both of the problems mentioned.