### PR TITLE
Add missing translator tests for C++, Nim and Rust

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -413,6 +413,7 @@ class TranslatorSpec extends AnyFunSpec {
   describe("arrays") {
     describe("literals") {
       full("[0, 1, 100500]", CalcIntType, ArrayTypeInStream(CalcIntType), ResultMap(
+        CppCompiler -> "",
         CSharpCompiler -> "new List<int> { 0, 1, 100500 }",
         GoCompiler -> "[]int{0, 1, 100500}",
         JavaCompiler -> "new ArrayList<Integer>(Arrays.asList(0, 1, 100500))",
@@ -891,6 +892,7 @@ class TranslatorSpec extends AnyFunSpec {
 
       // type enforcement: casting to array of integers
       full("[0, 1, 2].as<u1[]>", CalcIntType, ArrayTypeInStream(Int1Type(false)), ResultMap(
+        CppCompiler -> "",
         CSharpCompiler -> "new List<byte> { 0, 1, 2 }",
         GoCompiler -> "[]uint8{0, 1, 2}",
         JavaCompiler -> "new ArrayList<Integer>(Arrays.asList(0, 1, 2))",

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -217,7 +217,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "sprintf('%d', 42)",
         PHPCompiler -> "strval(42)",
         PythonCompiler -> "str(42)",
-        RubyCompiler -> "42.to_s"
+        RubyCompiler -> "42.to_s",
+        RustCompiler -> "42.to_string()",
       ))
 
       full("(a + 42).to_s", CalcIntType, CalcStrType, ResultMap(
@@ -230,7 +231,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "sprintf('%d', $self->a() + 42)",
         PHPCompiler -> "strval($this->a() + 42)",
         PythonCompiler -> "str(self.a + 42)",
-        RubyCompiler -> "(a + 42).to_s"
+        RubyCompiler -> "(a + 42).to_s",
+        RustCompiler -> "(self.a + 42).to_string()",
       ))
 
       full("a + 42.to_s", CalcStrType, CalcStrType, ResultMap(
@@ -243,7 +245,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "$self->a() . sprintf('%d', 42)",
         PHPCompiler -> "$this->a() . strval(42)",
         PythonCompiler -> "self.a + str(42)",
-        RubyCompiler -> "a + 42.to_s"
+        RubyCompiler -> "a + 42.to_s",
+        RustCompiler -> "format!(\"{}{}\", self.a, 42.to_string())",
       ))
     }
   }
@@ -266,7 +269,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
       PHPCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
       PythonCompiler -> "(\"foo\" if 2 < 3 else \"bar\")",
-      RubyCompiler -> "(2 < 3 ? \"foo\" : \"bar\")"
+      RubyCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
+      RustCompiler -> "if 2 < 3 { \"foo\".to_string() } else { \"bar\".to_string() }",
     ))
   }
 
@@ -293,7 +297,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "1",
       PHPCompiler -> "true",
       PythonCompiler -> "True",
-      RubyCompiler -> "true"
+      RubyCompiler -> "true",
+      RustCompiler -> "true",
     ))
 
     full("false", CalcBooleanType, CalcBooleanType, ResultMap(
@@ -306,7 +311,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "0",
       PHPCompiler -> "false",
       PythonCompiler -> "False",
-      RubyCompiler -> "false"
+      RubyCompiler -> "false",
+      RustCompiler -> "false",
     ))
   }
 
@@ -326,7 +332,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "$self->some_bool()",
       PHPCompiler -> "intval($this->someBool())",
       PythonCompiler -> "int(self.some_bool)",
-      RubyCompiler -> "(some_bool ? 1 : 0)"
+      RubyCompiler -> "(some_bool ? 1 : 0)",
+      RustCompiler -> "self.some_bool as i32",
     ))
   }
 
@@ -341,7 +348,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "$self->foo_str()",
       PHPCompiler -> "$this->fooStr()",
       PythonCompiler -> "self.foo_str",
