### PR TITLE
Add name to ci steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,12 @@ jobs:
       run:
         working-directory: compiler
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout - compiler
+        uses: actions/checkout@v4
         with:
           path: compiler
-      - uses: actions/checkout@v4
+      - name: Checkout - spec and tests
+        uses: actions/checkout@v4
         with:
           repository: kaitai-io/kaitai_struct_tests
           path: tests


### PR DESCRIPTION
This makes the CI run log marginally more sensible. Note the two steps currently described as "Run actions/checkout@v4"

![image](https://github.com/kaitai-io/kaitai_struct_compiler/assets/119948/9d633d03-49b2-45aa-aa67-be8dc05e6231)

https://github.com/kaitai-io/kaitai_struct_compiler/actions/runs/8490623944/job/23261893805

