### PR TITLE
C++: add a method to translator to get the raw string literal instead of std::string object

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -60,6 +60,9 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     }
   }
 
+  /** Used by the KST translator. */
+  def doRawStringLiteral(s: String): String = super.doStringLiteral(s)
+
   /**
     * Handles string literal for C++ by wrapping a C `const char*`-style string
     * into a std::string constructor. Note that normally std::string


### PR DESCRIPTION
This method will be used in KST translator in https://github.com/kaitai-io/kaitai_struct_tests/pull/114