-      RubyCompiler -> "foo_str"
+      RubyCompiler -> "foo_str",
+      RustCompiler -> "self.foo_str",
     ))
 
     full("foo_block", userOwnedType(List("block")), userBorrowedType(List("block")), ResultMap(
@@ -354,7 +362,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "$self->foo_block()",
       PHPCompiler -> "$this->fooBlock()",
       PythonCompiler -> "self.foo_block",
-      RubyCompiler -> "foo_block"
+      RubyCompiler -> "foo_block",
+      RustCompiler -> "self.foo_block",
     ))
 
     full("foo.bar", FooBarProvider, CalcStrType, ResultMap(
@@ -367,7 +376,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "$self->foo()->bar()",
       PHPCompiler -> "$this->foo()->bar()",
       PythonCompiler -> "self.foo.bar",
-      RubyCompiler -> "foo.bar"
+      RubyCompiler -> "foo.bar",
+      RustCompiler -> "self.foo.bar",
     ))
 
     full("foo.inner.baz", FooBarProvider, CalcIntType, ResultMap(
@@ -380,7 +390,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "$self->foo()->inner()->baz()",
       PHPCompiler -> "$this->foo()->inner()->baz()",
       PythonCompiler -> "self.foo.inner.baz",
-      RubyCompiler -> "foo.inner.baz"
+      RubyCompiler -> "foo.inner.baz",
+      RustCompiler -> "self.foo.inner.baz",
     ))
 
     full("_root.foo", userOwnedType(List("top_class", "block")), userBorrowedType(List("top_class", "block")), ResultMap(
@@ -393,7 +404,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> "$self->_root()->foo()",
       PHPCompiler -> "$this->_root()->foo()",
       PythonCompiler -> "self._root.foo",
-      RubyCompiler -> "_root.foo"
+      RubyCompiler -> "_root.foo",
+      RustCompiler -> "self._root.foo",
     ))
 
     full("a != 2 and a != 5", CalcIntType, CalcBooleanType, ResultMap(
@@ -406,7 +418,8 @@ class TranslatorSpec extends AnyFunSpec {
       PerlCompiler -> " (($self->a() != 2) && ($self->a() != 5)) ",
       PHPCompiler -> " (($this->a() != 2) && ($this->a() != 5)) ",
       PythonCompiler -> " ((self.a != 2) and (self.a != 5)) ",
-      RubyCompiler -> " ((a != 2) && (a != 5)) "
+      RubyCompiler -> " ((a != 2) && (a != 5)) ",
+      RustCompiler -> " ((self.a != 2) && (self.a != 5)) ",
     ))
   }
 
@@ -422,7 +435,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "[0, 1, 100500]",
         PHPCompiler -> "[0, 1, 100500]",
         PythonCompiler -> "[0, 1, 100500]",
-        RubyCompiler -> "[0, 1, 100500]"
+        RubyCompiler -> "[0, 1, 100500]",
+        RustCompiler -> "vec![0, 1, 100500]",
       ))
 
       full("[34, 0, 10, 64, 65, 66, 92]", CalcIntType, CalcBytesType, ResultMap(
@@ -435,7 +449,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "pack('C*', (34, 0, 10, 64, 65, 66, 92))",
         PHPCompiler -> "\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
         PythonCompiler -> "b\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
-        RubyCompiler -> "[34, 0, 10, 64, 65, 66, 92].pack('C*')"
+        RubyCompiler -> "[34, 0, 10, 64, 65, 66, 92].pack('C*')",
+        RustCompiler -> "vec!([0x22u8, 0x0u8, 0xau8, 0x40u8, 0x41u8, 0x42u8, 0x5cu8])",
       ))
 
       full("[255, 0, 255]", CalcIntType, CalcBytesType, ResultMap(
@@ -448,7 +463,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "pack('C*', (255, 0, 255))",
         PHPCompiler -> "\"\\xFF\\x00\\xFF\"",
         PythonCompiler -> "b\"\\xFF\\x00\\xFF\"",
-        RubyCompiler -> "[255, 0, 255].pack('C*')"
+        RubyCompiler -> "[255, 0, 255].pack('C*')",
+        RustCompiler -> "vec!([0xffu8, 0x0u8, 0xffu8])",
       ))
     }
 
@@ -463,7 +479,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "length(pack('C*', (0, 1, 2)))",
         PHPCompiler -> "strlen(\"\\x00\\x01\\x02\")",
         PythonCompiler -> "len(b\"\\x00\\x01\\x02\")",
