### PR TITLE
Add Nim to TranslatorSpec and fix variaus errors found thanks to that

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -26,7 +26,8 @@ class TranslatorSpec extends AnyFunSpec {
       everybodyExcept("100000000000", "100000000000", ResultMap(
         CppCompiler -> "100000000000LL",
         GoCompiler -> "int64(100000000000)",
-        JavaCompiler -> "100000000000L"
+        JavaCompiler -> "100000000000L",
+        NimCompiler -> "100000000000'i64",
       ))
     }
 
@@ -38,18 +39,21 @@ class TranslatorSpec extends AnyFunSpec {
         CppCompiler -> "2147483648UL",
         GoCompiler -> "uint32(2147483648)",
         JavaCompiler -> "2147483648L",
+        NimCompiler -> "2147483648'i64",
       ))
       // 0xffff_ffff
       everybodyExcept("4294967295", "4294967295", ResultMap(
         CppCompiler -> "4294967295UL",
         GoCompiler -> "uint32(4294967295)",
         JavaCompiler -> "4294967295L",
+        NimCompiler -> "4294967295'i64",
       ))
       // 0x1_0000_0000
       everybodyExcept("4294967296", "4294967296", ResultMap(
         CppCompiler -> "4294967296LL",
         GoCompiler -> "int64(4294967296)",
         JavaCompiler -> "4294967296L",
+        NimCompiler -> "4294967296'i64",
       ))
 
       // -0x7fff_ffff
@@ -65,6 +69,7 @@ class TranslatorSpec extends AnyFunSpec {
         CppCompiler -> "-2147483649LL",
         GoCompiler -> "int64(-2147483649)",
         JavaCompiler -> "-2147483649L",
+        NimCompiler -> "-2147483649'i64",
       ))
 
       // 0x7fff_ffff_ffff_ffff
@@ -72,6 +77,7 @@ class TranslatorSpec extends AnyFunSpec {
         CppCompiler -> "9223372036854775807LL",
         GoCompiler -> "int64(9223372036854775807)",
         JavaCompiler -> "9223372036854775807L",
+        NimCompiler -> "9223372036854775807'i64",
       ))
       // 0x8000_0000_0000_0000
       everybodyExcept("9223372036854775808", "9223372036854775808", ResultMap(
@@ -79,6 +85,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "uint64(9223372036854775808)",
         JavaCompiler -> "0x8000000000000000L",
         LuaCompiler -> "0x8000000000000000",
+        NimCompiler -> "9223372036854775808'u64",
         PHPCompiler -> "-9223372036854775807 - 1",
       ))
       // 0xffff_ffff_ffff_ffff
@@ -87,6 +94,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "uint64(18446744073709551615)",
         JavaCompiler -> "0xffffffffffffffffL",
         LuaCompiler -> "0xffffffffffffffff",
+        NimCompiler -> "18446744073709551615'u64",
         PHPCompiler -> "-1",
       ))
       // -0x7fff_ffff_ffff_ffff
@@ -94,6 +102,7 @@ class TranslatorSpec extends AnyFunSpec {
         CppCompiler -> "-9223372036854775807LL",
         GoCompiler -> "int64(-9223372036854775807)",
         JavaCompiler -> "-9223372036854775807L",
+        NimCompiler -> "-9223372036854775807'i64",
       ))
       // -0x8000_0000_0000_0000
       everybodyExcept("-9223372036854775808", "-9223372036854775808", ResultMap(
@@ -101,6 +110,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "int64(-9223372036854775808)",
         JavaCompiler -> "-9223372036854775808L",
         LuaCompiler -> "-9223372036854775807 - 1",
+        NimCompiler -> "-9223372036854775808'i64",
         PHPCompiler -> "-9223372036854775807 - 1",
       ))
     }
