### PR TITLE
Fix string pattern tests

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -685,15 +685,15 @@ class TranslatorSpec extends AnyFunSuite {
 
   full("f\"abc{1}%def\"", CalcIntType, CalcStrType, Map[LanguageCompilerStatic, String](
     CppCompiler -> "std::string(\"abc\") + kaitai::kstream::to_string(1) + std::string(\"%def\")",
-    CSharpCompiler -> "\"abc\" + Convert.ToString((long) (1), 10) + \"%def\"",
+    CSharpCompiler -> "\"abc\" + (1).ToString() + \"%def\"",
     GoCompiler -> "fmt.Sprintf(\"abc%v%%def\", 1)",
-    JavaCompiler -> "\"abc\" + Long.toString(1, 10) + \"%def\"",
-    JavaScriptCompiler -> "\"abc\" + (1).toString(10) + \"%def\"",
+    JavaCompiler -> "\"abc\" + Long.toString(1) + \"%def\"",
+    JavaScriptCompiler -> "\"abc\" + (1).toString() + \"%def\"",
     LuaCompiler -> "\"abc\" .. tostring(1) .. \"%def\"",
     PerlCompiler -> "\"abc\" . sprintf('%d', 1) . \"\\%def\"",
     PHPCompiler -> "\"abc\" . strval(1) . \"%def\"",
     PythonCompiler -> "u\"abc\" + str(1) + u\"%def\"",
-    RubyCompiler -> "\"abc\" + 1.to_s(10) + \"%def\"",
+    RubyCompiler -> "\"abc\" + 1.to_s + \"%def\"",
   ))
 
   /**

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -689,7 +689,7 @@ class TranslatorSpec extends AnyFunSuite {
     GoCompiler -> "fmt.Sprintf(\"abc%v%%def\", 1)",
     JavaCompiler -> "\"abc\" + Long.toString(1, 10) + \"%def\"",
     JavaScriptCompiler -> "\"abc\" + (1).toString(10) + \"%def\"",
-    LuaCompiler -> "\"abc\" + tostring(1) + \"%def\"",
+    LuaCompiler -> "\"abc\" .. tostring(1) .. \"%def\"",
     PerlCompiler -> "\"abc\" . sprintf('%d', 1) . \"\\%def\"",
     PHPCompiler -> "\"abc\" . strval(1) . \"%def\"",
     PythonCompiler -> "u\"abc\" + str(1) + u\"%def\"",


### PR DESCRIPTION
This PR fixes the following errors:
```

[info] - csharp:f"abc{1}%def" *** FAILED ***
[info]   ""abc" + [(1).ToString(]) + "%def"" was not equal to ""abc" + [Convert.ToString((long) (1), 10]) + "%def"" (TranslatorSpec.scala:686)
[info]   Analysis:
[info]   ""abc" + [(1).ToString(]) + "%def"" -> ""abc" + [Convert.ToString((long) (1), 10]) + "%def""
[info] - java:f"abc{1}%def" *** FAILED ***
[info]   "...c" + Long.toString(1[]) + "%def"" was not equal to "...c" + Long.toString(1[, 10]) + "%def"" (TranslatorSpec.scala:686)
[info]   Analysis:
[info]   "...c" + Long.toString(1[]) + "%def"" -> "...c" + Long.toString(1[, 10]) + "%def""
[info] - javascript:f"abc{1}%def" *** FAILED ***
[info]   "...abc" + (1).toString([]) + "%def"" was not equal to "...abc" + (1).toString([10]) + "%def"" (TranslatorSpec.scala:686)
[info]   Analysis:
[info]   "...abc" + (1).toString([]) + "%def"" -> "...abc" + (1).toString([10]) + "%def""
[info] - lua:f"abc{1}%def" *** FAILED ***
[info]   ""abc" [.. tostring(1) ..] "%def"" was not equal to ""abc" [+ tostring(1) +] "%def"" (TranslatorSpec.scala:686)
[info]   Analysis:
[info]   ""abc" [.. tostring(1) ..] "%def"" -> ""abc" [+ tostring(1) +] "%def""
[info] - ruby:f"abc{1}%def" *** FAILED ***
[info]   ""abc" + 1.to_s[] + "%def"" was not equal to ""abc" + 1.to_s[(10)] + "%def"" (TranslatorSpec.scala:686)
[info]   Analysis:
[info]   ""abc" + 1.to_s[] + "%def"" -> ""abc" + 1.to_s[(10)] + "%def""
```

One of it is using wrong concatenation operator for Lua -- is should be `..`, not `+`.
The others is a change in to_string translation, explicit base 10 was removed in 7be4a2b1163e14441b3d9cd609a5829cd20c5383.