### PR TITLE
Fix some warnings about broken links in documentation

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/format/ClassSpecs.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ClassSpecs.scala
@@ -15,7 +15,7 @@ abstract class ClassSpecs(val firstSpec: ClassSpec) extends mutable.HashMap[Stri
   this(firstSpec.name.head) = firstSpec
 
   /**
-    * Calls certain function on all [[ClassSpec]] elements stored in this ClassSpecs,
+    * Calls certain function on all [[format.ClassSpec]] elements stored in this ClassSpecs,
     * and all subtypes stored in these elements, recursively.
     *
     * @param proc function to execute on every encountered type.
@@ -24,7 +24,7 @@ abstract class ClassSpecs(val firstSpec: ClassSpec) extends mutable.HashMap[Stri
     forEachTopLevel((_, typeSpec) => typeSpec.forEachRec(proc))
 
   /**
-    * Calls certain function on all top-level [[ClassSpec]] elements stored in this
+    * Calls certain function on all top-level [[format.ClassSpec]] elements stored in this
     * ClassSpecs.
     */
   def forEachTopLevel[R](proc: (String, ClassSpec) => Unit): Unit = {
@@ -39,7 +39,7 @@ abstract class ClassSpecs(val firstSpec: ClassSpec) extends mutable.HashMap[Stri
   }
 
   /**
-    * Calls certain function on all [[ClassSpec]] elements stored in this ClassSpecs,
+    * Calls certain function on all [[format.ClassSpec]] elements stored in this ClassSpecs,
     * and all subtypes stored in these elements, recursively.
     *
     * @param proc function to execute on every encountered type.
@@ -48,7 +48,7 @@ abstract class ClassSpecs(val firstSpec: ClassSpec) extends mutable.HashMap[Stri
     mapTopLevel((_, typeSpec) => typeSpec.mapRec(proc))
 
   /**
-    * Calls certain function on all top-level [[ClassSpec]] elements stored in this
+    * Calls certain function on all top-level [[format.ClassSpec]] elements stored in this
     * ClassSpecs.
     *
     * @param proc function to execute on every encountered type.

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -10,10 +10,10 @@ import io.kaitai.struct.precompile.TypeMismatchError
   * BaseTranslator is a common semi-abstract implementation of a translator
   * API (i.e. [[AbstractTranslator]]), which fits target languages that
   * follow "every KS expression is translatable into expression" paradigm.
-  * Main [[AbstractTranslator.translate]] method is implemented as a huge
-  * case matching, which usually just calls relevant abstract methods for
-  * every particular piece of KS expression, i.e. literals, operations,
-  * method calls, etc.
+  * Main [[AbstractTranslator.translate(v:io\.kaitai\.struct\.exprlang\.Ast\.expr,extPrec:Int)*]]
+  * method is implemented as a huge case matching, which usually just calls
+  * relevant abstract methods for every particular piece of KS expression,
+  * i.e. literals, operations, method calls, etc.
   *
   * Given that there are many of these abstract methods, to make it more
   * maintainable, they are grouped into several abstract traits:

--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala
@@ -152,7 +152,7 @@ abstract trait CommonMethods[T] extends TypeDetector {
     * of expression in certain target language.
     * @note Must be kept in sync with [[TypeDetector.detectAttributeType]]
     * @param call attribute call expression to translate
-    * @return result of translation as [[T]]
+    * @return result of translation as `T`
     */
   def translateAttribute(call: Ast.expr.Attribute): T = {
     val attr = call.attr
@@ -195,7 +195,7 @@ abstract trait CommonMethods[T] extends TypeDetector {
     *
     * @note Must be kept in sync with [[TypeDetector.detectCallType]]
     * @param call function call expression to translate
-    * @return result of translation as [[T]]
+    * @return result of translation as `T`
     */
   def translateCall(call: Ast.expr.Call): T = {
     val func = call.func


### PR DESCRIPTION
Fixes the warnings:
```
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\translators\CommonMethods.scala:150:3: Could not find any member to link for "T".
[warn]   /**
[warn]   ^
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\translators\CommonMethods.scala:192:3: Could not find any member to link for "T".
[warn]   /**
[warn]   ^
...
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\format\ClassSpecs.scala:17:3: Could not find any member to link for "ClassSpec".
[warn]   /**
[warn]   ^
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\format\ClassSpecs.scala:26:3: Could not find any member to link for "ClassSpec".
[warn]   /**
[warn]   ^
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\format\ClassSpecs.scala:41:3: Could not find any member to link for "ClassSpec".
[warn]   /**
[warn]   ^
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\format\ClassSpecs.scala:50:3: Could not find any member to link for "ClassSpec".
[warn]   /**
[warn]   ^
```
Very strange that this warnings does not present in CI logs, but present on both my machines. I got them when I run:
```
cd tests
./build-compiler
```

Unfortunately, any attempts to fix
```
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\translators\BaseTranslator.scala:9:1: The link target "AbstractTranslator.translate" is ambiguous. Several members fit the target:
[warn] (v: io.kaitai.struct.exprlang.Ast.expr): String in trait AbstractTranslator [chosen]
[warn] (v: io.kaitai.struct.exprlang.Ast.expr, extPrec: Int): String in trait AbstractTranslator
[warn] 
[warn] For an explanation of how to resolve ambiguous links,
[warn] see "Resolving Ambiguous Links within Scaladoc Comments" in the Scaladoc for Library Authors guide
[warn] (https://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html)
[warn] /**
[warn] ^
...
[warn] D:\Projects\parsers\kaitai_struct\compiler\shared\src\main\scala\io\kaitai\struct\Utils.scala:103:3: Could not find any member to link for "IterableOnce".
[warn]   /**
[warn]   ^
```

are unsuccessful. Scala is the most stupid language I even know.
