### PR TITLE
Fix cpp pointers warnings - remove unfinished SharedPointers option

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
+++ b/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
@@ -45,7 +45,6 @@ case class CppRuntimeConfig(
 object CppRuntimeConfig {
   sealed trait Pointers
   case object RawPointers extends Pointers
-  case object SharedPointers extends Pointers
   case object UniqueAndRawPointers extends Pointers
 }
 

--- a/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
+++ b/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
@@ -44,7 +44,19 @@ case class CppRuntimeConfig(
 
 object CppRuntimeConfig {
   sealed trait Pointers
+  /**
+    * Use `T*` for holding fields of kaitai-defined types and as return value
+    * of getters.
+    *
+    * Default setting for C++98 target.
+    */
   case object RawPointers extends Pointers
+  /**
+    * Use `std::unique_ptr<T>` for holding fields of kaitai-defined types.
+    * Use `T*` as return value of getters.
+    *
+    * Default setting for C++11 target.
+    */
   case object UniqueAndRawPointers extends Pointers
 }
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -2,7 +2,7 @@ package io.kaitai.struct.translators
 
 import java.nio.charset.Charset
 
-import io.kaitai.struct.CppRuntimeConfig.{RawPointers, SharedPointers, UniqueAndRawPointers}
+import io.kaitai.struct.CppRuntimeConfig.{RawPointers, UniqueAndRawPointers}
 import io.kaitai.struct.datatype.DataType
 import io.kaitai.struct.datatype.DataType._
 import io.kaitai.struct.exprlang.Ast
@@ -161,18 +161,6 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
   override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
     s"((${translate(condition)}) ? (${translate(ifTrue)}) : (${translate(ifFalse)}))"
   override def doCast(value: Ast.expr, typeName: DataType): String =
-    config.cppConfig.pointers match {
-      case RawPointers | UniqueAndRawPointers =>
-        cppStaticCast(value, typeName)
-      case SharedPointers =>
-        typeName match {
-          case ut: UserType =>
-            s"std::static_pointer_cast<${CppCompiler.types2class(ut.classSpec.get.name)}>(${translate(value)})"
-          case _ => cppStaticCast(value, typeName)
-        }
-    }
-
-  def cppStaticCast(value: Ast.expr, typeName: DataType): String =
     s"static_cast<${CppCompiler.kaitaiType2NativeType(config.cppConfig, typeName)}>(${translate(value)})"
 
   // Predefined methods of various types


### PR DESCRIPTION
In `SharedPointers` mode compiler is never generate the correct code and in many cases just throw `MatchError` due to missing arms in switches.

It was not even possible to ran compiler with this settings, so it is better to remove it for now, until it will be fully implemented. If you wish to keep the work, you can then revert the first commit and create a draft PR with it and wait when someone will finish it.

Fixes the following warnings (13):
```
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:511:26: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]         config.cppConfig.pointers match {
[warn]                          ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:511:26: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]         config.cppConfig.pointers match {
[warn]                          ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:727:22: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]     config.cppConfig.pointers match {
[warn]                      ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:870:24: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       config.cppConfig.pointers match {
[warn]                        ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:980:22: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]     config.cppConfig.pointers match {
[warn]                      ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:727:22: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]     config.cppConfig.pointers match {
[warn]                      ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:1103:48: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       case ArrayTypeInStream(inType) => config.pointers match {
[warn]                                                ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:1108:44: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       case OwnedKaitaiStreamType => config.pointers match {
[warn]                                            ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:870:24: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       config.cppConfig.pointers match {
[warn]                        ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:980:22: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]     config.cppConfig.pointers match {
[warn]                      ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:1103:48: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       case ArrayTypeInStream(inType) => config.pointers match {
[warn]                                                ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala:1108:44: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       case OwnedKaitaiStreamType => config.pointers match {
[warn]                                            ^
[warn] /home/runner/work/kaitai_struct_compiler/kaitai_struct_compiler/compiler/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala:106:24: match may not be exhaustive.
[warn] It would fail on the following input: SharedPointers
[warn]       config.cppConfig.pointers match {
[warn]                        ^
```