### PR TITLE
GoCompiler: add kaitai.Struct interface support

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -86,6 +86,8 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
     out.puts("}")
     universalFooter
+
+    ioAccessor()
   }
 
   override def classConstructorFooter: Unit = {}
@@ -568,6 +570,15 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
     out.puts("}")
   }
+
+  def ioAccessor(): Unit = {
+    out.puts
+    out.puts(s"func (this ${types2class(typeProvider.nowClass.name)}) IO_() *$kstreamName {")
+    out.inc
+    out.puts(s"return this._io")
+    out.dec
+    out.puts("}")
+  }
 }
 
 object GoCompiler extends LanguageCompilerStatic
@@ -631,7 +642,7 @@ object GoCompiler extends LanguageCompilerStatic
 
       case AnyType => "interface{}"
       case KaitaiStructType | CalcKaitaiStructType(_) => kstructName
-      case KaitaiStreamType | OwnedKaitaiStreamType => "*" + kstreamName
+      case KaitaiStreamType | OwnedKaitaiStreamType => s"*$kstreamName"
 
       case t: UserType => "*" + types2class(t.classSpec match {
         case Some(cs) => cs.name
@@ -657,7 +668,7 @@ object GoCompiler extends LanguageCompilerStatic
     types2class(typeName) + "__" + type2class(enumName)
 
   override def kstreamName: String = "kaitai.Stream"
-  override def kstructName: String = "interface{}"
+  override def kstructName: String = "kaitai.Struct"
   override def ksErrorName(err: KSError): String = err match {
     case ConversionError => "strconv.NumError"
     case _ => s"kaitai.${err.name}"


### PR DESCRIPTION
This adds support for common interface kaitai.Struct in Go, akin to other KaitaiStruct ancestor classes (e.g. [KaitaiStruct in Java](https://javadoc.io/doc/io.kaitai/kaitai-struct-runtime/latest/io/kaitai/struct/package-summary.html)).

Given that Go does not have inheritance, it provides the interface + makes sure that every single type we generate carries over this method:

```go
func (this HelloWorld) IO_() *kaitai.Stream {
        return this._io
}
```

This does not change the status quo that for all internal communications KS expressions still use `._io`, not `.IO_()`. That one we can address later.

To be merged after https://github.com/kaitai-io/kaitai_struct_go_runtime/pull/30

## Test check

Totals: 195 ran, 179 passed, 16 failed
SUMMARY: {"kst"=>183, "passed"=>179, "failed"=>16}

Comparison with previous: (no changes)