-        RubyCompiler -> "[0, 1, 2].pack('C*').size"
+        RubyCompiler -> "[0, 1, 2].pack('C*').size",
+        RustCompiler -> "vec!([0x0, 0x1, 0x2]).len()",
       ))
 
       full("a[42]", ArrayTypeInStream(CalcStrType), CalcStrType, ResultMap(
@@ -476,7 +493,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "@{$self->a()}[42]",
         PHPCompiler -> "$this->a()[42]",
         PythonCompiler -> "self.a[42]",
-        RubyCompiler -> "a[42]"
+        RubyCompiler -> "a[42]",
+        RustCompiler -> "self.a[42]",
       ))
 
       full("a[42 - 2]", ArrayTypeInStream(CalcStrType), CalcStrType, ResultMap(
@@ -489,7 +507,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "@{$self->a()}[42 - 2]",
         PHPCompiler -> "$this->a()[42 - 2]",
         PythonCompiler -> "self.a[42 - 2]",
-        RubyCompiler -> "a[42 - 2]"
+        RubyCompiler -> "a[42 - 2]",
+        RustCompiler -> "self.a[42 - 2]",
       ))
 
       full("a.first", ArrayTypeInStream(CalcIntType), CalcIntType, ResultMap(
@@ -502,7 +521,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "@{$self->a()}[0]",
         PHPCompiler -> "$this->a()[0]",
         PythonCompiler -> "self.a[0]",
-        RubyCompiler -> "a.first"
+        RubyCompiler -> "a.first",
+        RustCompiler -> "self.a.first()",
       ))
 
       full("a.last", ArrayTypeInStream(CalcIntType), CalcIntType, ResultMap(
@@ -517,7 +537,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "@{$self->a()}[-1]",
         PHPCompiler -> "$this->a()[count($this->a()) - 1]",
         PythonCompiler -> "self.a[-1]",
-        RubyCompiler -> "a.last"
+        RubyCompiler -> "a.last",
+        RustCompiler -> "self.a.last()",
       ))
 
       full("a.size", ArrayTypeInStream(CalcIntType), CalcIntType, ResultMap(
@@ -530,7 +551,8 @@ class TranslatorSpec extends AnyFunSpec {
         PHPCompiler -> "count($this->a())",
         PerlCompiler -> "scalar(@{$self->a()})",
         PythonCompiler -> "len(self.a)",
-        RubyCompiler -> "a.length"
+        RubyCompiler -> "a.length",
+        RustCompiler -> "self.a.len()",
       ))
     }
   }
@@ -547,7 +569,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "\"str\"",
         PHPCompiler -> "\"str\"",
         PythonCompiler -> "\"str\"",
-        RubyCompiler -> "\"str\""
+        RubyCompiler -> "\"str\"",
+        RustCompiler -> "\"str\"",
       ))
 
       full("\"str\\nnext\"", CalcIntType, CalcStrType, ResultMap(
@@ -560,7 +583,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "\"str\\nnext\"",
         PHPCompiler -> "\"str\\nnext\"",
         PythonCompiler -> "\"str\\nnext\"",
-        RubyCompiler -> "\"str\\nnext\""
+        RubyCompiler -> "\"str\\nnext\"",
+        RustCompiler -> "\"str\\nnext\"",
       ))
 
       full("\"str\\u000anext\"", CalcIntType, CalcStrType, ResultMap(
@@ -573,7 +597,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "\"str\\nnext\"",
         PHPCompiler -> "\"str\\nnext\"",
         PythonCompiler -> "\"str\\nnext\"",
-        RubyCompiler -> "\"str\\nnext\""
+        RubyCompiler -> "\"str\\nnext\"",
+        RustCompiler -> "\"str\\nnext\"",
       ))
 
       full("\"str\\0next\"", CalcIntType, CalcStrType, ResultMap(
@@ -586,7 +611,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "\"str\\000next\"",
         PHPCompiler -> "\"str\\000next\"",
         PythonCompiler -> "\"str\\000next\"",
-        RubyCompiler -> "\"str\\000next\""
+        RubyCompiler -> "\"str\\000next\"",
+        RustCompiler -> "\"str\\u{0}next\"",
       ))
     }
 
