### PR TITLE
Ignore configuration of scalameta.metals VSCode Extension (Scala language server)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ project/boot/
 .cache
 .bsp
 
+# scalameta.metals VSCode Extension (Scala language server)
+.bloop/
+metals.sbt
+
 # Unpacking complete binaries for testing purposes
 /runnable
 js/npm


### PR DESCRIPTION
Today I installed new Scala LSP plugin in VSCode (scalameta.metals) and it creates many files of its configuration. I think, it is supposed to ignore them