@@ -122,6 +132,7 @@ class TranslatorSpec extends AnyFunSpec {
     everybodyExcept("3 / 2", "3 / 2", ResultMap(
       JavaScriptCompiler -> "Math.floor(3 / 2)",
       LuaCompiler -> "math.floor(3 / 2)",
+      NimCompiler -> "3 div 2",
       PerlCompiler -> "int(3 / 2)",
       PHPCompiler -> "intval(3 / 2)",
       PythonCompiler -> "3 // 2"
@@ -146,6 +157,7 @@ class TranslatorSpec extends AnyFunSpec {
     everybodyExcept("(1 + 2) / (7 * 8)", "(1 + 2) / (7 * 8)", ResultMap(
       JavaScriptCompiler -> "Math.floor((1 + 2) / (7 * 8))",
       LuaCompiler -> "math.floor((1 + 2) / (7 * 8))",
+      NimCompiler -> "(1 + 2) div (7 * 8)",
       PerlCompiler -> "int((1 + 2) / (7 * 8))",
       PHPCompiler -> "intval((1 + 2) / (7 * 8))",
       PythonCompiler -> "(1 + 2) // (7 * 8)"
@@ -154,26 +166,38 @@ class TranslatorSpec extends AnyFunSpec {
     everybodyExcept("3 - ((1 + 2) / (7 * 8) + 5)", "3 - ((1 + 2) / (7 * 8) + 5)", ResultMap(
       JavaScriptCompiler -> "3 - (Math.floor((1 + 2) / (7 * 8)) + 5)",
       LuaCompiler -> "3 - (math.floor((1 + 2) / (7 * 8)) + 5)",
+      NimCompiler -> "3 - ((1 + 2) div (7 * 8) + 5)",
       PerlCompiler -> "3 - (int((1 + 2) / (7 * 8)) + 5)",
       PHPCompiler -> "3 - (intval((1 + 2) / (7 * 8)) + 5)",
       PythonCompiler -> "3 - ((1 + 2) // (7 * 8) + 5)"
     ))
 
-    everybody("1 + 2 << 5", "1 + 2 << 5")
-    everybody("(1 + 2) << 5", "1 + 2 << 5")
-    everybody("1 + (2 << 5)", "1 + (2 << 5)")
+    everybodyExcept("1 + 2 << 5", "1 + 2 << 5", ResultMap(
+      NimCompiler -> "1 + 2 shl 5",
+    ))
+    everybodyExcept("(1 + 2) << 5", "1 + 2 << 5", ResultMap(
+      NimCompiler -> "1 + 2 shl 5",
+    ))
+    everybodyExcept("1 + (2 << 5)", "1 + (2 << 5)", ResultMap(
+      NimCompiler -> "1 + (2 shl 5)",
+    ))
 
     everybodyExcept("~777", "~777", ResultMap(
-      GoCompiler -> "^777"
+      GoCompiler -> "^777",
+      NimCompiler -> "not 777",
     ))
     everybodyExcept("~(7+3)", "~(7 + 3)", ResultMap(
-      GoCompiler -> "^(7 + 3)"
+      GoCompiler -> "^(7 + 3)",
+      NimCompiler -> "not (7 + 3)",
     ))
 
-    everybody("(0b01 & 0b11) << 1", "(1 & 3) << 1")
+    everybodyExcept("(0b01 & 0b11) << 1", "(1 & 3) << 1", ResultMap(
+      NimCompiler -> "(1 and 3) shl 1",
+    ))
 
     everybodyExcept("(0b01 & 0b10) >> 1", "(1 & 2) >> 1", ResultMap(
-      JavaScriptCompiler -> "(1 & 2) >>> 1"
+      JavaScriptCompiler -> "(1 & 2) >>> 1",
+      NimCompiler -> "(1 and 2) shr 1",
     ))
   }
 
@@ -191,6 +215,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "Long.toString(42)",
         JavaScriptCompiler -> "(42).toString()",
         LuaCompiler -> "tostring(42)",
+        NimCompiler -> "intToStr(int(42))",
         PerlCompiler -> "sprintf('%d', 42)",
         PHPCompiler -> "strval(42)",
         PythonCompiler -> "str(42)",
@@ -204,6 +229,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "Long.toString(a() + 42)",
         JavaScriptCompiler -> "(this.a + 42).toString()",
         LuaCompiler -> "tostring(self.a + 42)",
+        NimCompiler -> "intToStr(int(this.a + 42))",
         PerlCompiler -> "sprintf('%d', $self->a() + 42)",
         PHPCompiler -> "strval($this->a() + 42)",
         PythonCompiler -> "str(self.a + 42)",
@@ -217,6 +243,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "a() + Long.toString(42)",
         JavaScriptCompiler -> "this.a + (42).toString()",
         LuaCompiler -> "self.a .. tostring(42)",
+        NimCompiler -> "$this.a & $intToStr(int(42))",
         PerlCompiler -> "$self->a() . sprintf('%d', 42)",
         PHPCompiler -> "$this->a() . strval(42)",
         PythonCompiler -> "self.a + str(42)",
@@ -240,6 +267,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
       JavaScriptCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
       LuaCompiler -> "utils.box_unwrap((2 < 3) and utils.box_wrap(\"foo\") or (\"bar\"))",
+      NimCompiler -> "if 2 < 3: \"foo\" else: \"bar\"",
       PerlCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
       PHPCompiler -> "(2 < 3 ? \"foo\" : \"bar\")",
       PythonCompiler -> "(u\"foo\" if 2 < 3 else u\"bar\")",
@@ -267,6 +295,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "true",
       JavaScriptCompiler -> "true",
       LuaCompiler -> "true",
+      NimCompiler -> "true",
       PerlCompiler -> "1",
       PHPCompiler -> "true",
       PythonCompiler -> "True",
@@ -280,6 +309,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "false",
       JavaScriptCompiler -> "false",
       LuaCompiler -> "false",
+      NimCompiler -> "false",
       PerlCompiler -> "0",
       PHPCompiler -> "false",
       PythonCompiler -> "False",
@@ -300,6 +330,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "(someBool() ? 1 : 0)",
       JavaScriptCompiler -> "(this.someBool | 0)",
       LuaCompiler -> "(self.some_bool and 1 or 0)",
+      NimCompiler -> "if this.someBool: 1 else: 0",
       PerlCompiler -> "$self->some_bool()",
       PHPCompiler -> "intval($this->someBool())",
       PythonCompiler -> "int(self.some_bool)",
@@ -315,6 +346,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "fooStr()",
       JavaScriptCompiler -> "this.fooStr",
       LuaCompiler -> "self.foo_str",
+      NimCompiler -> "this.fooStr",
       PerlCompiler -> "$self->foo_str()",
       PHPCompiler -> "$this->fooStr()",
       PythonCompiler -> "self.foo_str",
@@ -328,6 +360,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "fooBlock()",
       JavaScriptCompiler -> "this.fooBlock",
       LuaCompiler -> "self.foo_block",
+      NimCompiler -> "this.fooBlock",
       PerlCompiler -> "$self->foo_block()",
       PHPCompiler -> "$this->fooBlock()",
       PythonCompiler -> "self.foo_block",
@@ -341,6 +374,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "foo().bar()",
       JavaScriptCompiler -> "this.foo.bar",
       LuaCompiler -> "self.foo.bar",
+      NimCompiler -> "this.foo.bar",
       PerlCompiler -> "$self->foo()->bar()",
       PHPCompiler -> "$this->foo()->bar()",
       PythonCompiler -> "self.foo.bar",
@@ -354,6 +388,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "foo().inner().baz()",
       JavaScriptCompiler -> "this.foo.inner.baz",
       LuaCompiler -> "self.foo.inner.baz",
+      NimCompiler -> "this.foo.inner.baz",
       PerlCompiler -> "$self->foo()->inner()->baz()",
       PHPCompiler -> "$this->foo()->inner()->baz()",
       PythonCompiler -> "self.foo.inner.baz",
@@ -367,6 +402,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "_root().foo()",
       JavaScriptCompiler -> "this._root.foo",
       LuaCompiler -> "self._root.foo",
+      NimCompiler -> "TopClass_Block(this.root).foo",
       PerlCompiler -> "$self->_root()->foo()",
       PHPCompiler -> "$this->_root()->foo()",
       PythonCompiler -> "self._root.foo",
@@ -380,6 +416,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> " ((a() != 2) && (a() != 5)) ",
       JavaScriptCompiler -> " ((this.a != 2) && (this.a != 5)) ",
       LuaCompiler -> " ((self.a ~= 2) and (self.a ~= 5)) ",
+      NimCompiler -> " ((this.a != 2) and (this.a != 5)) ",
       PerlCompiler -> " (($self->a() != 2) && ($self->a() != 5)) ",
       PHPCompiler -> " (($this->a() != 2) && ($this->a() != 5)) ",
       PythonCompiler -> " ((self.a != 2) and (self.a != 5)) ",
@@ -395,6 +432,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new ArrayList<Integer>(Arrays.asList(0, 1, 100500))",
         JavaScriptCompiler -> "[0, 1, 100500]",
         LuaCompiler -> "{0, 1, 100500}",
+        NimCompiler -> "@[int(0), int(1), int(100500)]",
         PerlCompiler -> "[0, 1, 100500]",
         PHPCompiler -> "[0, 1, 100500]",
         PythonCompiler -> "[0, 1, 100500]",
@@ -408,6 +446,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new byte[] { 34, 0, 10, 64, 65, 66, 92 }",
         JavaScriptCompiler -> "[34, 0, 10, 64, 65, 66, 92]",
         LuaCompiler -> "\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
+        NimCompiler -> "@[34'u8, 0'u8, 10'u8, 64'u8, 65'u8, 66'u8, 92'u8]",
         PerlCompiler -> "pack('C*', (34, 0, 10, 64, 65, 66, 92))",
         PHPCompiler -> "\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
         PythonCompiler -> "b\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
@@ -421,6 +460,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new byte[] { -1, 0, -1 }",
         JavaScriptCompiler -> "[255, 0, 255]",
         LuaCompiler -> "\"\\xFF\\x00\\xFF\"",
+        NimCompiler -> "@[255'u8, 0'u8, 255'u8]",
         PerlCompiler -> "pack('C*', (255, 0, 255))",
         PHPCompiler -> "\"\\xFF\\x00\\xFF\"",
         PythonCompiler -> "b\"\\xFF\\x00\\xFF\"",
@@ -436,6 +476,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new byte[] { 0, 1, 2 }.length",
         JavaScriptCompiler -> "[0, 1, 2].length",
         LuaCompiler -> "#\"\\x00\\x01\\x02\"",
+        NimCompiler -> "len(@[0'u8, 1'u8, 2'u8])",
         PerlCompiler -> "length(pack('C*', (0, 1, 2)))",
         PHPCompiler -> "strlen(\"\\x00\\x01\\x02\")",
         PythonCompiler -> "len(b\"\\x00\\x01\\x02\")",
@@ -449,6 +490,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "a().get((int) 42)",
         JavaScriptCompiler -> "this.a[42]",
         LuaCompiler -> "self.a[42 + 1]", // TODO: self.a[43]
+        NimCompiler -> "this.a[42]",
         PerlCompiler -> "@{$self->a()}[42]",
         PHPCompiler -> "$this->a()[42]",
         PythonCompiler -> "self.a[42]",
@@ -462,6 +504,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "a().get((int) (42 - 2))",
         JavaScriptCompiler -> "this.a[42 - 2]",
         LuaCompiler -> "self.a[42 - 2 + 1]", // TODO: self.a[41]
+        NimCompiler -> "this.a[42 - 2]",
         PerlCompiler -> "@{$self->a()}[42 - 2]",
         PHPCompiler -> "$this->a()[42 - 2]",
         PythonCompiler -> "self.a[42 - 2]",
@@ -475,6 +518,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "a().get(0)",
         JavaScriptCompiler -> "this.a[0]",
         LuaCompiler -> "self.a[1]",
+        NimCompiler -> "this.a[0]",
         PerlCompiler -> "@{$self->a()}[0]",
         PHPCompiler -> "$this->a()[0]",
         PythonCompiler -> "self.a[0]",
@@ -490,6 +534,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "a().get(a().size() - 1)",
         JavaScriptCompiler -> "this.a[this.a.length - 1]",
         LuaCompiler -> "self.a[#self.a]",
+        NimCompiler -> "this.a[^1]",
         PerlCompiler -> "@{$self->a()}[-1]",
         PHPCompiler -> "$this->a()[count($this->a()) - 1]",
         PythonCompiler -> "self.a[-1]",
@@ -503,6 +548,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "a().size()",
         JavaScriptCompiler -> "this.a.length",
         LuaCompiler -> "#self.a",
+        NimCompiler -> "len(this.a)",
         PHPCompiler -> "count($this->a())",
         PerlCompiler -> "scalar(@{$self->a()})",
         PythonCompiler -> "len(self.a)",
@@ -520,6 +566,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"str\"",
         JavaScriptCompiler -> "\"str\"",
         LuaCompiler -> "\"str\"",
+        NimCompiler -> "\"str\"",
         PerlCompiler -> "\"str\"",
         PHPCompiler -> "\"str\"",
         PythonCompiler -> "u\"str\"",
@@ -533,6 +580,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"str\\nnext\"",
         JavaScriptCompiler -> "\"str\\nnext\"",
         LuaCompiler -> "\"str\\nnext\"",
+        NimCompiler -> "\"str\\nnext\"",
         PerlCompiler -> "\"str\\nnext\"",
         PHPCompiler -> "\"str\\nnext\"",
         PythonCompiler -> "u\"str\\nnext\"",
@@ -546,6 +594,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"str\\nnext\"",
         JavaScriptCompiler -> "\"str\\nnext\"",
         LuaCompiler -> "\"str\\nnext\"",
+        NimCompiler -> "\"str\\nnext\"",
         PerlCompiler -> "\"str\\nnext\"",
         PHPCompiler -> "\"str\\nnext\"",
         PythonCompiler -> "u\"str\\nnext\"",
@@ -559,6 +608,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"str\\000next\"",
         JavaScriptCompiler -> "\"str\\x00next\"",
         LuaCompiler -> "\"str\\x00next\"",
+        NimCompiler -> "\"str\\x00next\"",
         PerlCompiler -> "\"str\\x00next\"",
         PHPCompiler -> "\"str\\x00next\"",
         PythonCompiler -> "u\"str\\x00next\"",
@@ -570,6 +620,7 @@ class TranslatorSpec extends AnyFunSpec {
       everybodyExcept("\"str1\" + \"str2\"", "\"str1\" + \"str2\"", ResultMap(
         CppCompiler -> "std::string(\"str1\") + std::string(\"str2\")",
         LuaCompiler -> "\"str1\" .. \"str2\"",
+        NimCompiler -> "$\"str1\" & $\"str2\"",
         PerlCompiler -> "\"str1\" . \"str2\"",
         PHPCompiler -> "\"str1\" . \"str2\"",
         PythonCompiler -> "u\"str1\" + u\"str2\""
@@ -609,6 +660,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"str\".length()",
         JavaScriptCompiler -> "\"str\".length",
         LuaCompiler -> "string.len(\"str\")",
+        NimCompiler -> "len(\"str\")",
         PerlCompiler -> "length(\"str\")",
         PHPCompiler -> "strlen(\"str\")",
         PythonCompiler -> "len(u\"str\")",
@@ -622,6 +674,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "(foo() + bar()).length()",
         JavaScriptCompiler -> "(this.foo + this.bar).length",
         LuaCompiler -> "string.len(self.foo .. self.bar)",
+        NimCompiler -> "len($this.foo & $this.bar)",
         PerlCompiler -> "length($self->foo() . $self->bar())",
         PHPCompiler -> "strlen($this->foo() . $this->bar())",
         PythonCompiler -> "len(self.foo + self.bar)",
@@ -635,6 +688,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new StringBuilder(\"str\").reverse().toString()",
         JavaScriptCompiler -> "Array.from(\"str\").reverse().join('')",
         LuaCompiler -> "string.reverse(\"str\")",
+        NimCompiler -> "reversed(\"str\")",
         PerlCompiler -> "scalar(reverse(\"str\"))",
         PHPCompiler -> "strrev(\"str\")",
         PythonCompiler -> "(u\"str\")[::-1]",
@@ -648,6 +702,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new StringBuilder(foo() + bar()).reverse().toString()",
         JavaScriptCompiler -> "Array.from(this.foo + this.bar).reverse().join('')",
         LuaCompiler -> "string.reverse(self.foo .. self.bar)",
+        NimCompiler -> "reversed($this.foo & $this.bar)",
         PerlCompiler -> "scalar(reverse($self->foo() . $self->bar()))",
         PHPCompiler -> "strrev($this->foo() . $this->bar())",
         PythonCompiler -> "(self.foo + self.bar)[::-1]",
@@ -666,6 +721,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "Long.parseLong(\"12345\", 10)",
         JavaScriptCompiler -> "Number.parseInt(\"12345\", 10)",
         LuaCompiler -> "tonumber(\"12345\")",
+        NimCompiler -> "\"12345\".parseInt(10)",
         PerlCompiler -> "\"12345\" + 0",
         PHPCompiler -> "intval(\"12345\", 10)",
         PythonCompiler -> "int(u\"12345\")",
@@ -684,6 +740,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "Long.parseLong(\"1234fe\", 16)",
         JavaScriptCompiler -> "Number.parseInt(\"1234fe\", 16)",
         LuaCompiler -> "tonumber(\"1234fe\", 16)",
+        NimCompiler -> "\"1234fe\".parseInt(16)",
         PerlCompiler -> "hex(\"1234fe\")",
         PHPCompiler -> "intval(\"1234fe\", 16)",
         PythonCompiler -> "int(u\"1234fe\", 16)",
@@ -698,6 +755,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "\"foobar\".substring(2, 4)",
         JavaScriptCompiler -> "\"foobar\".substring(2, 4)",
         LuaCompiler -> "string.sub(\"foobar\", 2 + 1, 4)",
+        NimCompiler -> "\"foobar\".substr(2, 4 - 1)",
         PerlCompiler -> "substr(\"foobar\", 2, 4 - 2)",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring(\"foobar\", 2, 4)",
         PythonCompiler -> "u\"foobar\"[2:4]",
@@ -713,6 +771,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "(foo() + bar()).substring(2, 4)",
         JavaScriptCompiler -> "(this.foo + this.bar).substring(2, 4)",
         LuaCompiler -> "string.sub(self.foo .. self.bar, 2 + 1, 4)",
+        NimCompiler -> "($this.foo & $this.bar).substr(2, 4 - 1)",
         PerlCompiler -> "substr($self->foo() . $self->bar(), 2, 4 - 2)",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo() . $this->bar(), 2, 4)",
         PythonCompiler -> "(self.foo + self.bar)[2:4]",
@@ -728,6 +787,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "foo().substring(10 - 7, 10 - 3)",
         JavaScriptCompiler -> "this.foo.substring(10 - 7, 10 - 3)",
         LuaCompiler -> "string.sub(self.foo, (10 - 7) + 1, 10 - 3)", // TODO: LuaCompiler -> "string.sub(self.foo, 10 - 7 + 1, 10 - 3)",
+        NimCompiler -> "this.foo.substr(10 - 7, 10 - 3 - 1)",
         PerlCompiler -> "substr($self->foo(), 10 - 7, (10 - 3) - (10 - 7))", // TODO: PerlCompiler -> "substr($self->foo(), 10 - 7, 10 - 3 - (10 - 7))",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo(), 10 - 7, 10 - 3)",
         PythonCompiler -> "self.foo[10 - 7:10 - 3]",
@@ -743,6 +803,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "foo().substring(10 - 7, 10 << 2)",
         JavaScriptCompiler -> "this.foo.substring(10 - 7, 10 << 2)",
         LuaCompiler -> "string.sub(self.foo, (10 - 7) + 1, 10 << 2)", // TODO: LuaCompiler -> "string.sub(self.foo, 10 - 7 + 1, 10 << 2)",
+        NimCompiler -> "this.foo.substr(10 - 7, 10 shl 2 - 1)",
         PerlCompiler -> "substr($self->foo(), 10 - 7, (10 << 2) - (10 - 7))",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo(), 10 - 7, 10 << 2)",
         PythonCompiler -> "self.foo[10 - 7:10 << 2]",
@@ -758,6 +819,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "foo().substring(10 << 1, 42)",
         JavaScriptCompiler -> "this.foo.substring(10 << 1, 42)",
         LuaCompiler -> "string.sub(self.foo, (10 << 1) + 1, 42)",
+        NimCompiler -> "this.foo.substr(10 shl 1, 42 - 1)",
         PerlCompiler -> "substr($self->foo(), 10 << 1, 42 - (10 << 1))",
         PHPCompiler -> "\\Kaitai\\Struct\\Stream::substring($this->foo(), 10 << 1, 42)",
         PythonCompiler -> "self.foo[10 << 1:42]",
@@ -775,6 +837,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "((TopClass.Block) (other())).bar()",
         JavaScriptCompiler -> "this.other.bar",
         LuaCompiler -> "self.other.bar",
+        NimCompiler -> "TopClass_Block(this.other).bar",
         PerlCompiler -> "$self->other()->bar()",
         PHPCompiler -> "$this->other()->bar()",
         PythonCompiler -> "self.other.bar",
@@ -788,6 +851,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "((TopClass.Block.Innerblock) (other())).baz()",
         JavaScriptCompiler -> "this.other.baz",
         LuaCompiler -> "self.other.baz",
+        NimCompiler -> "TopClass_Block_Innerblock(this.other).baz",
         PerlCompiler -> "$self->other()->baz()",
         PHPCompiler -> "$this->other()->baz()",
         PythonCompiler -> "self.other.baz",
@@ -803,6 +867,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "((short) (1 + 2))",
         JavaScriptCompiler -> "1 + 2",
         LuaCompiler -> "1 + 2",
+        NimCompiler -> "int16(1 + 2)",
         PerlCompiler -> "1 + 2",
         PHPCompiler -> "1 + 2",
         PythonCompiler -> "1 + 2",
@@ -818,6 +883,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new byte[] {  }",
         JavaScriptCompiler -> "[]",
         LuaCompiler -> "\"\"",
+        NimCompiler -> "@[]",
         PerlCompiler -> "pack('C*', ())",
         PHPCompiler -> "\"\"",
         PythonCompiler -> "b\"\"",
@@ -831,6 +897,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new ArrayList<Integer>(Arrays.asList())",
         JavaScriptCompiler -> "[]",
         LuaCompiler -> "{}",
+        NimCompiler -> "@[]",
         PerlCompiler -> "[]",
         PHPCompiler -> "[]",
         PythonCompiler -> "[]",
@@ -844,6 +911,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new ArrayList<Double>(Arrays.asList())",
         JavaScriptCompiler -> "[]",
         LuaCompiler -> "{}",
+        NimCompiler -> "@[]",
         PerlCompiler -> "[]",
         PHPCompiler -> "[]",
         PythonCompiler -> "[]",
@@ -860,6 +928,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new byte[] { 0 + 1, 5 }",
         JavaScriptCompiler -> "new Uint8Array([0 + 1, 5])",
         LuaCompiler -> "???",
+        NimCompiler -> "@[0 + 1, 5]",
         PerlCompiler -> "pack('C*', (0 + 1, 5))",
         PHPCompiler -> "pack('C*', 0 + 1, 5)",
         PythonCompiler -> "struct.pack('2B', 0 + 1, 5)",
@@ -873,6 +942,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> "new ArrayList<Integer>(Arrays.asList(0, 1, 2))",
         JavaScriptCompiler -> "[0, 1, 2]",
         LuaCompiler -> "{0, 1, 2}",
+        NimCompiler -> "@[uint8(0), uint8(1), uint8(2)]",
         PerlCompiler -> "[0, 1, 2]",
         PHPCompiler -> "[0, 1, 2]",
         PythonCompiler -> "[0, 1, 2]",
@@ -928,6 +998,7 @@ class TranslatorSpec extends AnyFunSpec {
       JavaCompiler -> "\"abc\" + Long.toString(1) + \"%def\"",
       JavaScriptCompiler -> "\"abc\" + (1).toString() + \"%def\"",
       LuaCompiler -> "\"abc\" .. tostring(1) .. \"%def\"",
+      NimCompiler -> "\"abc\" & intToStr(int(1)) & \"%def\"",
       PerlCompiler -> "\"abc\" . sprintf('%d', 1) . \"\\%def\"",
       PHPCompiler -> "\"abc\" . strval(1) . \"%def\"",
       PythonCompiler -> "u\"abc\" + str(1) + u\"%def\"",
@@ -959,6 +1030,7 @@ class TranslatorSpec extends AnyFunSpec {
         JavaCompiler -> new JavaTranslator(tp, new ImportList()),
         JavaScriptCompiler -> new JavaScriptTranslator(tp),
         LuaCompiler -> new LuaTranslator(tp, new ImportList()),
+        NimCompiler -> new NimTranslator(tp, new ImportList()),
         PerlCompiler -> new PerlTranslator(tp, new ImportList()),
         PHPCompiler -> new PHPTranslator(tp, RuntimeConfig()),
         PythonCompiler -> new PythonTranslator(tp, new ImportList()),

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -407,7 +407,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "[]uint8{34, 0, 10, 64, 65, 66, 92}",
         JavaCompiler -> "new byte[] { 34, 0, 10, 64, 65, 66, 92 }",
         JavaScriptCompiler -> "[34, 0, 10, 64, 65, 66, 92]",
-        LuaCompiler -> "\"\\034\\000\\010\\064\\065\\066\\092\"",
+        LuaCompiler -> "\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
         PerlCompiler -> "pack('C*', (34, 0, 10, 64, 65, 66, 92))",
         PHPCompiler -> "\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
         PythonCompiler -> "b\"\\x22\\x00\\x0A\\x40\\x41\\x42\\x5C\"",
@@ -420,7 +420,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "[]uint8{255, 0, 255}",
         JavaCompiler -> "new byte[] { -1, 0, -1 }",
         JavaScriptCompiler -> "[255, 0, 255]",
-        LuaCompiler -> "\"\\255\\000\\255\"",
+        LuaCompiler -> "\"\\xFF\\x00\\xFF\"",
         PerlCompiler -> "pack('C*', (255, 0, 255))",
         PHPCompiler -> "\"\\xFF\\x00\\xFF\"",
         PythonCompiler -> "b\"\\xFF\\x00\\xFF\"",
@@ -435,7 +435,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "len([]uint8{0, 1, 2})",
         JavaCompiler -> "new byte[] { 0, 1, 2 }.length",
         JavaScriptCompiler -> "[0, 1, 2].length",
-        LuaCompiler -> "#\"\\000\\001\\002\"",
+        LuaCompiler -> "#\"\\x00\\x01\\x02\"",
         PerlCompiler -> "length(pack('C*', (0, 1, 2)))",
         PHPCompiler -> "strlen(\"\\x00\\x01\\x02\")",
         PythonCompiler -> "len(b\"\\x00\\x01\\x02\")",
@@ -555,14 +555,14 @@ class TranslatorSpec extends AnyFunSpec {
       full("\"str\\0next\"", CalcIntType, CalcStrType, ResultMap(
         CppCompiler -> "std::string(\"str\\000next\", 8)",
         CSharpCompiler -> "\"str\\0next\"",
-        GoCompiler -> "\"str\\000next\"",
+        GoCompiler -> "\"str\\x00next\"",
         JavaCompiler -> "\"str\\000next\"",
         JavaScriptCompiler -> "\"str\\x00next\"",
-        LuaCompiler -> "\"str\\000next\"",
-        PerlCompiler -> "\"str\\000next\"",
-        PHPCompiler -> "\"str\\000next\"",
-        PythonCompiler -> "u\"str\\000next\"",
-        RubyCompiler -> "\"str\\000next\""
+        LuaCompiler -> "\"str\\x00next\"",
+        PerlCompiler -> "\"str\\x00next\"",
+        PHPCompiler -> "\"str\\x00next\"",
+        PythonCompiler -> "u\"str\\x00next\"",
+        RubyCompiler -> "\"str\\x00next\""
       ))
     }
 

--- a/shared/src/main/scala/io/kaitai/struct/JSON.scala
+++ b/shared/src/main/scala/io/kaitai/struct/JSON.scala
@@ -28,7 +28,6 @@ object JSON extends CommonLiterals {
     }
   }
 
-  /** octal escapes (which [[translators.CommonLiterals.strLiteralGenericCC]] uses by default) are not allowed in JSON */
   override def strLiteralGenericCC(code: Char): String = strLiteralUnicode(code)
 
   def stringToJson(str: String): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonLiterals.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonLiterals.scala
@@ -34,7 +34,7 @@ trait CommonLiterals {
   /**
     * Handle ASCII character conversion for inlining into string literals.
     * Default implementation consults [[asciiCharQuoteMap]] first, then
-    * just dumps it as is if it's a printable ASCII charcter, or calls
+    * just dumps it as is if it's a printable ASCII character, or calls
     * [[strLiteralGenericCC]] if it's a control character.
     * @param code character code to convert into string for inclusion in
     *             a string literal
@@ -53,18 +53,14 @@ trait CommonLiterals {
 
   /**
     * Converts generic control character code into something that's allowed
-    * inside a string literal. Default implementation uses octal encoding,
+    * inside a string literal. Default implementation uses hex encoding,
     * which is ok for most C-derived languages.
     *
-    * Note that we use strictly 3 octal digits to work around potential
-    * problems with following decimal digits, i.e. "\0" + "2" that would be
-    * parsed as single character "\02" = "\x02", instead of two characters
-    * "\x00\x32".
     * @param code character code to represent
     * @return string literal representation of given code
     */
   def strLiteralGenericCC(code: Char): String =
-    "\\%03o".format(code.toInt)
+    "\\x%02X".format(code.toInt)
 
   /**
     * Converts Unicode (typically, non-ASCII) character code into something

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -118,6 +118,21 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
   override def doByteArrayLiteral(arr: Seq[Byte]): String =
     "std::string(\"" + Utils.hexEscapeByteArray(arr) + "\", " + arr.length + ")"
 
+  /**
+    * Hex escapes in C++ does not limited in length, so we use octal, as they are shorter.
+    *
+    * Note that we use strictly 3 octal digits to work around potential
+    * problems with following decimal digits, i.e. "\0" + "2" that would be
+    * parsed as single character "\02" = "\x02", instead of two characters
+    * "\x00\x32".
+    *
+    * @see https://en.cppreference.com/w/cpp/language/escape
+    * @param code character code to represent
+    * @return string literal representation of given code
+    */
+  override def strLiteralGenericCC(code: Char): String =
+    "\\%03o".format(code.toInt)
+
   override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Mod) =>

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -11,19 +11,6 @@ class JavaScriptTranslator(provider: TypeProvider) extends BaseTranslator(provid
   override def doByteArrayNonLiteral(elts: Seq[Ast.expr]): String =
     s"new Uint8Array([${elts.map(translate).mkString(", ")}])"
 
-  /**
-    * JavaScript rendition of common control character that would use hex form,
-    * not octal. "Octal" control character string literals might be accepted
-    * in non-strict JS mode, but in strict mode only hex or unicode are ok.
-    * Here we'll use hex, as they are shorter.
-    *
-    * @see https://github.com/kaitai-io/kaitai_struct/issues/279
-    * @param code character code to represent
-    * @return string literal representation of given code
-    */
-  override def strLiteralGenericCC(code: Char): String =
-    "\\x%02x".format(code.toInt)
-
   override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -45,6 +45,21 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def doByteArrayNonLiteral(elts: Seq[expr]): String =
     s"new byte[] { ${elts.map(translate).mkString(", ")} }"
 
+  /**
+    * Java does not support two-digit hex escape sequences, so use octal, as they are shorter.
+    *
+    * Note that we use strictly 3 octal digits to work around potential
+    * problems with following decimal digits, i.e. "\0" + "2" that would be
+    * parsed as single character "\02" = "\x02", instead of two characters
+    * "\x00\x32".
+    *
+    * @see https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.6
+    * @param code character code to represent
+    * @return string literal representation of given code
+    */
+  override def strLiteralGenericCC(code: Char): String =
+    "\\%03o".format(code.toInt)
+
   override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Mod) =>

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -181,7 +181,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
     case Ast.boolop.And => "and"
   }
   override def unaryOp(op: Ast.unaryop): String = op match {
-    case Ast.unaryop.Not => "not"
+    case Ast.unaryop.Not => "not "
     case _ => super.unaryOp(op)
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -39,7 +39,6 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
     '\b' -> "\\b",
     '\u000b' -> "\\v",
     '\f' -> "\\f",
-    '\u001b' -> "\\027"
   )
 
   override def strLiteralUnicode(code: Char): String =
@@ -70,7 +69,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def doArrayLiteral(t: DataType, value: Seq[Ast.expr]): String =
     "{" + value.map((v) => translate(v)).mkString(", ") + "}"
   override def doByteArrayLiteral(arr: Seq[Byte]): String =
-    "\"" + decEscapeByteArray(arr) + "\""
+    "\"" + Utils.hexEscapeByteArray(arr) + "\""
 
   override def doLocalName(s: String) = s match {
     case Identifier.ITERATOR => "_"
@@ -185,14 +184,4 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
     case Ast.unaryop.Not => "not"
     case _ => super.unaryOp(op)
   }
-
-  /**
-   * Converts byte array (Seq[Byte]) into decimal-escaped Lua-style literal
-   * characters (i.e. like \255).
-   *
-   * @param arr byte array to escape
-   * @return array contents decimal-escaped as string
-   */
-  private def decEscapeByteArray(arr: Seq[Byte]): String =
-    arr.map((x) => "\\%03d".format(x & 0xff)).mkString
 }

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -49,9 +49,9 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
     s"if ${translate(condition)}: ${translate(ifTrue)} else: ${translate(ifFalse)}"
   override def arraySubscript(container: expr, idx: expr): String =
-    s"${translate(container)}[${translate(idx)}]"
+    s"${translate(container, METHOD_PRECEDENCE)}[${translate(idx)}]"
 
-  override def strConcat(left: expr, right: expr, extPrec: Int) = "($" + s"${translate(left)} & " + "$" + s"${translate(right)})"
+  override def strConcat(left: expr, right: expr, extPrec: Int) = "($" + s"${translate(left, METHOD_PRECEDENCE)} & " + "$" + s"${translate(right, METHOD_PRECEDENCE)})"
 
   // Members declared in io.kaitai.struct.translators.CommonMethods
 
@@ -84,7 +84,7 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
     typeName match {
       case at: ArrayType => {
         importList.add("sequtils")
-        s"${translate(value)}.mapIt(it.${ksToNim(at.elType)})"
+        s"${translate(value, METHOD_PRECEDENCE)}.mapIt(it.${ksToNim(at.elType)})"
       }
       case _ => s"(${ksToNim(typeName)}(${translate(value)}))"
     }
@@ -116,8 +116,8 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
   }
   override def doByteArrayNonLiteral(elts: Seq[expr]): String =
     s"@[${elts.map(translate).mkString(", ")}]"
-  override def arrayFirst(a: expr): String = s"${translate(a)}[0]"
-  override def arrayLast(a: expr): String = s"${translate(a)}[^1]"
+  override def arrayFirst(a: expr): String = s"${translate(a, METHOD_PRECEDENCE)}[0]"
+  override def arrayLast(a: expr): String = s"${translate(a, METHOD_PRECEDENCE)}[^1]"
   override def arrayMax(a: expr): String = s"max(${translate(a)})"
   override def arrayMin(a: expr): String = s"min(${translate(a)})"
   override def arraySize(a: expr): String = s"len(${translate(a)})"
@@ -133,9 +133,9 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
     s"reversed(${translate(s)})"
   }
   override def strSubstring(s: expr, from: expr, to: expr): String =
-    s"${translate(s)}.substr(${translate(from)}, ${translate(to)} - 1)"
+    s"${translate(s, METHOD_PRECEDENCE)}.substr(${translate(from)}, ${translate(to)} - 1)"
   override def strToInt(s: expr, base: expr): String =
-    s"${translate(s)}.parseInt(${translate(base)})"
+    s"${translate(s, METHOD_PRECEDENCE)}.parseInt(${translate(base)})"
 
   override def doInterpolatedStringLiteral(exprs: Seq[Ast.expr]): String =
     if (exprs.isEmpty) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -51,7 +51,17 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container, METHOD_PRECEDENCE)}[${translate(idx)}]"
 
-  override def strConcat(left: expr, right: expr, extPrec: Int) = "($" + s"${translate(left, METHOD_PRECEDENCE)} & " + "$" + s"${translate(right, METHOD_PRECEDENCE)})"
+  override def strConcat(left: expr, right: expr, extPrec: Int): String = {
+    val thisPrec = OPERATOR_PRECEDENCE(Ast.operator.Add)
+    // $ is a special method which converts everything to a string, so use METHOD_PRECEDENCE
+    val leftStr = "$" + translate(left, METHOD_PRECEDENCE)
+    val rightStr = "$" + translate(right, METHOD_PRECEDENCE)
+    if (thisPrec <= extPrec) {
+      s"($leftStr & $rightStr)"
+    } else {
+      s"$leftStr & $rightStr"
+    }
+  }
 
   // Members declared in io.kaitai.struct.translators.CommonMethods
 
@@ -86,7 +96,7 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
         importList.add("sequtils")
         s"${translate(value, METHOD_PRECEDENCE)}.mapIt(it.${ksToNim(at.elType)})"
       }
-      case _ => s"(${ksToNim(typeName)}(${translate(value)}))"
+      case _ => s"${ksToNim(typeName)}(${translate(value)})"
     }
   override def doIntLiteral(n: BigInt): String = {
     if (n <= -2147483649L) { // -9223372036854775808..-2147483649

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -38,7 +38,7 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
       case _ => s"this.${doName(s)}"
     }
   override def doIfExp(condition: expr, ifTrue: expr, ifFalse: expr): String =
-    s"(if ${translate(condition)}: ${translate(ifTrue)} else: ${translate(ifFalse)})"
+    s"if ${translate(condition)}: ${translate(ifTrue)} else: ${translate(ifFalse)}"
   override def arraySubscript(container: expr, idx: expr): String =
     s"${translate(container)}[${translate(idx)}]"
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -47,9 +47,9 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
   // Members declared in io.kaitai.struct.translators.CommonMethods
 
   override def unaryOp(op: Ast.unaryop): String = op match {
-    case Ast.unaryop.Invert => "not"
+    case Ast.unaryop.Invert => "not "
     case Ast.unaryop.Minus => "-"
-    case Ast.unaryop.Not => "not"
+    case Ast.unaryop.Not => "not "
   }
 
   override def booleanOp(op: Ast.boolop): String = op match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -10,6 +10,15 @@ import io.kaitai.struct.format.Identifier
 import io.kaitai.struct.languages.NimCompiler.{ksToNim, namespaced, camelCase}
 
 class NimTranslator(provider: TypeProvider, importList: ImportList) extends BaseTranslator(provider) {
+  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+    (detectType(left), detectType(right), op) match {
+      case (_: IntType, _: IntType, Ast.operator.Div) =>
+        genericBinOpStr(left, op, "div", right, extPrec)
+      case _ =>
+        super.genericBinOp(left, op, right, extPrec)
+    }
+  }
+
   // Members declared in io.kaitai.struct.translators.BaseTranslator
   override def bytesToStr(bytesExpr: String, encoding: String): String = {
     s"""encode($bytesExpr, "$encoding")"""
@@ -62,7 +71,7 @@ class NimTranslator(provider: TypeProvider, importList: ImportList) extends Base
       case Ast.operator.Add => "+"
       case Ast.operator.Sub => "-"
       case Ast.operator.Mult => "*"
-      case Ast.operator.Div => "div"
+      case Ast.operator.Div => "/"
       case Ast.operator.Mod => "%%%"
       case Ast.operator.BitAnd => "and"
       case Ast.operator.BitOr => "or"

--- a/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
@@ -23,6 +23,13 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig) extends Base
     '\\' -> "\\\\"
   )
 
+  /**
+    * Hex escapes in form `\xHH` in Rust allows only codes in the range 0x00 - 0x7f.
+    *
+    * @see https://doc.rust-lang.org/reference/tokens.html#examples
+    * @param code character code to represent
+    * @return string literal representation of given code
+    */
   override def strLiteralUnicode(code: Char): String =
     "\\u{%x}".format(code.toInt)
 


### PR DESCRIPTION
This PR includes #291, because Nim octal escapes will consume all possible digits, so string with escape sequence followed by digit will be treated incorrectly. Hex escape form does not suffer from such problem. Instead of overriding logic in Nim I decided to make a Hex representation as default because most languages have it. If you do not agree, please tell me and I change that.

This PR fixes the following bugs found during testing:
- Bitwise NOT operation can glue to the number because in Nim it is represented as a `not` keyword and require a space after it, so `~777` not become identifier `not777`. Lua was suffer from the same problem.
- Removed extra parenthesis around ternary operator (represented by `if ...: ... else: ...` expression), casts and string concatenation (`&` operator)
- Like Python, Nim have different operators for integer and float division, `div` and `/` accordingly. Attempt to use `div` with float numbers lead to a compilation error. This was fixed in the same way as Python does that by inspecting deduced types of an arguments
- `.first`, `.last`, `.to_i`, `.substring` methods called on expressions does not wrap them into parenthesis, so `(1 + 2).to_i` becomes `1 + 2.to_i`

I checked all generated expressions on https://play.nim-lang.org/ so I assume that their all are correct.

I also notice a strange thing. Nim has an extendable `$` operator to converting everything to a string. However, `.to_s` implementation generates `intToStr(int(value))` which means conversion to integer, then conversion to string. It seems that it is possible to replace that stuff with `$` operator stuff, but maybe there are some nuances. @sealmove, you a created Nim implementation, can you check, is that possible?