@@ -596,7 +622,8 @@ class TranslatorSpec extends AnyFunSpec {
         LuaCompiler -> "\"str1\" .. \"str2\"",
         PerlCompiler -> "\"str1\" . \"str2\"",
         PHPCompiler -> "\"str1\" . \"str2\"",
-        PythonCompiler -> "\"str1\" + \"str2\""
+        PythonCompiler -> "\"str1\" + \"str2\"",
+        RustCompiler -> "format!(\"{}{}\", \"str1\", \"str2\")",
       ), CalcStrType)
 
       everybodyExcept("\"str1\" == \"str2\"", "\"str1\" == \"str2\"", ResultMap(
@@ -604,7 +631,8 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"str1\".equals(\"str2\")",
         LuaCompiler -> "\"str1\" == \"str2\"",
         PerlCompiler -> "\"str1\" eq \"str2\"",
-        PythonCompiler -> "\"str1\" == \"str2\""
+        PythonCompiler -> "\"str1\" == \"str2\"",
+        RustCompiler -> "\"str1\" == \"str2\".to_string()",
       ), CalcBooleanType)
 
       everybodyExcept("\"str1\" != \"str2\"", "\"str1\" != \"str2\"", ResultMap(
@@ -612,7 +640,8 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "!\"str1\".equals(\"str2\")",
         LuaCompiler -> "\"str1\" ~= \"str2\"",
         PerlCompiler -> "\"str1\" ne \"str2\"",
-        PythonCompiler -> "\"str1\" != \"str2\""
+        PythonCompiler -> "\"str1\" != \"str2\"",
+        RustCompiler -> "\"str1\" != \"str2\".to_string()",
       ), CalcBooleanType)
 
       everybodyExcept("\"str1\" < \"str2\"", "\"str1\" < \"str2\"", ResultMap(
@@ -621,7 +650,8 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "(\"str1\".compareTo(\"str2\") < 0)",
         LuaCompiler -> "\"str1\" < \"str2\"",
         PerlCompiler -> "\"str1\" lt \"str2\"",
-        PythonCompiler -> "\"str1\" < \"str2\""
+        PythonCompiler -> "\"str1\" < \"str2\"",
+        RustCompiler -> "\"str1\" < \"str2\".to_string()",
       ), CalcBooleanType)
     }
 
@@ -636,7 +666,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "length(\"str\")",
         PHPCompiler -> "strlen(\"str\")",
         PythonCompiler -> "len(\"str\")",
-        RubyCompiler -> "\"str\".size"
+        RubyCompiler -> "\"str\".size",
+        RustCompiler -> "\"str\".len()",
       ))
 
       full("(foo + bar).length", CalcStrType, CalcIntType, ResultMap(
@@ -649,7 +680,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "length($self->foo() . $self->bar())",
         PHPCompiler -> "strlen($this->foo() . $this->bar())",
         PythonCompiler -> "len(self.foo + self.bar)",
-        RubyCompiler -> "(foo + bar).size"
+        RubyCompiler -> "(foo + bar).size",
+        RustCompiler -> "format!(\"{}{}\", self.foo, self.bar).len()",
       ))
 
       full("\"str\".reverse", CalcIntType, CalcStrType, ResultMap(
@@ -662,7 +694,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "scalar(reverse(\"str\"))",
         PHPCompiler -> "strrev(\"str\")",
         PythonCompiler -> "(\"str\")[::-1]",
-        RubyCompiler -> "\"str\".reverse"
+        RubyCompiler -> "\"str\".reverse",
+        RustCompiler -> "reverse_string(\"str\")?",
       ))
 
       full("(foo + bar).reverse", CalcStrType, CalcStrType, ResultMap(
@@ -675,7 +708,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "scalar(reverse($self->foo() . $self->bar()))",
         PHPCompiler -> "strrev($this->foo() . $this->bar())",
         PythonCompiler -> "(self.foo + self.bar)[::-1]",
-        RubyCompiler -> "(foo + bar).reverse"
+        RubyCompiler -> "(foo + bar).reverse",
+        RustCompiler -> "reverse_string(format!(\"{}{}\", self.foo, self.bar))?",
       ))
 
       full("\"12345\".to_i", CalcIntType, CalcIntType, ResultMap(
@@ -693,7 +727,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "\"12345\" + 0",
         PHPCompiler -> "intval(\"12345\", 10)",
         PythonCompiler -> "int(\"12345\")",
-        RubyCompiler -> "\"12345\".to_i"
+        RubyCompiler -> "\"12345\".to_i",
+        RustCompiler -> "\"12345\".parse::<i32>().map_err(|_| KError::CastError)?",
       ))
 
       full("\"1234fe\".to_i(16)", CalcIntType, CalcIntType, ResultMap(
@@ -711,7 +746,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "hex(\"1234fe\")",
         PHPCompiler -> "intval(\"1234fe\", 16)",
         PythonCompiler -> "int(\"1234fe\", 16)",
-        RubyCompiler -> "\"1234fe\".to_i(16)"
+        RubyCompiler -> "\"1234fe\".to_i(16)",
+        RustCompiler -> "FromStrRadix::from_str_radix(\"1234fe\", 16).map_err(|_| KError::CastError)?",
       ))
 
       // substring() call on a single string literal
