### PR TITLE
Multiply also `METHOD_PRECEDENCE` constant to match new precedence of operators

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala
@@ -145,7 +145,7 @@ abstract trait CommonMethods[T] extends TypeDetector {
     *  - if `obj` is complex (like an expression `a + b`), then this will ensure framing as
     *    `(a + b).method(args)`.
     */
-  val METHOD_PRECEDENCE = 99
+  val METHOD_PRECEDENCE = 990
 
   /**
     * Translates a certain attribute call (as in `foo.bar`) into a rendition


### PR DESCRIPTION
The last commit multiply precedence of all operators by 10x, but the constant `METHOD_PRECEDENCE` remains unchanged and as a results many tests failed.

Please, be careful and checks the CI results. I see good efforts in the last time to make CI green and I hope we can do that, but until that we need to be focuses and check results manually.

The ever-falling CI relaxes, so it's just overlooked, and then gets stupid bugs in the code.