### PR TITLE
ErrorMessagesSpec: make failures easier to read

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/SimpleMatchers.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/SimpleMatchers.scala
@@ -29,7 +29,7 @@ trait SimpleMatchers {
     def shouldEqualPlainly(right: Any)(implicit equality: Equality[T]): Assertion =
       if (!equality.areEqual(leftSideValue, right)) {
         throw new exceptions.TestFailedException(
-          (e: exceptions.StackDepthException) => Some(s"""${leftSideValue} did not equal ${right}"""),
+          (e: exceptions.StackDepthException) => Some(s"""[${leftSideValue}]\n  did not equal\n[${right}]"""),
           None,
           Position.here
         )


### PR DESCRIPTION
Old output of `sbt test`:

```
ErrorMessagesSpec:
- attr_invalid_switch_inner *** FAILED ***
  attr_invalid_switch_inner.ksy: /seq/1/size:
  	error: invalid type: expected integer, got CalcBooleanType

  attr_invalid_switch_inner.ksy: /seq/1/size:
  	error: invalid type: expected integer, got CalcBooleanType
   did not equal attr_invalid_switch_inner.ksy: /seq/1/size:
  	error: invalid type: expected integer, got CalcBooleanType (SimpleMatchers.scala:34)
```

New output of `sbt test`:

```
ErrorMessagesSpec:
- attr_invalid_switch_inner *** FAILED ***
  [attr_invalid_switch_inner.ksy: /seq/1/size:
         error: invalid type: expected integer, got CalcBooleanType

  attr_invalid_switch_inner.ksy: /seq/1/size:
         error: invalid type: expected integer, got CalcBooleanType
  ]
    did not equal
  [attr_invalid_switch_inner.ksy: /seq/1/size:
         error: invalid type: expected integer, got CalcBooleanType
  ] (SimpleMatchers.scala:34)
```