@@ -725,7 +761,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "substr(\"foobar\", 2, 4 - 2)",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring(\"foobar\", 2, 4)",
         PythonCompiler -> "\"foobar\"[2:4]",
-        RubyCompiler -> "\"foobar\"[2...4]"
+        RubyCompiler -> "\"foobar\"[2...4]",
+        RustCompiler -> "\"foobar\"[2..4]",
       ))
 
       // substring() call on concatenation of strings: for some languages, concatenation needs to be
@@ -740,7 +777,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "substr($self->foo() . $self->bar(), 2, 4 - 2)",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo() . $this->bar(), 2, 4)",
         PythonCompiler -> "(self.foo + self.bar)[2:4]",
-        RubyCompiler -> "(foo + bar)[2...4]"
+        RubyCompiler -> "(foo + bar)[2...4]",
+        RustCompiler -> "format!(\"{}{}\", self.foo, self.bar)[2..4]",
       ))
 
       // substring() call with non-left-associative "from" and "to": for languages where subtraction
@@ -755,7 +793,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "substr($self->foo(), 10 - 7, (10 - 3) - (10 - 7))", // TODO: PerlCompiler -> "substr($self->foo(), 10 - 7, 10 - 3 - (10 - 7))",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo(), 10 - 7, 10 - 3)",
         PythonCompiler -> "self.foo[10 - 7:10 - 3]",
-        RubyCompiler -> "foo[10 - 7...10 - 3]"
+        RubyCompiler -> "foo[10 - 7...10 - 3]",
+        RustCompiler -> "self.foo[(10 - 7)..(10 - 3)]",
       ))
 
       // substring() call with "to" using `<<` which is lower precedence than `+` or `-`: if such
@@ -770,7 +809,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "substr($self->foo(), 10 - 7, (10 << 2) - (10 - 7))",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo(), 10 - 7, 10 << 2)",
         PythonCompiler -> "self.foo[10 - 7:10 << 2]",
-        RubyCompiler -> "foo[10 - 7...10 << 2]"
+        RubyCompiler -> "foo[10 - 7...10 << 2]",
+        RustCompiler -> "self.foo[(10 - 7)..(10 << 2)]",
       ))
 
       // substring() call with "from" using `<<` which is lower precedence than `+` or `-`: if such
@@ -785,7 +825,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "substr($self->foo(), 10 << 1, 42 - (10 << 1))",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo(), 10 << 1, 42)",
         PythonCompiler -> "self.foo[10 << 1:42]",
-        RubyCompiler -> "foo[10 << 1...42]"
+        RubyCompiler -> "foo[10 << 1...42]",
+        RustCompiler -> "self.foo[(10 << 1)..42]",
       ))
     }
   }
@@ -802,7 +843,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "$self->other()->bar()",
         PHPCompiler -> "$this->other()->bar()",
         PythonCompiler -> "self.other.bar",
