### PR TITLE
Implement optimal parenthesis for ternary operator + add tests

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -122,7 +122,7 @@ abstract class BaseTranslator(val provider: TypeProvider)
       case Ast.expr.BoolOp(op: Ast.boolop, values: Seq[Ast.expr]) =>
         doBooleanOp(op, values)
       case Ast.expr.IfExp(condition, ifTrue, ifFalse) =>
-        doIfExp(condition, ifTrue, ifFalse)
+        doIfExp(condition, ifTrue, ifFalse, extPrec)
       case Ast.expr.Subscript(container: Ast.expr, idx: Ast.expr) =>
         detectType(idx) match {
           case _: IntType =>
@@ -152,7 +152,6 @@ abstract class BaseTranslator(val provider: TypeProvider)
     }
   }
 
-  def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String
   def doCast(value: Ast.expr, typeName: DataType): String = translate(value)
   def doByteSizeOfType(typeName: Ast.typeId): String = doIntLiteral(
     CommonSizeOf.bitToByteSize(
@@ -192,8 +191,10 @@ abstract class BaseTranslator(val provider: TypeProvider)
   // Predefined methods of various types
   def strConcat(left: Ast.expr, right: Ast.expr, extPrec: Int) =
     genericBinOp(left, Ast.operator.Add, right, extPrec)
-  def boolToInt(value: Ast.expr): String =
-    doIfExp(value, Ast.expr.IntNum(1), Ast.expr.IntNum(0))
+  def boolToInt(value: Ast.expr): String = {
+    // TODO: fix METHOD_PRECEDENCE with proper propagation
+    doIfExp(value, Ast.expr.IntNum(1), Ast.expr.IntNum(0), METHOD_PRECEDENCE)
+  }
 
   def kaitaiStreamSize(value: Ast.expr): String = anyField(value, "size")
   def kaitaiStreamEof(value: Ast.expr): String = anyField(value, "is_eof")

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -86,8 +86,6 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container, METHOD_PRECEDENCE)}[${translate(idx)}]"
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
-    s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
   override def doCast(value: Ast.expr, typeName: DataType): String =
     s"((${CSharpCompiler.kaitaiType2NativeType(typeName)}) (${translate(value)}))"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonOps.scala
@@ -26,6 +26,8 @@ trait CommonOps extends AbstractTranslator {
     Ast.operator.BitOr -> 80,
   )
 
+  val IF_EXP_PRECEDENCE = 30
+
   def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int): String =
     genericBinOpStr(left, op, binOp(op), right, extPrec)
 
@@ -96,5 +98,17 @@ trait CommonOps extends AbstractTranslator {
     case Ast.unaryop.Invert => "~"
     case Ast.unaryop.Minus => "-"
     case Ast.unaryop.Not => "!"
+  }
+
+  def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr, extPrec: Int): String = {
+    val conditionStr = translate(condition, IF_EXP_PRECEDENCE)
+    val ifTrueStr = translate(ifTrue, IF_EXP_PRECEDENCE)
+    val ifFalseStr = translate(ifFalse, IF_EXP_PRECEDENCE)
+    val fullStr = s"$conditionStr ? $ifTrueStr : $ifFalseStr"
+    if (IF_EXP_PRECEDENCE <= extPrec) {
+      s"($fullStr)"
+    } else {
+      fullStr
+    }
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -128,7 +128,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
   }
 
   override def anyField(value: expr, attrName: String): String =
-    s"${translate(value)}->${doName(attrName)}"
+    s"${translate(value, METHOD_PRECEDENCE)}->${doName(attrName)}"
 
   override def doName(s: String) = s match {
     case Identifier.ITERATOR => "_"
@@ -158,8 +158,6 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}->at(${translate(idx)})"
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
-    s"((${translate(condition)}) ? (${translate(ifTrue)}) : (${translate(ifFalse)}))"
   override def doCast(value: Ast.expr, typeName: DataType): String =
     config.cppConfig.pointers match {
       case RawPointers | UniqueAndRawPointers =>

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -67,8 +67,6 @@ class JavaScriptTranslator(provider: TypeProvider) extends BaseTranslator(provid
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}[${translate(idx)}]"
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
-    s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
 
   // Predefined methods of various types
   override def strToInt(s: expr, base: expr): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -100,8 +100,6 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}.get((int) ${translate(idx, METHOD_PRECEDENCE)})"
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
-    s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
   override def doCast(value: Ast.expr, typeName: DataType): String =
     s"((${JavaCompiler.kaitaiType2JavaType(typeName)}) (${translate(value)}))"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -58,7 +58,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
     // Lua indexes start at 1, so we need to offset them
     s"${translate(container)}[${translate(idx)} + 1]"
   }
