### PR TITLE
KS expression language: adjust tests after optimizations in parenthesis generation

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -855,15 +855,15 @@ class TranslatorSpec extends AnyFunSpec {
       // type enforcement: casting to non-literal byte array
       full("[0 + 1, 5].as<bytes>", CalcIntType, CalcBytesType, ResultMap(
         CppCompiler -> "???",
-        CSharpCompiler -> "new byte[] { (0 + 1), 5 }",
-        GoCompiler -> "[]uint8{(0 + 1), 5}",
-        JavaCompiler -> "new byte[] { (0 + 1), 5 }",
-        JavaScriptCompiler -> "new Uint8Array([(0 + 1), 5])",
+        CSharpCompiler -> "new byte[] { 0 + 1, 5 }",
+        GoCompiler -> "[]uint8{0 + 1, 5}",
+        JavaCompiler -> "new byte[] { 0 + 1, 5 }",
+        JavaScriptCompiler -> "new Uint8Array([0 + 1, 5])",
         LuaCompiler -> "???",
-        PerlCompiler -> "pack('C*', ((0 + 1), 5))",
-        PHPCompiler -> "pack('C*', (0 + 1), 5)",
-        PythonCompiler -> "struct.pack('2B', (0 + 1), 5)",
-        RubyCompiler -> "[(0 + 1), 5].pack('C*')"
+        PerlCompiler -> "pack('C*', (0 + 1, 5))",
+        PHPCompiler -> "pack('C*', 0 + 1, 5)",
+        PythonCompiler -> "struct.pack('2B', 0 + 1, 5)",
+        RubyCompiler -> "[0 + 1, 5].pack('C*')"
       ))
 
       // type enforcement: casting to array of integers


### PR DESCRIPTION
In #277 some optimizations was made in parenthesis generation, but not all tests were updated. This PR updates them.

Fixes this new errors (parenthesis around expression is not generated anymore):
```
[info]     - csharp:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "new byte[] { [0 + 1], 5 }" was not equal to "new byte[] { [(0 + 1)], 5 }" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "new byte[] { [0 + 1], 5 }" -> "new byte[] { [(0 + 1)], 5 }"
[info]     - go:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "[]uint8{[0 + 1], 5}" was not equal to "[]uint8{[(0 + 1)], 5}" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "[]uint8{[0 + 1], 5}" -> "[]uint8{[(0 + 1)], 5}"
[info]     - java:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "new byte[] { [0 + 1], 5 }" was not equal to "new byte[] { [(0 + 1)], 5 }" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "new byte[] { [0 + 1], 5 }" -> "new byte[] { [(0 + 1)], 5 }"
[info]     - javascript:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "new Uint8Array([[0 + 1], 5])" was not equal to "new Uint8Array([[(0 + 1)], 5])" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "new Uint8Array([[0 + 1], 5])" -> "new Uint8Array([[(0 + 1)], 5])"

[info]     - perl:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "pack('C*', ([0 + 1], 5))" was not equal to "pack('C*', ([(0 + 1)], 5))" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "pack('C*', ([0 + 1], 5))" -> "pack('C*', ([(0 + 1)], 5))"
[info]     - php:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "pack('C*', [0 + 1], 5)" was not equal to "pack('C*', [(0 + 1)], 5)" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "pack('C*', [0 + 1], 5)" -> "pack('C*', [(0 + 1)], 5)"
[info]     - python:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "struct.pack('2B', [0 + 1], 5)" was not equal to "struct.pack('2B', [(0 + 1)], 5)" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "struct.pack('2B', [0 + 1], 5)" -> "struct.pack('2B', [(0 + 1)], 5)"
[info]     - ruby:[0 + 1, 5].as<bytes> *** FAILED ***
[info]       "[[0 + 1], 5].pack('C*')" was not equal to "[[(0 + 1)], 5].pack('C*')" (TranslatorSpec.scala:856)
[info]       Analysis:
[info]       "[[0 + 1], 5].pack('C*')" -> "[[(0 + 1)], 5].pack('C*')"
```