### PR TITLE
Python/Construct: Use `unsigned char` representation when converting to `bytes`

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -675,7 +675,7 @@ class TranslatorSpec extends AnyFunSpec {
         LuaCompiler -> "???",
         PerlCompiler -> "pack('C*', ((0 + 1), 5))",
         PHPCompiler -> "pack('C*', (0 + 1), 5)",
-        PythonCompiler -> "struct.pack('2b', (0 + 1), 5)",
+        PythonCompiler -> "struct.pack('2B', (0 + 1), 5)",
         RubyCompiler -> "[(0 + 1), 5].pack('C*')"
       ))
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -40,7 +40,8 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList) extends B
     "b\"" + Utils.hexEscapeByteArray(arr) + "\""
   override def doByteArrayNonLiteral(elts: Seq[Ast.expr]): String = {
     importList.add("import struct")
-    s"struct.pack('${elts.length}b', ${elts.map(translate).mkString(", ")})"
+    // Use `unsigned char` representation (see https://docs.python.org/3/library/struct.html#struct-format-strings)
+    s"struct.pack('${elts.length}B', ${elts.map(translate).mkString(", ")})"
   }
 
   override def doLocalName(s: String) = {


### PR DESCRIPTION
Currently Python (and Construct) KST test `tests\formats\expr_bytes_non_literal.ksy`
```yaml
meta:
  id: expr_bytes_non_literal
seq:
  - id: one
    type: u1
  - id: two
    type: u1
instances:
  calc_bytes:
    value: '[one, two].as<bytes>'
```
failed with the following error:
```
Traceback (most recent call last):
  File "/tests/spec/construct/test_expr_bytes_non_literal.py", line 9, in test_expr_bytes_non_literal
    r = _schema.parse_file('src/enum_negative.bin')
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 309, in parse_file
    return self.parse_stream(f, **contextkw)
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 300, in parse_stream
    return self._parsereport(stream, context, "(parsing)")
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 312, in _parsereport
    obj = self._parse(stream, context, path)
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 1982, in _parse
    subobj = sc._parsereport(stream, context, path)
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 312, in _parsereport
    obj = self._parse(stream, context, path)
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 2440, in _parse
    return self.subcon._parsereport(stream, context, path)
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 312, in _parsereport
    obj = self._parse(stream, context, path)
  File "/usr/local/lib/python2.7/site-packages/construct/core.py", line 2576, in _parse
    return self.func(context) if callable(self.func) else self.func
  File "/tests/compiled/construct/expr_bytes_non_literal.py", line 8, in <lambda>
    'calc_bytes' / Computed(lambda this: struct.pack('2b', this.one, this.two)),
error: byte format requires -128 <= number <= 127
```
The reason is because [`PythonTranslator` uses](https://github.com/kaitai-io/kaitai_struct_compiler/blob/6aef6faeb00d4800d493460bc0f83483e60bad01/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala#L41-L44) [`signed char`](https://docs.python.org/3/library/struct.html#format-characters) representation of bytes when casting to `bytes` type using `struct.pack('Nb')`, but it tries to pack from `u1` (unsigned) integers. So `0xFF` from test data raises an error.

It is unclear, what to do here. I speculate, that we expect that arrays for conversion must contain integers in the range [0; 255] and implement it in my PR, but that is only my assumption. I suspect is it correct, although, because both Perl and Ruby uses `'C*'` which in both means `unsigned char`s.

Also, I think, we should add tests with `s1` types, alone and mixed with `u1` types. What the expected result of converting arrays of such values to `bytes` type?