### PR TITLE
Fix deprecation warnings from Scala 2.13.0

### DIFF
--- a/js/src/main/scala/io/kaitai/struct/format/JavaScriptKSYParser.scala
+++ b/js/src/main/scala/io/kaitai/struct/format/JavaScriptKSYParser.scala
@@ -34,7 +34,7 @@ object JavaScriptKSYParser {
       case _: String | _: Int | _: Double | _: Boolean =>
         src
       case dict =>
-        dict.asInstanceOf[js.Dictionary[AnyRef]].toMap.mapValues(yamlJavascriptToScala)
+        dict.asInstanceOf[js.Dictionary[AnyRef]].toMap.view.mapValues(yamlJavascriptToScala).toMap
     }
   }
 }

--- a/jvm/src/main/scala/io/kaitai/struct/formats/JavaKSYParser.scala
+++ b/jvm/src/main/scala/io/kaitai/struct/formats/JavaKSYParser.scala
@@ -10,9 +10,9 @@ import io.kaitai.struct.{Log, Main}
 import org.yaml.snakeyaml.error.MarkedYAMLException
 import org.yaml.snakeyaml.{LoaderOptions, Yaml}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
 
 object JavaKSYParser {
   def localFileToSpecs(yamlFilename: String, config: CLIConfig): (Option[ClassSpecs], Iterable[CompilationProblem]) = {

--- a/shared/src/main/scala/io/kaitai/struct/Utils.scala
+++ b/shared/src/main/scala/io/kaitai/struct/Utils.scala
@@ -102,14 +102,14 @@ object Utils {
 
   /**
     * Joins collection together to make a single string. Makes extra exception for empty
-    * collections (not like [[TraversableOnce]] `mkString`).
+    * collections (not like [[IterableOnce]] `mkString`).
     * @param start the starting string.
     * @param sep   the separator string.
     * @param end   the ending string.
     * @return If the collection is empty, returns empty string, otherwise returns `start`,
     *         then elements of the collection, every pair separated with `sep`, then `end`.
     */
-  def join[T](coll: TraversableOnce[T], start: String, sep: String, end: String): String =
+  def join[T](coll: IterableOnce[T], start: String, sep: String, end: String): String =
     if (coll.isEmpty) "" else coll.mkString(start, sep, end)
 
   /**

--- a/shared/src/main/scala/io/kaitai/struct/Utils.scala
+++ b/shared/src/main/scala/io/kaitai/struct/Utils.scala
@@ -96,7 +96,7 @@ object Utils {
     if (s.isEmpty) {
       s
     } else {
-      s.charAt(0).toUpper + s.substring(1)
+      s.charAt(0).toUpper.toString + s.substring(1)
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/Utils.scala
+++ b/shared/src/main/scala/io/kaitai/struct/Utils.scala
@@ -109,8 +109,10 @@ object Utils {
     * @return If the collection is empty, returns empty string, otherwise returns `start`,
     *         then elements of the collection, every pair separated with `sep`, then `end`.
     */
-  def join[T](coll: IterableOnce[T], start: String, sep: String, end: String): String =
-    if (coll.isEmpty) "" else coll.mkString(start, sep, end)
+  def join[T](coll: IterableOnce[T], start: String, sep: String, end: String): String = {
+    val it = coll.iterator
+    if (it.isEmpty) "" else it.mkString(start, sep, end)
+  }
 
   /**
     * Converts byte array (Seq[Byte]) into hex-escaped C-style literal characters

--- a/shared/src/main/scala/io/kaitai/struct/format/KSVersion.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/KSVersion.scala
@@ -75,7 +75,7 @@ object KSVersion {
     */
   private var _current: Option[KSVersion] = None
 
-  def current_=(str: String) {
+  def current_=(str: String): Unit = {
     _current = Some(KSVersion.fromStr(str))
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -92,7 +92,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts
   }
 
-  override def classConstructorFooter(): Unit = {
+  override def classConstructorFooter: Unit = {
     out.puts
     out.puts("return $self;")
     universalFooter

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -159,7 +159,7 @@ abstract class LanguageCompiler(
   def instanceFooter: Unit
   def instanceCheckCacheAndReturn(instName: InstanceIdentifier, dataType: DataType): Unit
   def instanceReturn(instName: InstanceIdentifier, attrType: DataType): Unit
-  def instanceCalculate(instName: Identifier, dataType: DataType, value: Ast.expr)
+  def instanceCalculate(instName: Identifier, dataType: DataType, value: Ast.expr): Unit
 
   def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(Long, EnumValueSpec)]): Unit
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/UniversalDoc.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/UniversalDoc.scala
@@ -9,5 +9,5 @@ trait UniversalDoc extends LanguageCompiler {
   override def classDoc(name: List[String], doc: DocSpec) = universalDoc(doc)
   override def attributeDoc(id: Identifier, doc: DocSpec) = universalDoc(doc)
 
-  def universalDoc(doc: DocSpec)
+  def universalDoc(doc: DocSpec): Unit
 }


### PR DESCRIPTION
I just followed suggestions from compiler. This PR fixes most of warnings that reported by new compiler.

The only not addressed deprecation warnings are:
```
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala:197:24: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): implicit conversions from Array to immutable.IndexedSeq are implemented by copying; use `toIndexedSeq` explicitly if you want to copy, or use the more efficient non-copying ArraySeq.unsafeWrapArray
[warn]           byteArray.map(x => Ast.expr.IntNum(x & 0xff))
[warn]                        ^
```
If I understand correctly, `.map()` returns a mutable array which is implicitly converted to immutable `Seq` by copying. I do not know what the best strategy to fix those warnings so I did not touch them.