### PR TITLE
Use a filename (with a fallback to root type name) in locations of import errors

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/precompile/LoadImports.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/LoadImports.scala
@@ -32,7 +32,7 @@ class LoadImports(specs: ClassSpecs) {
         loadImport(
           name,
           curClass.meta.path ++ List("imports", idx.toString),
-          Some(curClass.nameAsStr),
+          Some(curClass.fileNameAsStr),
           workDir
         )
       }).map((x) => x.flatten)


### PR DESCRIPTION
Fixes the test:
```
[info] - meta_imports_abs_unknown *** FAILED ***
[info]   meta_imports_abs_unknown: /meta/imports/0:
[info]   	error: unable to find 'unknown_absolute_name.ksy' in import search paths, using: List()
[info]    did not equal meta_imports_abs_unknown.ksy: /meta/imports/0:
[info]   	error: unable to find 'unknown_absolute_name.ksy' in import search paths, using: List() (SimpleMatchers.scala:34)
```

Changes filename in the following tests:
```
[info] - meta_imports_rel2 *** FAILED ***
[info]   meta_imports_rel_unknown: /meta/imports/0:
[info]   	error: unknown_relative_name.ksy (No such file or directory)
[info]    did not equal meta_imports_rel_unknown: /meta/imports/0:
[info]   	error: ../tests/formats_err/unknown_relative_name.ksy (No such file or directory) (SimpleMatchers.scala:34)
[info] - meta_imports_rel_unknown *** FAILED ***
[info]   meta_imports_rel_unknown: /meta/imports/0:
[info]   	error: unknown_relative_name.ksy (No such file or directory)
[info]    did not equal meta_imports_rel_unknown: /meta/imports/0:
[info]   	error: ../tests/formats_err/unknown_relative_name.ksy (No such file or directory) (SimpleMatchers.scala:34)
```

Corresponding PR in `kaitai_struct_tests` repository that fixes tests accordingly:
- https://github.com/kaitai-io/kaitai_struct_tests/pull/107