### PR TITLE
Implement `doByteArrayNonLiteral` for Lua and C++

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -854,7 +854,7 @@ class TranslatorSpec extends AnyFunSpec {
     describe("to do type enforcement") {
       // type enforcement: casting to non-literal byte array
       full("[0 + 1, 5].as<bytes>", CalcIntType, CalcBytesType, ResultMap(
-        CppCompiler -> "???",
+        CppCompiler -> "std::string({static_cast<char>(0 + 1), static_cast<char>(5)})",
         CSharpCompiler -> "new byte[] { 0 + 1, 5 }",
         GoCompiler -> "[]uint8{0 + 1, 5}",
         JavaCompiler -> "new byte[] { 0 + 1, 5 }",

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -859,7 +859,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "[]uint8{0 + 1, 5}",
         JavaCompiler -> "new byte[] { 0 + 1, 5 }",
         JavaScriptCompiler -> "new Uint8Array([0 + 1, 5])",
-        LuaCompiler -> "???",
+        LuaCompiler -> "string.char(0 + 1, 5)",
         PerlCompiler -> "pack('C*', (0 + 1, 5))",
         PHPCompiler -> "pack('C*', 0 + 1, 5)",
         PythonCompiler -> "struct.pack('2B', 0 + 1, 5)",

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -113,7 +113,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
         // TODO: C++14
       }
     } else {
-      throw new RuntimeException("C++ literal arrays are not implemented yet without list initializers")
+      throw new RuntimeException("literal arrays are not yet implemented for C++98 (pass `--cpp-standard 11` to target C++11)")
     }
   }
 
@@ -126,7 +126,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     } else {
       // TODO: We need to produce an expression, but this is possible only with initializer lists
       // or variadic templates (if use a helper function) which both available only since C++11
-      throw new RuntimeException("C++ non-literal arrays are not implemented yet without list initializers")
+      throw new RuntimeException("non-literal byte arrays are not yet implemented for C++98 (pass `--cpp-standard 11` to target C++11)")
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -124,8 +124,9 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     if (config.cppConfig.useListInitializers) {
       "std::string({" + values.map(value => s"static_cast<char>(${translate(value)})").mkString(", ") + "})"
     } else {
-      // TODO: We need to produce an expression, but this is possible only with initializer lists
-      // or variadic templates (if use a helper function) which both available only since C++11
+      // TODO: We need to produce an expression, but this is only possible using
+      // initializer lists or variadic templates (if we use a helper function),
+      // both of which are only available since C++11
       throw new RuntimeException("non-literal byte arrays are not yet implemented for C++98 (pass `--cpp-standard 11` to target C++11)")
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -67,10 +67,14 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
 
   override def doBoolLiteral(n: Boolean): String =
     if (n) "true" else "false"
+
   override def doArrayLiteral(t: DataType, value: Seq[Ast.expr]): String =
     "{" + value.map((v) => translate(v)).mkString(", ") + "}"
   override def doByteArrayLiteral(arr: Seq[Byte]): String =
     "\"" + decEscapeByteArray(arr) + "\""
+  override def doByteArrayNonLiteral(values: Seq[Ast.expr]): String =
+    // It is assumed that every expression produces integer in the range [0; 255]
+    "string.char(" + values.map(translate).mkString(", ") + ")"
 
   override def doLocalName(s: String) = s match {
     case Identifier.ITERATOR => "_"


### PR DESCRIPTION
Fixes the test:
```
[info]     - lua:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       scala.NotImplementedError: an implementation is missing
[info]       at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
[info]       at io.kaitai.struct.translators.BaseTranslator.doByteArrayNonLiteral(BaseTranslator.scala:179)
[info]       at io.kaitai.struct.translators.BaseTranslator.doByteArrayNonLiteral(BaseTranslator.scala:28)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doByteArray(CommonArraysAndCast.scala:85)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doCastOrArray(CommonArraysAndCast.scala:62)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doCastOrArray$(CommonArraysAndCast.scala:53)
[info]       at io.kaitai.struct.translators.BaseTranslator.doCastOrArray(BaseTranslator.scala:28)
[info]       at io.kaitai.struct.translators.BaseTranslator.translate(BaseTranslator.scala:147)
[info]       at io.kaitai.struct.translators.AbstractTranslator.translate(AbstractTranslator.scala:25)
[info]       at io.kaitai.struct.translators.AbstractTranslator.translate$(AbstractTranslator.scala:25)
[info]       ...
```
Looking at existing implementations for other languages I suspect that the missing implementation in both cases was just an oversight when `doByteArrayNonLiteral` was added.

C++ test
```
[info]     - cpp_stl:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       scala.NotImplementedError: an implementation is missing
[info]       at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
[info]       at io.kaitai.struct.translators.BaseTranslator.doByteArrayNonLiteral(BaseTranslator.scala:179)
[info]       at io.kaitai.struct.translators.BaseTranslator.doByteArrayNonLiteral(BaseTranslator.scala:28)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doByteArray(CommonArraysAndCast.scala:85)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doCastOrArray(CommonArraysAndCast.scala:62)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doCastOrArray$(CommonArraysAndCast.scala:53)
[info]       at io.kaitai.struct.translators.BaseTranslator.doCastOrArray(BaseTranslator.scala:28)
[info]       at io.kaitai.struct.translators.BaseTranslator.translate(BaseTranslator.scala:147)
[info]       at io.kaitai.struct.translators.AbstractTranslator.translate(AbstractTranslator.scala:25)
[info]       at io.kaitai.struct.translators.AbstractTranslator.translate$(AbstractTranslator.scala:25)
[info]       ...
```
now converted to another failure
```
[info]     - cpp_stl:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       java.lang.RuntimeException: C++ literal arrays are not implemented yet
[info]       at io.kaitai.struct.translators.CppTranslator.doArrayLiteral(CppTranslator.scala:114)
[info]       at io.kaitai.struct.translators.CppTranslator.doByteArrayNonLiteral(CppTranslator.scala:121)
[info]       at io.kaitai.struct.translators.CppTranslator.doByteArrayNonLiteral(CppTranslator.scala:15)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doByteArray(CommonArraysAndCast.scala:85)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doCastOrArray(CommonArraysAndCast.scala:62)
[info]       at io.kaitai.struct.translators.CommonArraysAndCast.doCastOrArray$(CommonArraysAndCast.scala:53)
[info]       at io.kaitai.struct.translators.BaseTranslator.doCastOrArray(BaseTranslator.scala:28)
[info]       at io.kaitai.struct.translators.BaseTranslator.translate(BaseTranslator.scala:146)
[info]       at io.kaitai.struct.translators.TranslatorSpec.$anonfun$runTest$4(TranslatorSpec.scala:789)
[info]       at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]       ...
```
which is because of unimplemented feature (tracked in #932).

Note, that it would be worth to test targets with options, such as C++, with different set of options. Right now only default options are used.