### PR TITLE
Partialy implement validation for `valid` key

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
@@ -182,8 +182,8 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
     val text = valid match {
       case Some(v) =>
         v match {
-          case ValidationEq(expected) =>
-            s"must be equal to ${expression(expected, fullPortName, STYLE_EDGE_VALID)}"
+          case expected: ValidationEquals =>
+            s"must be equal to ${expression(expected.value, fullPortName, STYLE_EDGE_VALID)}"
           case ValidationMin(min) =>
             s"must be at least ${expression(min, fullPortName, STYLE_EDGE_VALID)}"
           case ValidationMax(max) =>
@@ -519,12 +519,17 @@ object GraphvizClassCompiler extends LanguageCompilerStatic {
 
   private def fixedBytes(blt: BytesLimitType, valid: Option[ValidationSpec]): Option[String] = {
     valid match {
-      case Some(ValidationEq(Ast.expr.List(contents)))
-          if blt.size == Ast.expr.IntNum(contents.length) =>
-        Some(contents.map(_ match {
-          case Ast.expr.IntNum(byteVal) if byteVal >= 0x00 && byteVal <= 0xff => "%02X".format(byteVal)
-          case _ => return None
-        }).mkString(" "))
+      case Some(expected: ValidationEquals) => {
+        expected.value match {
+          case Ast.expr.List(contents) if blt.size == Ast.expr.IntNum(contents.length) => {
+            Some(contents.map(_ match {
+              case Ast.expr.IntNum(byteVal) if byteVal >= 0x00 && byteVal <= 0xff => "%02X".format(byteVal)
+              case _ => return None
+            }).mkString(" "))
+          }
+          case _ => None
+        }
+      }
       case _ => None
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/ValidateOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/ValidateOps.scala
@@ -17,8 +17,8 @@ trait ValidateOps extends ExceptionNames {
   def attrValidate(attr: AttrLikeSpec, valid: ValidationSpec, useIo: Boolean): Unit = {
     val itemValue = Identifier.itemExpr(attr.id, attr.cond.repeat)
     valid match {
-      case ValidationEq(expected) =>
-        attrValidateExprCompare(attr, Ast.cmpop.Eq, expected, ValidationNotEqualError(attr.dataType), useIo)
+      case expected: ValidationEquals =>
+        attrValidateExprCompare(attr, Ast.cmpop.Eq, expected.value, ValidationNotEqualError(attr.dataType), useIo)
       case ValidationMin(min) =>
         attrValidateExprCompare(attr, Ast.cmpop.GtE, min, ValidationLessThanError(attr.dataType), useIo)
       case ValidationMax(max) =>


### PR DESCRIPTION
This PR adds missing validation for `valid` keys. Some problems not solved, because I do not know what is the prefered way for you to solve them. Namely:
- some expected error messages was written with some other check method in mind, namely `TypeDetector.assertCompareTypes`. Actually the other methods are used which produces another messages. Sometimes this produces false-positives, I guess
- some tests produces additional errors, the expected messages should be updated accordingly

Below the changed parts in the output (this is how errors looks after this PR).

Fixed (5):
```
[info] - attr_bad_valid_expr *** FAILED ***
[info]   []
[info]     did not equal
[info]   [attr_bad_valid_expr.ksy: /seq/0/valid/expr:
[info]          error: invalid type: expected boolean, got Int1Type(true)
[info]   ] (SimpleMatchers.scala:34)
[info] - expr_field_unknown_valid_eq_long *** FAILED ***
[info]   []
[info]     did not equal
[info]   [expr_field_unknown_valid_eq_long.ksy: /seq/0/valid/eq:
[info]          error: unable to access 'bar' in expr_field_unknown_valid_eq_long context
[info]   ] (SimpleMatchers.scala:34)
[info] - expr_field_unknown_valid_expr *** FAILED ***
[info]   []
[info]     did not equal
[info]   [expr_field_unknown_valid_expr.ksy: /seq/0/valid/expr:
[info]          error: unable to access 'bar' in expr_field_unknown_valid_expr context
[info]   ] (SimpleMatchers.scala:34)
[info] - expr_field_unknown_valid_range *** FAILED ***
[info]   []
[info]     did not equal
[info]   [expr_field_unknown_valid_range.ksy: /seq/0/valid/min:
[info]          error: unable to access 'bar' in expr_field_unknown_valid_range context
[info]
[info]   expr_field_unknown_valid_range.ksy: /seq/0/valid/max:
[info]          error: unable to access 'qux' in expr_field_unknown_valid_range context
[info]   ] (SimpleMatchers.scala:34)
[info] - expr_field_unknown_valid_eq_short *** FAILED ***
[info]   []
[info]     did not equal
[info]   [expr_field_unknown_valid_eq_short.ksy: /seq/0/valid:
[info]          error: unable to access 'bar' in expr_field_unknown_valid_eq_short context
[info]   ] (SimpleMatchers.scala:34)
```
Changed error message (6, expected must be corrected or false-positives):
```
[info] - attr_bad_valid_repeat_eq_short *** FAILED ***
[info]   [attr_bad_valid_repeat_eq_short.ksy: /seq/0/valid:
[info]          error: invalid type: expected IntMultiType(true,Width4,Some(LittleEndian)), got ArrayTypeInStream(CalcIntType)
[info]   ]
[info]     did not equal
[info]   [attr_bad_valid_repeat_eq_short.ksy: /seq/0/valid:
[info]          error: can't compare IntMultiType(true,Width4,Some(LittleEndian)) and ArrayTypeInStream(CalcIntType)
[info]   ] (SimpleMatchers.scala:34)
[info] - attr_bad_valid_eq_short *** FAILED ***
[info]   [attr_bad_valid_eq_short.ksy: /seq/0/valid:
[info]          error: invalid type: expected Int1Type(false), got CalcStrType
[info]   ]
[info]     did not equal
[info]   [attr_bad_valid_eq_short.ksy: /seq/0/valid:
[info]          error: can't compare Int1Type(false) and CalcStrType
[info]   ] (SimpleMatchers.scala:34)
[info] - attr_bad_valid_eq_long *** FAILED ***
[info]   [attr_bad_valid_eq_long.ksy: /seq/0/valid/eq:
[info]          error: invalid type: expected Int1Type(false), got CalcStrType
[info]   ]
[info]     did not equal
[info]   [attr_bad_valid_eq_long.ksy: /seq/0/valid/eq:
[info]          error: can't compare Int1Type(false) and CalcStrType
[info]   ] (SimpleMatchers.scala:34)
[info] - attr_bad_valid_any_of *** FAILED ***
[info]   [attr_bad_valid_any_of.ksy: /seq/0/valid/any-of/0:
[info]          error: invalid type: expected Int1Type(false), got Int1Type(true)
[info]
[info]   attr_bad_valid_any_of.ksy: /seq/0/valid/any-of/1:
[info]          error: invalid type: expected Int1Type(false), got Int1Type(true)
[info]
[info]   attr_bad_valid_any_of.ksy: /seq/0/valid/any-of/2:
[info]          error: invalid type: expected Int1Type(false), got CalcBooleanType
[info]
[info]   attr_bad_valid_any_of.ksy: /seq/0/valid/any-of/3:
[info]          error: invalid type: expected Int1Type(false), got Int1Type(true)
[info]   ]
[info]     did not equal
[info]   [attr_bad_valid_any_of.ksy: /seq/0/valid/any-of/2:
[info]          error: can't compare Int1Type(false) and CalcBooleanType
[info]   ] (SimpleMatchers.scala:34)
[info] - attr_bad_valid_range *** FAILED ***
[info]   [attr_bad_valid_range.ksy: /seq/0/valid/min:
[info]          error: invalid type: expected Int1Type(false), got CalcBooleanType
[info]
[info]   attr_bad_valid_range.ksy: /seq/0/valid/max:
[info]          error: invalid type: expected Int1Type(false), got CalcStrType
[info]   ]
[info]     did not equal
[info]   [attr_bad_valid_range.ksy: /seq/0/valid/min:
[info]          error: can't compare Int1Type(false) and CalcBooleanType
[info]
[info]   attr_bad_valid_range.ksy: /seq/0/valid/max:
[info]          error: can't compare Int1Type(false) and CalcStrType
[info]   ] (SimpleMatchers.scala:34)
[info] - expr_field_unknown_valid_any_of *** FAILED ***
[info]   [expr_field_unknown_valid_any_of.ksy: /seq/0/valid/any-of/0:
[info]          error: invalid type: expected Int1Type(false), got Int1Type(true)
[info]
[info]   expr_field_unknown_valid_any_of.ksy: /seq/0/valid/any-of/1:
[info]          error: unable to access 'bar' in expr_field_unknown_valid_any_of context
[info]
[info]   expr_field_unknown_valid_any_of.ksy: /seq/0/valid/any-of/2:
[info]          error: invalid type: expected Int1Type(false), got Int1Type(true)
[info]
[info]   expr_field_unknown_valid_any_of.ksy: /seq/0/valid/any-of/3:
[info]          error: unable to access 'qux' in expr_field_unknown_valid_any_of context
[info]   ]
[info]     did not equal
[info]   [expr_field_unknown_valid_any_of.ksy: /seq/0/valid/any-of/1:
[info]          error: unable to access 'bar' in expr_field_unknown_valid_any_of context
[info]
[info]   expr_field_unknown_valid_any_of.ksy: /seq/0/valid/any-of/3:
[info]          error: unable to access 'qux' in expr_field_unknown_valid_any_of context
[info]   ] (SimpleMatchers.scala:34)
```