### PR TITLE
Fix a number of errors in loops

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -11,7 +11,16 @@ class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends
   var nowClass = topClass
   val allClasses: ClassSpecs = classSpecs
 
+  /**
+    * Type of the `_` variable in the expression. That variable is defined in
+    * `repeat-until` and `valid: expr` contexts and refers to the attribute
+    * just parsed.
+    */
   var _currentIteratorType: Option[DataType] = None
+  /**
+    * Type of the `_on` variable in the expression. That variable is defined in
+    * `cases.<case>` contexts and refers to the value of `switch-on` expression.
+    */
   var _currentSwitchType: Option[DataType] = None
   def currentIteratorType: DataType = _currentIteratorType.get
   def currentSwitchType: DataType = _currentSwitchType.get

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -16,7 +16,7 @@ class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends
     * `repeat-until` and `valid: expr` contexts and refers to the attribute
     * just parsed.
     */
-  var _currentIteratorType: Option[DataType] = None
+  var _lastParsedType: Option[DataType] = None
   /**
     * Type of the `_on` variable in the expression. That variable is defined in
     * `cases.<case>` contexts and refers to the value of `switch-on` expression.
@@ -42,7 +42,7 @@ class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends
       case Identifier.IO =>
         KaitaiStreamType
       case Identifier.ITERATOR =>
-        _currentIteratorType match {
+        _lastParsedType match {
           case Some(value) => value
           case None => throw new ExpressionError(s"Context variable '$attrName' is available only in the 'repeat-until' and 'valid/expr' attributes")
         }

--- a/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ConstructClassCompiler.scala
@@ -87,7 +87,7 @@ class ConstructClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extend
     case RepeatExpr(expr) =>
       s"Array(${translator.translate(expr)}, $typeStr)"
     case RepeatUntil(expr) =>
-      provider._currentIteratorType = Some(dataType)
+      provider._lastParsedType = Some(dataType)
       s"RepeatUntil(lambda obj_, list_, this: ${translator.translate(expr)}, $typeStr)"
     case RepeatEos =>
       s"GreedyRange($typeStr)"

--- a/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
@@ -196,7 +196,7 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
           case ValidationInEnum() =>
             "must be defined in the enum"
           case ValidationExpr(expr) =>
-            provider._currentIteratorType = Some(dataType)
+            provider._lastParsedType = Some(dataType)
             s"must satisfy ${expression(expr, fullPortName, STYLE_EDGE_VALID)}"
         }
       case None => return
@@ -212,7 +212,7 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
           expression(ex, s"$currentTable:$portName", STYLE_EDGE_REPEAT) +
           " times</TD></TR>")
       case RepeatUntil(ex) =>
-        provider._currentIteratorType = Some(dataType)
+        provider._lastParsedType = Some(dataType)
         out.puts("<TR><TD COLSPAN=\"4\" PORT=\"" + portName + "\">repeat until " +
           expression(ex, s"$currentTable:$portName", STYLE_EDGE_REPEAT) +
           "</TD></TR>")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -300,8 +300,8 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (var i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i)")
+  override def condRepeatExprHeader(countExpr: expr): Unit = {
+    out.puts(s"for (var i = 0, _end = ${expression(countExpr)}; i < _end; ++i)")
     out.puts("{")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -331,7 +331,6 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts("i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -316,7 +316,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
     out.puts("var i = 0;")
     out.puts(s"${kaitaiType2NativeType(itemType)} ${translator.doName(Identifier.ITERATOR)};")
-    out.puts("do {")
+    out.puts("while (true) {")
     out.inc
   }
 
@@ -331,11 +331,16 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: expr): Unit = {
-    out.puts("i++;")
-    out.dec
-    out.puts(s"} while (!(${expression(untilExpr)}));")
+    out.puts(s"if (${expression(untilExpr)}) {")
+    out.inc
+    out.puts("break;")
     out.dec
     out.puts("}")
+    out.puts("++i;")
+    out.dec
+    out.puts("}") // close while (true)
+    out.dec
+    out.puts("}") // close scope of i and _ variables
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -311,7 +311,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatExprFooter: Unit = fileFooter(null)
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("{")
     out.inc
     out.puts("var i = 0;")
@@ -330,7 +330,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)}.Add($tempVar);")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     out.puts("i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -301,7 +301,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (var i = 0; i < ${expression(repeatExpr)}; i++)")
+    out.puts(s"for (var i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i)")
     out.puts("{")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -280,7 +280,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)} = new ${kaitaiType2NativeType(ArrayTypeInStream(dataType))}();")
   }
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("{")
     out.inc
     out.puts("var i = 0;")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -315,7 +315,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("{")
     out.inc
     out.puts("var i = 0;")
-    out.puts(s"${kaitaiType2NativeType(dataType)} ${translator.doName("_")};")
+    out.puts(s"${kaitaiType2NativeType(dataType)} ${translator.doName(Identifier.ITERATOR)};")
     out.puts("do {")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -311,11 +311,11 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatExprFooter: Unit = fileFooter(null)
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("{")
     out.inc
     out.puts("var i = 0;")
-    out.puts(s"${kaitaiType2NativeType(dataType)} ${translator.doName(Identifier.ITERATOR)};")
+    out.puts(s"${kaitaiType2NativeType(itemType)} ${translator.doName(Identifier.ITERATOR)};")
     out.puts("do {")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -641,7 +641,6 @@ class CppCompiler(
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     outSrc.puts("i++;")
     outSrc.dec
     outSrc.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -611,7 +611,7 @@ class CppCompiler(
     outSrc.inc
     outSrc.puts("int i = 0;")
     outSrc.puts(s"${kaitaiType2NativeType(itemType.asNonOwning())} ${translator.doName(Identifier.ITERATOR)};")
-    outSrc.puts("do {")
+    outSrc.puts("while (true) {")
     outSrc.inc
   }
 
@@ -641,11 +641,16 @@ class CppCompiler(
   }
 
   override def condRepeatUntilFooter(untilExpr: expr): Unit = {
-    outSrc.puts("i++;")
-    outSrc.dec
-    outSrc.puts(s"} while (!(${expression(untilExpr)}));")
+    outSrc.puts(s"if (${expression(untilExpr)}) {")
+    outSrc.inc
+    outSrc.puts("break;")
     outSrc.dec
     outSrc.puts("}")
+    outSrc.puts("++i;")
+    outSrc.dec
+    outSrc.puts("}") // close while (true)
+    outSrc.dec
+    outSrc.puts("}") // close scope of i and _ variables
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -571,7 +571,7 @@ class CppCompiler(
     outSrc.puts(s"${privateMemberName(id)} = ${newVector(dataType)};")
   }
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     outSrc.puts("{")
     outSrc.inc
     outSrc.puts("int i = 0;")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -591,8 +591,8 @@ class CppCompiler(
     outSrc.puts("}")
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    outSrc.puts(s"for (int i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i) {")
+  override def condRepeatExprHeader(countExpr: Ast.expr): Unit = {
+    outSrc.puts(s"for (int i = 0, _end = ${expression(countExpr)}; i < _end; ++i) {")
     outSrc.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -592,9 +592,7 @@ class CppCompiler(
   }
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    val lenVar = s"l_${idToStr(id)}"
-    outSrc.puts(s"const int $lenVar = ${expression(repeatExpr)};")
-    outSrc.puts(s"for (int i = 0; i < $lenVar; i++) {")
+    outSrc.puts(s"for (int i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i) {")
     outSrc.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -610,7 +610,7 @@ class CppCompiler(
     outSrc.puts("{")
     outSrc.inc
     outSrc.puts("int i = 0;")
-    outSrc.puts(s"${kaitaiType2NativeType(dataType.asNonOwning())} ${translator.doName("_")};")
+    outSrc.puts(s"${kaitaiType2NativeType(dataType.asNonOwning())} ${translator.doName(Identifier.ITERATOR)};")
     outSrc.puts("do {")
     outSrc.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -606,7 +606,7 @@ class CppCompiler(
     outSrc.puts("}")
   }
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     outSrc.puts("{")
     outSrc.inc
     outSrc.puts("int i = 0;")
@@ -640,7 +640,7 @@ class CppCompiler(
     outSrc.puts(s"${privateMemberName(id)}->push_back($wrappedTempVar);")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     outSrc.puts("i++;")
     outSrc.dec
     outSrc.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -606,11 +606,11 @@ class CppCompiler(
     outSrc.puts("}")
   }
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     outSrc.puts("{")
     outSrc.inc
     outSrc.puts("int i = 0;")
-    outSrc.puts(s"${kaitaiType2NativeType(dataType.asNonOwning())} ${translator.doName(Identifier.ITERATOR)};")
+    outSrc.puts(s"${kaitaiType2NativeType(itemType.asNonOwning())} ${translator.doName(Identifier.ITERATOR)};")
     outSrc.puts("do {")
     outSrc.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -334,7 +334,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, r: TranslatorResult): Unit =
     handleAssignmentRepeatEos(id, r)
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts(s"for i := 1;; i++ {")
     out.inc
   }
@@ -346,7 +346,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)} = append(${privateMemberName(id)}, $tempVar)")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
     out.puts(s"if ${expression(untilExpr)} {")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -320,8 +320,8 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"$name = append($name, $expr)")
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    out.puts(s"for i, _end := 0, int(${expression(repeatExpr)}); i < _end; i++ {")
+  override def condRepeatExprHeader(countExpr: Ast.expr): Unit = {
+    out.puts(s"for i, _end := 0, int(${expression(countExpr)}); i < _end; i++ {")
     out.inc
     // FIXME: Go throws a fatal compile error when the `i` variable is not used (unused variables
     // can only use the blank identifier `_`, see https://go.dev/doc/effective_go#blank), so we have

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -334,7 +334,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, r: TranslatorResult): Unit =
     handleAssignmentRepeatEos(id, r)
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts(s"for i := 1;; i++ {")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -347,7 +347,6 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts(s"if ${expression(untilExpr)} {")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -335,7 +335,10 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     handleAssignmentRepeatEos(id, r)
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
-    out.puts(s"for i := 1;; i++ {")
+    out.puts("{")
+    out.inc
+    out.puts("i := 0")
+    out.puts(s"for {")
     out.inc
   }
 
@@ -352,8 +355,11 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("break")
     out.dec
     out.puts("}")
+    out.puts("i++;")
     out.dec
-    out.puts("}")
+    out.puts("}") // close for
+    out.dec
+    out.puts("}") // close scope of i variable
   }
 
   private def castToType(r: TranslatorResult, dataType: DataType): TranslatorResult = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -305,7 +305,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
 
     val eofVar = translator.allocateLocalVar()
-    out.puts(s"${translator.localVarName(eofVar)}, err := this._io.EOF()")
+    out.puts(s"${translator.localVarName(eofVar)}, err := $io.EOF()")
     translator.outAddErrCheck()
     out.puts(s"if ${translator.localVarName(eofVar)} {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -300,7 +300,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     // function works even on `nil` slices (https://go.dev/tour/moretypes/15)
   }
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts(s"for i := 0;; i++ {")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -321,7 +321,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    out.puts(s"for i := 0; i < int(${expression(repeatExpr)}); i++ {")
+    out.puts(s"for i, _end := 0, int(${expression(repeatExpr)}); i < _end; i++ {")
     out.inc
     // FIXME: Go throws a fatal compile error when the `i` variable is not used (unused variables
     // can only use the blank identifier `_`, see https://go.dev/doc/effective_go#blank), so we have

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -390,7 +390,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
     out.puts("{")
     out.inc
-    out.puts(s"${kaitaiType2JavaType(dataType)} ${translator.doName("_")};")
+    out.puts(s"${kaitaiType2JavaType(dataType)} ${translator.doName(Identifier.ITERATOR)};")
     out.puts("int i = 0;")
     out.puts("do {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -409,7 +409,6 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts("i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -377,8 +377,8 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (int i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i) {")
+  override def condRepeatExprHeader(countExpr: expr): Unit = {
+    out.puts(s"for (int i = 0, _end = ${expression(countExpr)}; i < _end; ++i) {")
     out.inc
 
     importList.add("java.util.ArrayList")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -355,7 +355,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit =
     out.puts(s"${privateMemberName(id)} = new ${kaitaiType2JavaType(ArrayTypeInStream(dataType))}();")
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("{")
     out.inc
     out.puts("int i = 0;")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -387,10 +387,10 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("{")
     out.inc
-    out.puts(s"${kaitaiType2JavaType(dataType)} ${translator.doName(Identifier.ITERATOR)};")
+    out.puts(s"${kaitaiType2JavaType(itemType)} ${translator.doName(Identifier.ITERATOR)};")
     out.puts("int i = 0;")
     out.puts("do {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -378,7 +378,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (int i = 0; i < ${expression(repeatExpr)}; i++) {")
+    out.puts(s"for (int i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i) {")
     out.inc
 
     importList.add("java.util.ArrayList")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -392,7 +392,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
     out.puts(s"${kaitaiType2JavaType(itemType)} ${translator.doName(Identifier.ITERATOR)};")
     out.puts("int i = 0;")
-    out.puts("do {")
+    out.puts("while (true) {")
     out.inc
 
     importList.add("java.util.ArrayList")
@@ -409,11 +409,16 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: expr): Unit = {
-    out.puts("i++;")
-    out.dec
-    out.puts(s"} while (!(${expression(untilExpr)}));")
+    out.puts(s"if (${expression(untilExpr)}) {")
+    out.inc
+    out.puts("break;")
     out.dec
     out.puts("}")
+    out.puts("++i;")
+    out.dec
+    out.puts("}") // close while (true)
+    out.dec
+    out.puts("}") // close scope of i and _ variables
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -387,7 +387,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("{")
     out.inc
     out.puts(s"${kaitaiType2JavaType(dataType)} ${translator.doName(Identifier.ITERATOR)};")
@@ -408,7 +408,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)}.add($tempVar);")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     out.puts("i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -303,7 +303,7 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit =
     out.puts(s"${privateMemberName(id)} = [];")
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("var i = 0;")
     out.puts(s"while (!$io.isEof()) {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -320,7 +320,7 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (var i = 0; i < ${expression(repeatExpr)}; i++) {")
+    out.puts(s"for (var i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i) {")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -333,8 +333,9 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
+    // "var" variables in any case have a scope of surrounding function, no need a scope to isolate them
     out.puts("var i = 0;")
-    out.puts("do {")
+    out.puts("while (true) {")
     out.inc
   }
 
@@ -345,9 +346,14 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: expr): Unit = {
-    out.puts("i++;")
+    out.puts(s"if (${expression(untilExpr)}) {")
+    out.inc
+    out.puts("break;")
     out.dec
-    out.puts(s"} while (!(${expression(untilExpr)}));")
+    out.puts("}")
+    out.puts("++i;")
+    out.dec
+    out.puts("}") // close while (true)
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -332,7 +332,7 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("var i = 0;")
     out.puts("do {")
     out.inc
@@ -344,7 +344,7 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)}.push($tmpName);")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     out.puts("i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -345,7 +345,6 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts("i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -332,7 +332,7 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("var i = 0;")
     out.puts("do {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -319,8 +319,8 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (var i = 0, _end = ${expression(repeatExpr)}; i < _end; ++i) {")
+  override def condRepeatExprHeader(countExpr: expr): Unit = {
+    out.puts(s"for (var i = 0, _end = ${expression(countExpr)}; i < _end; ++i) {")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -196,7 +196,6 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
   }
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts(s"if ${expression(untilExpr)} then")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -190,7 +190,7 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("end")
   }
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("local i = 0")
     out.puts("while true do")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -190,12 +190,12 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("end")
   }
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("local i = 0")
     out.puts("while true do")
     out.inc
   }
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
     out.puts(s"if ${expression(untilExpr)} then")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -191,6 +191,7 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
+    // Lua allows shadowing of variables, no need a scope to isolate them
     out.puts("local i = 0")
     out.puts("while true do")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -181,8 +181,8 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("end")
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    out.puts(s"for i = 0, ${expression(repeatExpr)} - 1 do")
+  override def condRepeatExprHeader(countExpr: Ast.expr): Unit = {
+    out.puts(s"for i = 0, ${expression(countExpr)} - 1 do")
     out.inc
   }
   override def condRepeatExprFooter: Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -170,7 +170,7 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)} = {}")
   }
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("local i = 0")
     out.puts(s"while not $io:is_eof() do")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -171,7 +171,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"for i in 0 ..< int(${expression(repeatExpr)}):")
     out.inc
   }
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("block:")
     out.inc
     out.puts("var i: int")

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -179,7 +179,6 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
   }
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts(s"if ${expression(untilExpr)}:")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -171,14 +171,14 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"for i in 0 ..< int(${expression(repeatExpr)}):")
     out.inc
   }
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("block:")
     out.inc
     out.puts("var i: int")
     out.puts("while true:")
     out.inc
   }
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
     out.puts(s"if ${expression(untilExpr)}:")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -167,8 +167,8 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
     out.dec
   }
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    out.puts(s"for i in 0 ..< int(${expression(repeatExpr)}):")
+  override def condRepeatExprHeader(countExpr: Ast.expr): Unit = {
+    out.puts(s"for i in 0 ..< int(${expression(countExpr)}):")
     out.inc
   }
   override def condRepeatUntilHeader(itemType: DataType): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -155,7 +155,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     // empty sequences (see https://narimiran.github.io/nim-basics/#_result_variable)
   }
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("block:")
     out.inc
     out.puts("var i: int")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -306,7 +306,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("$i = 0;")
     out.puts("do {")
     out.inc
@@ -318,7 +318,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)}[] = $tmpName;")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
     out.puts("$i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -297,8 +297,8 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     super.condRepeatEosFooter
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
-    out.puts(s"$$n = ${expression(repeatExpr)};")
+  override def condRepeatExprHeader(countExpr: Ast.expr): Unit = {
+    out.puts(s"$$n = ${expression(countExpr)};")
     out.puts("for ($i = 0; $i < $n; $i++) {")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -306,7 +306,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("$i = 0;")
     out.puts("do {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -282,7 +282,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit =
     out.puts(s"${privateMemberName(id)} = [];")
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("$i = 0;")
     out.puts(s"while (!$io->isEof()) {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -319,7 +319,6 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts("$i++;")
     out.dec
     out.puts(s"} while (!(${expression(untilExpr)}));")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -308,7 +308,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("$i = 0;")
-    out.puts("do {")
+    out.puts("while (1) {")
     out.inc
   }
 
@@ -319,9 +319,16 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
+    out.puts(s"if ${expression(untilExpr)} {")
+    out.inc
+    out.puts("break;")
+    out.dec
+    out.puts("}")
     out.puts("$i++;")
     out.dec
-    out.puts(s"} while (!(${expression(untilExpr)}));")
+    out.puts("}") // close while (1)
+    out.dec
+    out.puts("}") // close scope of i variable
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -255,9 +255,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"push @{${privateMemberName(id)}}, $expr;")
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    val nVar = s"$$n_${idToStr(id)}"
-    out.puts(s"my $nVar = ${expression(repeatExpr)};")
-    out.puts(s"for (my $$i = 0; $$i < $nVar; $$i++) {")
+    out.puts(s"for (my $$i = 0, $$_end = ${expression(repeatExpr)}; $$i < $$_end; ++$$i) {")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -264,7 +264,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("do {")
     out.inc
   }
@@ -279,7 +279,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"push @{${privateMemberName(id)}}, $tmpName;")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     out.dec
     out.puts(s"} until (${expression(untilExpr)});")
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -247,12 +247,20 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)} = [];")
 
   override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+    // Perl allows shadowing of variables, no need a scope to isolate them
+    out.puts("my $i = 0;")
     out.puts(s"while (!$io->is_eof()) {")
     out.inc
   }
 
   override def handleAssignmentRepeatEos(id: Identifier, expr: String): Unit =
     out.puts(s"push @{${privateMemberName(id)}}, $expr;")
+
+  override def condRepeatEosFooter: Unit = {
+    out.puts("$i++;")
+    out.dec
+    out.puts("}")
+  }
 
   override def condRepeatExprHeader(countExpr: expr): Unit = {
     out.puts(s"for (my $$i = 0, $$_end = ${expression(countExpr)}; $$i < $$_end; ++$$i) {")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -264,7 +264,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("do {")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -246,7 +246,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit =
     out.puts(s"${privateMemberName(id)} = [];")
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     // Perl allows shadowing of variables, no need a scope to isolate them
     out.puts("my $i = 0;")
     out.puts(s"while (!$io->is_eof()) {")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -352,7 +352,6 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def switchRequiresIfs(onType: DataType): Boolean = true
 
   override def switchIfStart(id: Identifier, on: Ast.expr, onType: DataType): Unit = {
-    typeProvider._currentSwitchType = Some(translator.detectType(on))
     out.puts(s"my $$_on = ${expression(on)};")
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -280,7 +280,6 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.dec
     out.puts(s"} until (${expression(untilExpr)});")
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -265,7 +265,9 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     handleAssignmentRepeatEos(id, expr)
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
-    out.puts("do {")
+    // Perl allows shadowing of variables, no need a scope to isolate them
+    out.puts("my $i = 0;")
+    out.puts("while (1) {")
     out.inc
   }
 
@@ -280,8 +282,10 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: expr): Unit = {
+    out.puts(s"last if (${expression(untilExpr)});")
+    out.puts("$i++;")
     out.dec
-    out.puts(s"} until (${expression(untilExpr)});")
+    out.puts("}") // close while (1)
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -254,8 +254,8 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatEos(id: Identifier, expr: String): Unit =
     out.puts(s"push @{${privateMemberName(id)}}, $expr;")
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for (my $$i = 0, $$_end = ${expression(repeatExpr)}; $$i < $$_end; ++$$i) {")
+  override def condRepeatExprHeader(countExpr: expr): Unit = {
+    out.puts(s"for (my $$i = 0, $$_end = ${expression(countExpr)}; $$i < $$_end; ++$$i) {")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -300,7 +300,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit =
     out.puts(s"${privateMemberName(id)} = []")
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("i = 0")
     out.puts(s"while not $io.is_eof():")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -320,7 +320,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("i = 0")
     out.puts("while True:")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -333,7 +333,6 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts(s"if ${expression(untilExpr)}:")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -313,8 +313,8 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     universalFooter
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"for i in range(${expression(repeatExpr)}):")
+  override def condRepeatExprHeader(countExpr: expr): Unit = {
+    out.puts(s"for i in range(${expression(countExpr)}):")
     out.inc
   }
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -320,7 +320,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =
     handleAssignmentRepeatEos(id, expr)
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("i = 0")
     out.puts("while True:")
     out.inc
@@ -332,7 +332,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)}.append($tmpName)")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     out.puts(s"if ${expression(untilExpr)}:")
     out.inc
     out.puts("break")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -331,7 +331,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("i = 0")
     out.puts("begin")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -331,7 +331,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("i = 0")
     out.puts("begin")
     out.inc
@@ -343,7 +343,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"${privateMemberName(id)} << $tmpName")
   }
 
-  override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: expr): Unit = {
     out.puts("i += 1")
     out.dec
     out.puts(s"end until ${expression(untilExpr)}")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -306,7 +306,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit =
     out.puts(s"${privateMemberName(id)} = []")
 
-  override def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit = {
+  override def condRepeatEosHeader(io: String): Unit = {
     out.puts("i = 0")
     out.puts(s"while not $io.eof?")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -333,7 +333,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("i = 0")
-    out.puts("begin")
+    out.puts("while true")
     out.inc
   }
 
@@ -344,9 +344,10 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: expr): Unit = {
+    out.puts(s"break if ${expression(untilExpr)}")
     out.puts("i += 1")
     out.dec
-    out.puts(s"end until ${expression(untilExpr)}")
+    out.puts("end")
   }
 
   override def handleAssignmentSimple(id: Identifier, expr: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -319,8 +319,8 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     super.condRepeatEosFooter
   }
 
-  override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: expr): Unit = {
-    out.puts(s"(${expression(repeatExpr)}).times { |i|")
+  override def condRepeatExprHeader(countExpr: expr): Unit = {
+    out.puts(s"(${expression(countExpr)}).times { |i|")
     out.inc
   }
   override def handleAssignmentRepeatExpr(id: Identifier, expr: String): Unit =

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -344,7 +344,6 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: expr): Unit = {
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts("i += 1")
     out.dec
     out.puts(s"end until ${expression(untilExpr)}")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -329,8 +329,8 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
                                            isRaw: Boolean): Unit = {
     out.puts(s"${RustCompiler.privateMemberName(id, writeAccess = true)}.push($expr);")
     var copy_type = ""
-    // typeProvider._currentIteratorType is set in CommonReads.attrParse0
-    if (translator.is_copy_type(typeProvider._currentIteratorType.get)) {
+    // typeProvider._lastParsedType is set in CommonReads.attrParse0
+    if (translator.is_copy_type(typeProvider._lastParsedType.get)) {
       copy_type = "*"
     }
     val t = localTemporaryName(id)

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -277,11 +277,8 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"*${RustCompiler.privateMemberName(id, writeAccess = true)} = Vec::new();")
   }
 
-  override def condRepeatEosHeader(id: Identifier,
-                                   io: String,
-                                   dataType: DataType): Unit = {
-    out.puts("{")
-    out.inc
+  override def condRepeatEosHeader(io: String): Unit = {
+    // Rust allows shadowing of variables, no need a scope to isolate them
     out.puts(s"let mut _i = 0;")
     out.puts(s"while !$io.is_eof() {")
     out.inc
@@ -293,8 +290,6 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def condRepeatEosFooter: Unit = {
     out.puts("_i += 1;")
-    out.dec
-    out.puts("}")
     out.dec
     out.puts("}")
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -343,8 +343,6 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
                                      io: String,
                                      dataType: DataType,
                                      repeatExpr: Ast.expr): Unit = {
-    // this line required by kaitai code
-    typeProvider._currentIteratorType = Some(dataType)
     out.puts("_i += 1;")
     out.puts(s"let x = !(${expression(repeatExpr)});")
     out.puts("x")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -309,10 +309,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
   }
 
-  override def condRepeatUntilHeader(id: Identifier,
-                                     io: String,
-                                     dataType: DataType,
-                                     repeatExpr: Ast.expr): Unit = {
+  override def condRepeatUntilHeader(dataType: DataType): Unit = {
     out.puts("{")
     out.inc
     out.puts("let mut _i = 0;")
@@ -338,12 +335,9 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"let ${translator.doLocalName(Identifier.ITERATOR)} = $copy_type$t.last().unwrap();")
   }
 
-  override def condRepeatUntilFooter(id: Identifier,
-                                     io: String,
-                                     dataType: DataType,
-                                     repeatExpr: Ast.expr): Unit = {
+  override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
     out.puts("_i += 1;")
-    out.puts(s"let x = !(${expression(repeatExpr)});")
+    out.puts(s"let x = !(${expression(untilExpr)});")
     out.puts("x")
     out.dec
     out.puts("} {}")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -299,11 +299,8 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("}")
   }
 
-  override def condRepeatExprHeader(id: Identifier,
-                                    io: String,
-                                    dataType: DataType,
-                                    repeatExpr: Ast.expr): Unit = {
-    out.puts(s"let _end = ${expression(repeatExpr)};")
+  override def condRepeatExprHeader(countExpr: Ast.expr): Unit = {
+    out.puts(s"let _end = ${expression(countExpr)};")
     out.puts(s"for _i in 0.._end {")
     out.inc
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -309,7 +309,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
   }
 
-  override def condRepeatUntilHeader(dataType: DataType): Unit = {
+  override def condRepeatUntilHeader(itemType: DataType): Unit = {
     out.puts("{")
     out.inc
     out.puts("let mut _i = 0;")

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -310,10 +310,9 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilHeader(itemType: DataType): Unit = {
-    out.puts("{")
-    out.inc
+    // Rust allows shadowing of variables, no need a scope to isolate them
     out.puts("let mut _i = 0;")
-    out.puts("while {")
+    out.puts("loop {")
     out.inc
   }
 
@@ -336,13 +335,14 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def condRepeatUntilFooter(untilExpr: Ast.expr): Unit = {
-    out.puts("_i += 1;")
-    out.puts(s"let x = !(${expression(untilExpr)});")
-    out.puts("x")
-    out.dec
-    out.puts("} {}")
+    out.puts(s"if ${expression(untilExpr)} {")
+    out.inc
+    out.puts("break")
     out.dec
     out.puts("}")
+    out.puts("_i += 1;")
+    out.dec
+    out.puts("}") // close loop
   }
 
   def getRawIdExpr(varName: Identifier, rep: RepeatSpec): String = {

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -273,9 +273,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.inc
   }
 
-   override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit = {
-    // this line required for handleAssignmentRepeatUntil
-    typeProvider._currentIteratorType = Some(dataType)
+  override def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit = {
     out.puts(s"*${RustCompiler.privateMemberName(id, writeAccess = true)} = Vec::new();")
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -283,7 +283,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("{")
     out.inc
     out.puts(s"let mut _i = 0;")
-    out.puts(s"while !_io.is_eof() {")
+    out.puts(s"while !$io.is_eof() {")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -329,7 +329,8 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
                                            isRaw: Boolean): Unit = {
     out.puts(s"${RustCompiler.privateMemberName(id, writeAccess = true)}.push($expr);")
     var copy_type = ""
-    if (typeProvider._currentIteratorType.isDefined && translator.is_copy_type(typeProvider._currentIteratorType.get)) {
+    // typeProvider._currentIteratorType is set in CommonReads.attrParse0
+    if (translator.is_copy_type(typeProvider._currentIteratorType.get)) {
       copy_type = "*"
     }
     val t = localTemporaryName(id)

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -303,9 +303,8 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
                                     io: String,
                                     dataType: DataType,
                                     repeatExpr: Ast.expr): Unit = {
-    val lenVar = s"l_${idToStr(id)}"
-    out.puts(s"let $lenVar = ${expression(repeatExpr)};")
-    out.puts(s"for _i in 0..$lenVar {")
+    out.puts(s"let _end = ${expression(repeatExpr)};")
+    out.puts(s"for _i in 0.._end {")
     out.inc
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
@@ -64,7 +64,7 @@ trait CommonReads extends LanguageCompiler {
       (ExtraAttrs.forAttr(attr, this) ++ List(attr)).foreach(a => condRepeatInitAttr(a.id, a.dataType))
     attr.cond.repeat match {
       case RepeatEos =>
-        condRepeatEosHeader(id, io, attr.dataType)
+        condRepeatEosHeader(io)
       case RepeatExpr(countExpr: Ast.expr) =>
         condRepeatExprHeader(countExpr)
       case RepeatUntil(_) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
@@ -88,6 +88,8 @@ trait CommonReads extends LanguageCompiler {
       case _: RepeatExpr =>
         condRepeatExprFooter
       case RepeatUntil(untilExpr: Ast.expr) =>
+        // Set the type of the `_` variable in expression
+        typeProvider._currentIteratorType = Some(attr.dataType)
         condRepeatUntilFooter(id, io, attr.dataType, untilExpr)
       case NoRepeat =>
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
@@ -65,8 +65,8 @@ trait CommonReads extends LanguageCompiler {
     attr.cond.repeat match {
       case RepeatEos =>
         condRepeatEosHeader(id, io, attr.dataType)
-      case RepeatExpr(repeatExpr: Ast.expr) =>
-        condRepeatExprHeader(id, io, attr.dataType, repeatExpr)
+      case RepeatExpr(countExpr: Ast.expr) =>
+        condRepeatExprHeader(countExpr)
       case RepeatUntil(_) =>
         condRepeatUntilHeader(attr.dataType)
       case NoRepeat =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
@@ -89,7 +89,7 @@ trait CommonReads extends LanguageCompiler {
         condRepeatExprFooter
       case RepeatUntil(untilExpr: Ast.expr) =>
         // Set the type of the `_` variable in expression
-        typeProvider._currentIteratorType = Some(attr.dataType)
+        typeProvider._lastParsedType = Some(attr.dataType)
         condRepeatUntilFooter(id, io, attr.dataType, untilExpr)
       case NoRepeat =>
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/CommonReads.scala
@@ -67,8 +67,8 @@ trait CommonReads extends LanguageCompiler {
         condRepeatEosHeader(id, io, attr.dataType)
       case RepeatExpr(repeatExpr: Ast.expr) =>
         condRepeatExprHeader(id, io, attr.dataType, repeatExpr)
-      case RepeatUntil(untilExpr: Ast.expr) =>
-        condRepeatUntilHeader(id, io, attr.dataType, untilExpr)
+      case RepeatUntil(_) =>
+        condRepeatUntilHeader(attr.dataType)
       case NoRepeat =>
     }
 
@@ -90,7 +90,7 @@ trait CommonReads extends LanguageCompiler {
       case RepeatUntil(untilExpr: Ast.expr) =>
         // Set the type of the `_` variable in expression
         typeProvider._lastParsedType = Some(attr.dataType)
-        condRepeatUntilFooter(id, io, attr.dataType, untilExpr)
+        condRepeatUntilFooter(untilExpr)
       case NoRepeat =>
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -133,7 +133,16 @@ abstract class LanguageCompiler(
 
   def condRepeatInitAttr(id: Identifier, dataType: DataType): Unit
 
-  def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit
+  /**
+    * Generates start of loop until end-of-stream is reached.
+    *
+    * @param io rendered expression that evaluates to reference of a stream which
+    *        should be checked
+    */
+  def condRepeatEosHeader(io: String): Unit
+  /**
+    * Generates end of loop until end-of-stream is reached.
+    */
   def condRepeatEosFooter: Unit
 
   /**

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -139,8 +139,8 @@ abstract class LanguageCompiler(
   def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit
   def condRepeatExprFooter: Unit
 
-  def condRepeatUntilHeader(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit
-  def condRepeatUntilFooter(id: Identifier, io: String, dataType: DataType, untilExpr: Ast.expr): Unit
+  def condRepeatUntilHeader(dataType: DataType): Unit
+  def condRepeatUntilFooter(untilExpr: Ast.expr): Unit
 
   def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier, rep: RepeatSpec): Unit
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -136,7 +136,16 @@ abstract class LanguageCompiler(
   def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType): Unit
   def condRepeatEosFooter: Unit
 
-  def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit
+  /**
+    * Generates start of "for 0..<count>" loop which loops specified count of times.
+    *
+    * @param countExpr expression that evaluates into number of repetitions.
+    *        That expression should be evaluated only once before loop is started
+    */
+  def condRepeatExprHeader(countExpr: Ast.expr): Unit
+  /**
+    * Generates end of "for 0..<count>" loop.
+    */
   def condRepeatExprFooter: Unit
 
   /**

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -139,7 +139,22 @@ abstract class LanguageCompiler(
   def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit
   def condRepeatExprFooter: Unit
 
-  def condRepeatUntilHeader(dataType: DataType): Unit
+  /**
+    * Generates start of "repeat ... until" loop which parses element of type `itemType`
+    * on each iteration.
+    *
+    * @param itemType Type of the element that can be used to declare variable for
+    *        holding that element so it will accessible in the condition in the footer.
+    *        In most languages condition in special "repeat ... until" loop cannot
+    *        access variables, defined in body of loop
+    */
+  def condRepeatUntilHeader(itemType: DataType): Unit
+  /**
+    * Generates end of "repeat ... until" loop which checks the specified condition.
+    *
+    * @param untilExpr condition that evaluates to boolean value where `true` means
+    *        that loop will be finished
+    */
   def condRepeatUntilFooter(untilExpr: Ast.expr): Unit
 
   def attrProcess(proc: ProcessExpr, varSrc: Identifier, varDest: Identifier, rep: RepeatSpec): Unit

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/ValidateOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/ValidateOps.scala
@@ -62,7 +62,7 @@ trait ValidateOps extends ExceptionNames {
         )
       case ValidationExpr(expr) =>
         blockScopeHeader