-        RubyCompiler -> "other.bar"
+        RubyCompiler -> "other.bar",
+        RustCompiler -> "self.other.bar", // TODO: RustCompiler: check .as<> casts
       ))
 
       full("other.as<block::innerblock>.baz", FooBarProvider, CalcIntType, ResultMap(
@@ -815,7 +857,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "$self->other()->baz()",
         PHPCompiler -> "$this->other()->baz()",
         PythonCompiler -> "self.other.baz",
-        RubyCompiler -> "other.baz"
+        RubyCompiler -> "other.baz",
+        RustCompiler -> "self.other.baz", // TODO: RustCompiler: check .as<> casts
       ))
     }
 
@@ -830,7 +873,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "1 + 2",
         PHPCompiler -> "1 + 2",
         PythonCompiler -> "1 + 2",
-        RubyCompiler -> "1 + 2"
+        RubyCompiler -> "1 + 2",
+        RustCompiler -> "((1 + 2) as i16)",
       ))
     }
 
@@ -845,7 +889,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "pack('C*', ())",
         PHPCompiler -> "\"\"",
         PythonCompiler -> "b\"\"",
-        RubyCompiler -> "[].pack('C*')"
+        RubyCompiler -> "[].pack('C*')",
+        RustCompiler -> "vec![]",
       ))
 
       full("[].as<u1[]>", CalcIntType, ArrayTypeInStream(Int1Type(false)), ResultMap(
@@ -858,7 +903,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "[]",
         PHPCompiler -> "[]",
         PythonCompiler -> "[]",
-        RubyCompiler -> "[]"
+        RubyCompiler -> "[]",
+        RustCompiler -> "vec![]",
       ))
 
       full("[].as<f8[]>", CalcIntType, ArrayTypeInStream(FloatMultiType(Width8, None)), ResultMap(
@@ -871,7 +917,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "[]",
         PHPCompiler -> "[]",
         PythonCompiler -> "[]",
-        RubyCompiler -> "[]"
+        RubyCompiler -> "[]",
+        RustCompiler -> "vec![]",
       ))
     }
 
@@ -887,7 +934,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "pack('C*', (0 + 1, 5))",
         PHPCompiler -> "pack('C*', 0 + 1, 5)",
         PythonCompiler -> "struct.pack('2B', 0 + 1, 5)",
-        RubyCompiler -> "[0 + 1, 5].pack('C*')"
+        RubyCompiler -> "[0 + 1, 5].pack('C*')",
+        RustCompiler -> "vec![(0 + 1), 5]",
       ))
 
       // type enforcement: casting to array of integers
@@ -901,7 +949,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> "[0, 1, 2]",
         PHPCompiler -> "[0, 1, 2]",
         PythonCompiler -> "[0, 1, 2]",
-        RubyCompiler -> "[0, 1, 2]"
+        RubyCompiler -> "[0, 1, 2]",
+        RustCompiler -> "vec![0, 1, 2]",
       ))
     }
   }
@@ -957,6 +1006,7 @@ class TranslatorSpec extends AnyFunSpec {
       PHPCompiler -> "\"abc\" . strval(1) . \"%def\"",
       PythonCompiler -> "\"abc\" + str(1) + \"%def\"",
       RubyCompiler -> "\"abc\" + 1.to_s + \"%def\"",
+      RustCompiler -> "format!(\"{}{}{}\", \"abc\", 1, \"%def\")",
     ))
   }
 
@@ -987,7 +1037,8 @@ class TranslatorSpec extends AnyFunSpec {
         PerlCompiler -> new PerlTranslator(tp, new ImportList()),
         PHPCompiler -> new PHPTranslator(tp, RuntimeConfig()),
         PythonCompiler -> new PythonTranslator(tp, new ImportList(), RuntimeConfig()),
-        RubyCompiler -> new RubyTranslator(tp)
+        RubyCompiler -> new RubyTranslator(tp),
+        RustCompiler -> new RustTranslator(tp, RuntimeConfig()),
       )
 
       langs.foreach { case (langObj, tr) =>


### PR DESCRIPTION
## Do not merge yet, it is not finished. Not a draft because I want to run CI checks

I noticed that `TranslatorSpec.scala` does not test some languages, which seems to be oversight for Nim, and unfinished work for Rust.

Nim compiler seems to be production ready, so tests needs to be added.

Rust compiler is not finished yet, and tests should make finishing it easy.