-  override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String = {
+  override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr, extPrec: Int): String = {
     importList.add("local utils = require(\"utils\")")
 
     // http://lua-users.org/wiki/TernaryOperator (section Boxing/unboxing, using functions)

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -37,7 +37,7 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
       case Identifier.ROOT => s"${ksToNim(provider.determineType(Identifier.ROOT))}(this.${doName(s)})"
       case _ => s"this.${doName(s)}"
     }
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
+  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr, extPrec: Int): String =
     s"(if ${translate(condition)}: ${translate(ifTrue)} else: ${translate(ifFalse)})"
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}[${translate(idx)}]"

--- a/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
@@ -54,7 +54,7 @@ class PHPTranslator(provider: TypeProvider, config: RuntimeConfig) extends BaseT
   }
 
   override def anyField(value: expr, attrName: String): String =
-    s"${translate(value)}->${doName(attrName)}"
+    s"${translate(value, METHOD_PRECEDENCE)}->${doName(attrName)}"
 
   override def doLocalName(s: String) = {
     s match {
@@ -80,8 +80,6 @@ class PHPTranslator(provider: TypeProvider, config: RuntimeConfig) extends BaseT
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}[${translate(idx)}]"
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
-    s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
 
   // Predefined methods of various types
   override def strConcat(left: expr, right: expr, extPrec: Int) =

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -54,7 +54,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     s"pack('C*', (${elts.map(translate).mkString(", ")}))"
 
   override def anyField(value: Ast.expr, attrName: String): String =
-    s"${translate(value)}->${doName(attrName)}"
+    s"${translate(value, METHOD_PRECEDENCE)}->${doName(attrName)}"
 
   override def doLocalName(s: String) = {
     s match {
@@ -108,8 +108,6 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
 
   override def arraySubscript(container: Ast.expr, idx: Ast.expr): String =
     s"@{${translate(container)}}[${translate(idx)}]"
-  override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String =
-    s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
 
   // Predefined methods of various types
   override def strConcat(left: Ast.expr, right: Ast.expr, extPrec: Int) =

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -73,8 +73,17 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList) extends B
 
   override def arraySubscript(container: Ast.expr, idx: Ast.expr): String =
     s"${translate(container)}[${translate(idx)}]"
-  override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String =
-    s"(${translate(ifTrue)} if ${translate(condition)} else ${translate(ifFalse)})"
+  override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr, extPrec: Int): String = {
+    val conditionStr = translate(condition, IF_EXP_PRECEDENCE)
+    val ifTrueStr = translate(ifTrue, IF_EXP_PRECEDENCE)
+    val ifFalseStr = translate(ifFalse, IF_EXP_PRECEDENCE)
+    val fullStr = s"$ifTrueStr if $conditionStr else $ifFalseStr"
+    if (IF_EXP_PRECEDENCE <= extPrec) {
+      s"($fullStr)"
+    } else {
+      fullStr
+    }
+  }
 
   // Predefined methods of various types
   override def strToInt(s: Ast.expr, base: Ast.expr): String = {

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -69,8 +69,6 @@ class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider)
 
   override def arraySubscript(container: Ast.expr, idx: Ast.expr): String =
     s"${translate(container, METHOD_PRECEDENCE)}[${translate(idx)}]"
-  override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String =
-    s"(${translate(condition)} ? ${translate(ifTrue)} : ${translate(ifFalse)})"
 
   // Predefined methods of various types
   override def strToInt(s: Ast.expr, base: Ast.expr): String = {

--- a/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
@@ -47,7 +47,7 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig) extends Base
 
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}[${translate(idx)}]"
-  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
+  override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr, extPrec: Int): String =
     "if " + translate(condition) +
     	" { " + translate(ifTrue) + " } else { " +
 	translate(ifFalse) + "}"


### PR DESCRIPTION
Another piece of partially contributing to resolving https://github.com/kaitai-io/kaitai_struct/issues/69 — this one handles ternary operator:

* Add common `doIfExp()` implementation (+add `extPrec` propagation into it) into CommonOps, which does a good job at parenthesizing
  * This provides default implementation which is ok for most languages following popular `condition ? ifTrue ? ifFalse` rendering originating from C.
  * Remove individual copy-pasted implementations in specific languages where we can rely on common one.
  * Adjust Python rendering to follow the same correct strategy
  * Don't touch special ad hoc implementations (Lua, Go)
* Add/fix tests proving that it works in many contexts