-        typeProvider._currentIteratorType = Some(attr.dataType)
+        typeProvider._lastParsedType = Some(attr.dataType)
         handleAssignmentTempVar(
           attr.dataType,
           translator.translate(Ast.expr.Name(Ast.identifier(Identifier.ITERATOR))),

--- a/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
@@ -8,7 +8,7 @@ import io.kaitai.struct.translators.MethodArgType
  * Base class for all expression-related errors, not localized to a certain path
  * in source file.
  */
-sealed abstract class ExpressionError(msg: String) extends RuntimeException(msg)
+sealed class ExpressionError(msg: String) extends RuntimeException(msg)
 class TypeMismatchError(msg: String) extends ExpressionError(msg)
 class TypeUndecidedError(msg: String) extends ExpressionError(msg)
 class WrongMethodCall(val dataType: MethodArgType, val methodName: String, val expectedSigs: Iterable[String], val actualSig: String)

--- a/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
@@ -70,11 +70,11 @@ class TypeValidator(specs: ClassSpecs) extends PrecompileStep {
       checkAssert[BooleanType](ifExpr, "boolean", path, "if")
     )
 
-    provider._currentIteratorType = Some(attr.dataType)
     val problemsRepeat: Iterable[CompilationProblem] = attr.cond.repeat match {
       case RepeatExpr(expr) =>
         checkAssert[IntType](expr, "integer", path, "repeat-expr")
       case RepeatUntil(expr) =>
+        provider._currentIteratorType = Some(attr.dataType)
         checkAssert[BooleanType](expr, "boolean", path, "repeat-until")
       case RepeatEos | NoRepeat =>
         None

--- a/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/TypeValidator.scala
@@ -74,7 +74,7 @@ class TypeValidator(specs: ClassSpecs) extends PrecompileStep {
       case RepeatExpr(expr) =>
         checkAssert[IntType](expr, "integer", path, "repeat-expr")
       case RepeatUntil(expr) =>
-        provider._currentIteratorType = Some(attr.dataType)
+        provider._lastParsedType = Some(attr.dataType)
         checkAssert[BooleanType](expr, "boolean", path, "repeat-until")
       case RepeatEos | NoRepeat =>
         None


### PR DESCRIPTION
This PR the result of revision of how generation of repeated attributes is implemented due to which a number of bugs was found and fixed:
- `TypeValidator` incorrectly define `_` variable for all kinds of loops, but it is generated only for `repeat-until` loops
- fixes https://github.com/kaitai-io/kaitai_struct/issues/958, closes #245
- C#, Go, Java, JavaScript was calculate count of repetitions of `repeat-expr` loops on each iteration, whereas other languages performs such calculations only once. Now they are also calculate count only once
- Now Perl defines `_index` variable in `repeat: eos` loops
- Go and Rust was incorrectly used root IO object instead of current IO object of the attribute. The difference should be noticable when `io: ...` is used

This PR supersedes #234

Also, some refactoring was done: removed unused parameters and documented methods that generates loops. 

Besides, `_currentIteratorType` was renamed to `_lastParsedType` (this is the variable that holds type of the `_` variable in expression language) because it is used also in `valid: expr` key to refer to the element that just was parsed.