### PR TITLE
Pass `_root` and `_parent` to all local and no external types

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
@@ -58,8 +58,8 @@ class ClassCompiler(
     curClass.params.foreach((paramDefSpec) =>
       paramDefSpec.dataType match {
         case ut: UserType =>
-          val externalTypeName = ut.classSpec.get.name
-          if (externalTypeName.head != curClass.name.head) {
+          if (ut.isExternal(curClass)) {
+            val externalTypeName = ut.classSpec.get.name
             lang.classForwardDeclaration(externalTypeName)
           }
         case _ => // no forward declarations needed

--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -164,10 +164,12 @@ object DataType {
   ) extends StructType {
     var classSpec: Option[ClassSpec] = None
     /**
-     * Determines whether the user type represented by this `UserType` instance
-     * is external from the perspective of the given `ClassSpec` in which it is
-     * used (via `seq`, `instances` or `params`).
-     */
+      * Determines whether the user type represented by this `UserType` instance
+      * is external from the perspective of the given `ClassSpec` in which it is
+      * used (via `seq`, `instances` or `params`).
+      * @param curClass class spec from which the local/external relationship
+      * should be evaluated
+      */
     def isExternal(curClass: ClassSpec): Boolean =
       classSpec.get.isExternal(curClass)
     def isOpaque = {

--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -163,6 +163,13 @@ object DataType {
     var args: Seq[Ast.expr]
   ) extends StructType {
     var classSpec: Option[ClassSpec] = None
+    /**
+     * Determines whether the user type represented by this `UserType` instance
+     * is external from the perspective of the given `ClassSpec` in which it is
+     * used (via `seq`, `instances` or `params`).
+     */
+    def isExternal(curClass: ClassSpec): Boolean =
+      classSpec.get.isExternal(curClass)
     def isOpaque = {
       val cs = classSpec.get
       cs.isTopLevel || cs.meta.isOpaque

--- a/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
@@ -79,10 +79,12 @@ case class ClassSpec(
   def parentType: DataType = parentClass.toDataType
 
   /**
-   * Determines whether this `ClassSpec` represents a type that is external
-   * (i.e. not defined in the same .ksy file) from the perspective of the given
-   * `ClassSpec`.
-   */
+    * Determines whether this `ClassSpec` represents a type that is external
+    * (i.e. not defined in the same .ksy file) from the perspective of the given
+    * `ClassSpec`.
+    * @param curClass class spec from which the local/external relationship
+    * should be evaluated
+    */
   def isExternal(curClass: ClassSpec): Boolean =
     name.head != curClass.name.head
 

--- a/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ClassSpec.scala
@@ -79,6 +79,14 @@ case class ClassSpec(
   def parentType: DataType = parentClass.toDataType
 
   /**
+   * Determines whether this `ClassSpec` represents a type that is external
+   * (i.e. not defined in the same .ksy file) from the perspective of the given
+   * `ClassSpec`.
+   */
+  def isExternal(curClass: ClassSpec): Boolean =
+    name.head != curClass.name.head
+
+  /**
     * Recursively traverses tree of types starting from this type, calling
     * certain function for every type, starting from this one.
     *

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -370,7 +370,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         s"$io.ReadBitsInt${Utils.upperCamelCase(bitEndian.toSuffix)}($width)"
       case t: UserType =>
         val addParams = Utils.join(t.args.map((a) => translator.translate(a)), "", ", ", ", ")
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -691,7 +691,7 @@ class CppCompiler(
         s"$io->read_bits_int_${bitEndian.toSuffix}($width)"
       case t: UserType =>
         val addParams = Utils.join(t.args.map((a) => translator.translate(a)), "", ", ", ", ")
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -409,7 +409,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       case BitsType(width: Int, bitEndian) =>
         s"$io.ReadBitsInt${Utils.upperCamelCase(bitEndian.toSuffix)}($width)"
       case t: UserType =>
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -444,7 +444,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       case BitsType(width: Int, bitEndian) =>
         s"$io.readBitsInt${Utils.upperCamelCase(bitEndian.toSuffix)}($width)"
       case t: UserType =>
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -326,7 +326,7 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       s"$io:read_bits_int_${bitEndian.toSuffix}($width)"
     case t: UserType =>
       val addParams = Utils.join(t.args.map((a) => translator.translate(a)), "", ", ", ", ")
-      val addArgs = if (t.isOpaque) {
+      val addArgs = if (t.isExternal(typeProvider.nowClass)) {
         ""
       } else {
         val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -336,7 +336,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         s"$io->readBitsInt${Utils.upperCamelCase(bitEndian.toSuffix)}($width)"
       case t: UserType =>
         val addParams = Utils.join(t.args.map((a) => translator.translate(a)), "", ", ", ", ")
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -296,7 +296,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
       case BitsType(width: Int, bitEndian) =>
         s"$io->read_bits_int_${bitEndian.toSuffix}($width)"
       case t: UserType =>
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -368,7 +368,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         s"$io.read_bits_int_${bitEndian.toSuffix}($width)"
       case t: UserType =>
         val addParams = Utils.join(t.args.map((a) => translator.translate(a)), "", ", ", ", ")
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {
@@ -502,9 +502,8 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   def userType2class(t: UserType): String = {
     val name = t.classSpec.get.name
-    val firstName = name.head
-    val prefix = if (t.isOpaque && firstName != translator.provider.nowClass.name.head) {
-      s"$firstName."
+    val prefix = if (t.isExternal(typeProvider.nowClass)) {
+      s"${name.head}."
     } else {
       ""
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -344,7 +344,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         s"$io.read_bits_int_${bitEndian.toSuffix}($width)"
       case t: UserType =>
         val addParams = Utils.join(t.args.map((a) => translator.translate(a)), ", ", ", ", "")
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -319,7 +319,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         s"$io.read_bits_int($width)?"
       case t: UserType =>
         val addParams = Utils.join(t.args.map((a) => translator.translate(a)), "", ", ", ", ")
-        val addArgs = if (t.isOpaque) {
+        val addArgs = if (t.isExternal(typeProvider.nowClass)) {
           ""
         } else {
           val parent = t.forcedParent match {

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ParentTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ParentTypes.scala
@@ -68,7 +68,6 @@ class ParentTypes(classSpecs: ClassSpecs) {
   }
 
   def markupParentAs(curClass: ClassSpec, ut: UserType): Unit = {
-    Log.typeProcParent.info(() => s"..... class=$ut has parent=${curClass.nameAsStr}")
     ut.classSpec match {
       case Some(usedClass) =>
         markupParentAs(curClass, usedClass)
@@ -79,6 +78,10 @@ class ParentTypes(classSpecs: ClassSpecs) {
   }
 
   def markupParentAs(parent: ClassSpec, child: ClassSpec): Unit = {
+    // Don't allow type usages across spec boundaries to affect parent resolution
+    if (child.isExternal(parent))
+      return
+    Log.typeProcParent.info(() => s"..... class=${child.nameAsStr} has parent=${parent.nameAsStr}")
     child.parentClass match {
       case UnknownClassSpec =>
         child.parentClass = parent

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ParentTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ParentTypes.scala
@@ -79,8 +79,10 @@ class ParentTypes(classSpecs: ClassSpecs) {
 
   def markupParentAs(parent: ClassSpec, child: ClassSpec): Unit = {
     // Don't allow type usages across spec boundaries to affect parent resolution
-    if (child.isExternal(parent))
+    if (child.isExternal(parent)) {
+      Log.typeProcParent.info(() => s"..... cross-spec usage of class=${child.nameAsStr} from parent=${parent.nameAsStr} ignored")
       return
+    }
     Log.typeProcParent.info(() => s"..... class=${child.nameAsStr} has parent=${parent.nameAsStr}")
     child.parentClass match {
       case UnknownClassSpec =>

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -457,12 +457,16 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
 
   def userType(t: UserType, io: String) = {
     val v = allocateLocalVar()
-    val parent = t.forcedParent match {
-      case Some(USER_TYPE_NO_PARENT) => "nil"
-      case Some(fp) => translate(fp)
-      case None => "this"
+    val (parent, root) = if (t.isExternal(provider.nowClass)) {
+      ("nil", "nil")
+    } else {
+      val parent = t.forcedParent match {
+        case Some(USER_TYPE_NO_PARENT) => "nil"
+        case Some(fp) => translate(fp)
+        case None => "this"
+      }
+      (parent, "this._root")
     }
-    val root = if (t.isOpaque) "nil" else "this._root"
     val addParams = t.args.map((a) => translate(a)).mkString(", ")
     out.puts(s"${localVarName(v)} := New${GoCompiler.types2class(t.classSpec.get.name)}($addParams)")
     out.puts(s"err = ${localVarName(v)}.Read($io, $parent, $root)")


### PR DESCRIPTION
* Fixes https://github.com/kaitai-io/kaitai_struct/issues/1089

  Previously, `_root` and `_parent` weren't passed to the local top-level type, which is fixed by this PR.

  This was demonstrated by tests NavRootRecursive and NavParentRecursive added in https://github.com/kaitai-io/kaitai_struct_tests/commit/5941262e

* Fixes https://github.com/kaitai-io/kaitai_struct/issues/963

  `_root` and `_parent` were incorrectly passed to nested types of imported specs (i.e. external types).

  This was demonstrated by asserts in the [KST spec of test NestedTypesImport](https://github.com/kaitai-io/kaitai_struct_tests/blob/d07deb4c/spec/ks/nested_types_import.kst#L17-L32).