### PR TITLE
Fix parsing of `enum` key: allow absolute paths and fix value instances

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
@@ -1,0 +1,566 @@
+package io.kaitai.struct
+
+import java.util.NoSuchElementException
+import io.kaitai.struct.format.{ClassSpec, ClassSpecs}
+import io.kaitai.struct.formats.{JavaClassSpecs, JavaKSYParser}
+import io.kaitai.struct.precompile.{EnumNotFoundError, MarkupClassNames, TypeNotFoundError}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+
+class ClassTypeProvider$Test extends AnyFunSpec {
+  val root = ClassSpec.fromYaml(JavaKSYParser.stringToYaml("""
+    meta:
+      id: root
+    types:
+      child_1:
+        types:
+          one: {} # child_11
+          two:    # child_12
+            types:
+              one: {} # child_121
+              two: {} # child_122
+      child_2:
+        types:
+          one: {} # child_21
+          two: {} # child_22
+  """), None)
+  val specs = new JavaClassSpecs("", Seq(), root)
+  // Calculates full class names needed for work of the provider
+  new MarkupClassNames(specs).run()
+
+  val child_1 = root.types.get("child_1").getOrElse(throw new NoSuchElementException("'child_1' not found"))
+  val child_2 = root.types.get("child_2").getOrElse(throw new NoSuchElementException("'child_2' not found"))
+
+  val child_11 = child_1.types.get("one").getOrElse(throw new NoSuchElementException("'child_11' not found"))
+  val child_12 = child_1.types.get("two").getOrElse(throw new NoSuchElementException("'child_12' not found"))
+
+  val child_21 = child_2.types.get("one").getOrElse(throw new NoSuchElementException("'child_21' not found"))
+  val child_22 = child_2.types.get("two").getOrElse(throw new NoSuchElementException("'child_22' not found"))
+
+  val child_121 = child_12.types.get("one").getOrElse(throw new NoSuchElementException("'child_121' not found"))
+  val child_122 = child_12.types.get("two").getOrElse(throw new NoSuchElementException("'child_122' not found"))
+
+  describe("resolveTypeName") {
+    describe("in 'root' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(root, "root") should be(root) // self-reference
+      }
+
+      it("doesn't resolve 'one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(root, "one")
+      }
+
+      it("doesn't resolve 'two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(root, "two")
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(root, "unknown")
+      }
+    }
+
+    describe("in 'child_1' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_1 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_1, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_1, "one") should be(child_11)
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_1, "two") should be(child_12)
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_1, "unknown")
+      }
+    }
+
+    describe("in 'child_2' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_2 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_2, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_2, "one") should be(child_21)
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_2, "two") should be(child_22)
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_2, "unknown")
+      }
+    }
+
+    describe("in 'child_11' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_11 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_11, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_11, "one") should be(child_11) // self-reference
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_11, "two") should be(child_12)
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_11, "unknown")
+      }
+    }
+
+    describe("in 'child_12' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_12 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_12, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_12, "one") should be(child_121)
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_12, "two") should be(child_12) // self-reference
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_12, "unknown")
+      }
+    }
+
+    describe("in 'child_21' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_21 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_21, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_21, "one") should be(child_21) // self-reference
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_21, "two") should be(child_22)
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_21, "unknown")
+      }
+    }
+
+    describe("in 'child_22' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_22 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_22, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_22, "one") should be(child_21)
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_22, "two") should be(child_22) // self-reference
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_22, "unknown")
+      }
+    }
+
+    describe("in 'child_121' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_121 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_121, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_121, "one") should be(child_121) // self-reference
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_121, "two") should be(child_12)
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_121, "unknown")
+      }
+    }
+
+    describe("in 'child_122' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_122 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves 'root'") {
+        resolver.resolveTypeName(child_122, "root") should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypeName(child_122, "one") should be(child_121)
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypeName(child_122, "two") should be(child_122) // self-reference
+      }
+
+      it("doesn't resolve 'unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_122, "unknown")
+      }
+    }
+  }
+
+  describe("resolveTypePath") {
+    describe("in 'root' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(root, Seq()) should be(root) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(root, Seq("root")) should be(root) // self-reference
+      }
+
+      it("doesn't resolve 'one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("one"))
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("one", "unknown"))
+      }
+
+      it("doesn't resolve 'two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("two"))
+      }
+
+      it("doesn't resolve 'two::one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("two", "one"))
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_1' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_1 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_1, Seq()) should be(child_1) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_1, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_1, Seq("one")) should be(child_11)
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_1, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_1, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_1, Seq("two")) should be(child_12)
+      }
+
+      it("resolves 'two::one'") {
+        resolver.resolveTypePath(child_1, Seq("two", "one")) should be(child_121)
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_1, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_2' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_2 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_2, Seq()) should be(child_2) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_2, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_2, Seq("one")) should be(child_21)
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_2, Seq("two")) should be(child_22)
+      }
+
+      it("doesn't resolve 'two::one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("two", "one"))
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_11' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_11 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_11, Seq()) should be(child_11) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_11, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_11, Seq("one")) should be(child_11) // self-reference
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_11, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_11, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_11, Seq("two")) should be(child_12)
+      }
+
+      it("resolves 'two::one'") {
+        resolver.resolveTypePath(child_11, Seq("two", "one")) should be(child_121)
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_11, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_12' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_12 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_12, Seq()) should be(child_12) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_12, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_12, Seq("one")) should be(child_121)
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_12, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_12, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_12, Seq("two")) should be(child_12) // self-reference
+      }
+
+      it("resolves 'two::one'") {
+        resolver.resolveTypePath(child_12, Seq("two", "one")) should be(child_121)
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_12, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_21' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_21 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_21, Seq()) should be(child_21) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_21, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_21, Seq("one")) should be(child_21) // self-reference
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_21, Seq("two")) should be(child_22)
+      }
+
+      it("doesn't resolve 'two::one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("two", "one"))
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_22' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_22 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_22, Seq()) should be(child_22) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_22, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_22, Seq("one")) should be(child_21)
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_22, Seq("two")) should be(child_22) // self-reference
+      }
+
+      it("doesn't resolve 'two::one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("two", "one"))
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_121' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_121 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_121, Seq()) should be(child_121) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_121, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_121, Seq("one")) should be(child_121) // self-reference
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_121, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_121, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_121, Seq("two")) should be(child_12)
+      }
+
+      it("doesn't resolve 'two::one'") {
+        resolver.resolveTypePath(child_121, Seq("two", "one")) should be(child_121) // self-reference
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_121, Seq("two", "unknown"))
+      }
+    }
+
+    describe("in 'child_122' context") {
+      val resolver = new ClassTypeProvider(specs, root)
+      resolver.nowClass = child_122 // Influences the error messages ("searching from '...'" part)
+
+      it("resolves empty path") {
+        resolver.resolveTypePath(child_122, Seq()) should be(child_122) // self-reference
+      }
+
+      it("resolves 'root'") {
+        resolver.resolveTypePath(child_122, Seq("root")) should be(root)
+      }
+
+      it("resolves 'one'") {
+        resolver.resolveTypePath(child_122, Seq("one")) should be(child_121)
+      }
+
+      it("doesn't resolve 'one::two'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("one", "two"))
+      }
+
+      it("doesn't resolve 'one::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("one", "unknown"))
+      }
+
+      it("resolves 'two'") {
+        resolver.resolveTypePath(child_122, Seq("two")) should be(child_122) // self-reference
+      }
+
+      it("doesn't resolve 'two::one'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("two", "one"))
+      }
+
+      it("doesn't resolve 'two::unknown'") {
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("two", "unknown"))
+      }
+    }
+  }
+}

--- a/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
@@ -50,14 +50,17 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(root, "one")
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(root, "two")
+        thrown.getMessage should be("unable to find type 'two', searching from 'root'")
       }
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(root, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root'")
       }
     }
 
@@ -79,6 +82,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_1, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1'")
       }
     }
 
@@ -100,6 +104,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_2, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2'")
       }
     }
 
@@ -121,6 +126,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_11, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::one'")
       }
     }
 
@@ -142,6 +148,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_12, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two'")
       }
     }
 
@@ -163,6 +170,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_21, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2::one'")
       }
     }
 
@@ -184,6 +192,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_22, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2::two'")
       }
     }
 
@@ -205,6 +214,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_121, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two::one'")
       }
     }
 
@@ -226,6 +236,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypeName(child_122, "unknown")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two::two'")
       }
     }
   }
@@ -244,26 +255,32 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("one"))
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("two"))
+        thrown.getMessage should be("unable to find type 'two', searching from 'root'")
       }
 
       it("doesn't resolve 'two::one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("two", "one"))
+        thrown.getMessage should be("unable to find type 'two', searching from 'root'")
       }
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(root, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'two', searching from 'root'")
       }
     }
 
@@ -285,10 +302,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_1, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_1, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::one'")
       }
 
       it("resolves 'two'") {
@@ -301,6 +320,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_1, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two'")
       }
     }
 
@@ -322,10 +342,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_2::one'")
       }
 
       it("resolves 'two'") {
@@ -334,10 +356,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("two", "one"))
+        thrown.getMessage should be("unable to find type 'one' in 'root::child_2::two'")
       }
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_2, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_2::two'")
       }
     }
 
@@ -359,10 +383,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_11, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_11, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::one'")
       }
 
       it("resolves 'two'") {
@@ -375,6 +401,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_11, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two'")
       }
     }
 
@@ -396,10 +423,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_12, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_12, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two::one'")
       }
 
       it("resolves 'two'") {
@@ -412,6 +441,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_12, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two'")
       }
     }
 
@@ -433,10 +463,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_2::one'")
       }
 
       it("resolves 'two'") {
@@ -445,10 +477,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("two", "one"))
+        thrown.getMessage should be("unable to find type 'one' in 'root::child_2::two'")
       }
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_21, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_2::two'")
       }
     }
 
@@ -470,10 +504,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_2::one'")
       }
 
       it("resolves 'two'") {
@@ -482,10 +518,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("two", "one"))
+        thrown.getMessage should be("unable to find type 'one' in 'root::child_2::two'")
       }
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_22, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_2::two'")
       }
     }
 
@@ -507,10 +545,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_121, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_121, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two::one'")
       }
 
       it("resolves 'two'") {
@@ -523,6 +563,7 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_121, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two'")
       }
     }
 
@@ -544,10 +585,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("one", "two"))
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("one", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two::one'")
       }
 
       it("resolves 'two'") {
@@ -556,10 +599,12 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'two::one'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("two", "one"))
+        thrown.getMessage should be("unable to find type 'one' in 'root::child_1::two::two'")
       }
 
       it("doesn't resolve 'two::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveTypePath(child_122, Seq("two", "unknown"))
+        thrown.getMessage should be("unable to find type 'unknown' in 'root::child_1::two::two'")
       }
     }
   }

--- a/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
@@ -624,35 +624,36 @@ class ClassTypeProvider$Test extends AnyFunSpec {
     val e_12 = child_12.enums.get("e").getOrElse(throw new NoSuchElementException("'e_12' not found"))
     val e_2 = child_2.enums.get("e").getOrElse(throw new NoSuchElementException("'e_2' not found"))
 
-    val none    = Ast.typeId(false, Seq())
-    val one     = Ast.typeId(false, Seq("one"))
-    val one_two = Ast.typeId(false, Seq("one", "two"))
-    val unknown = Ast.typeId(false, Seq("unknown"))
+    val none    = Ast.EnumRef(false, Seq(), "e")
+    val one_e   = Ast.EnumRef(false, Seq("one"), "e")
+    val one_unk = Ast.EnumRef(false, Seq("one"), "unknown")
+    val one_two = Ast.EnumRef(false, Seq("one", "two"), "e")
+    val unknown = Ast.EnumRef(false, Seq("unknown"), "e")
 
     describe("in 'root' context") {
       val resolver = new ClassTypeProvider(specs, root)
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_root)
+        resolver.resolveEnum(none) should be(e_root)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root'")
       }
     }
@@ -662,25 +663,25 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_1
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_root)
+        resolver.resolveEnum(none) should be(e_root)
       }
 
       it("resolves 'one::e'") {
-        resolver.resolveEnum(one, "e") should be(e_11)
+        resolver.resolveEnum(one_e) should be(e_11)
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1'")
       }
     }
@@ -690,26 +691,26 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_2
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_2)
+        resolver.resolveEnum(none) should be(e_2)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find enum 'e' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2'")
       }
     }
@@ -719,25 +720,25 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_11
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_11)
+        resolver.resolveEnum(none) should be(e_11)
       }
 
       it("resolves 'one::e'") {
-        resolver.resolveEnum(one, "e") should be(e_11)
+        resolver.resolveEnum(one_e) should be(e_11)
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::one'")
       }
     }
@@ -747,26 +748,26 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_12
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_12)
+        resolver.resolveEnum(none) should be(e_12)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find enum 'e' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two'")
       }
     }
@@ -776,26 +777,26 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_21
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_2)
+        resolver.resolveEnum(none) should be(e_2)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find enum 'e' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2::one'")
       }
     }
@@ -805,26 +806,26 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_22
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_2)
+        resolver.resolveEnum(none) should be(e_2)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find enum 'e' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2::two'")
       }
     }
@@ -834,26 +835,26 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_121
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_12)
+        resolver.resolveEnum(none) should be(e_12)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find enum 'e' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two::one'")
       }
     }
@@ -863,26 +864,26 @@ class ClassTypeProvider$Test extends AnyFunSpec {
       resolver.nowClass = child_122
 
       it("resolves 'e'") {
-        resolver.resolveEnum(none, "e") should be(e_12)
+        resolver.resolveEnum(none) should be(e_12)
       }
 
       it("doesn't resolve 'one::e'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_e)
         thrown.getMessage should be("unable to find enum 'e' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two)
         thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
-        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one_unk)
         thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
-        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown)
         thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two::two'")
       }
     }

--- a/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/ClassTypeProvider$Test.scala
@@ -638,18 +638,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find type 'one', searching from 'root'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root'")
       }
     }
 
@@ -667,14 +671,17 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1'")
       }
     }
 
@@ -688,18 +695,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find enum 'e' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2'")
       }
     }
 
@@ -717,14 +728,17 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::one'")
       }
     }
 
@@ -738,18 +752,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find enum 'e' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two'")
       }
     }
 
@@ -763,18 +781,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find enum 'e' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2::one'")
       }
     }
 
@@ -788,18 +810,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find enum 'e' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_2::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_2::two'")
       }
     }
 
@@ -813,18 +839,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find enum 'e' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two::one'")
       }
     }
 
@@ -838,18 +868,22 @@ class ClassTypeProvider$Test extends AnyFunSpec {
 
       it("doesn't resolve 'one::e'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "e")
+        thrown.getMessage should be("unable to find enum 'e' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::two::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(one_two, "e")
+        thrown.getMessage should be("unable to find type 'two' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'one::unknown'") {
         val thrown = the[EnumNotFoundError] thrownBy resolver.resolveEnum(one, "unknown")
+        thrown.getMessage should be("unable to find enum 'unknown' in 'root::child_1::two::one'")
       }
 
       it("doesn't resolve 'unknown::e'") {
         val thrown = the[TypeNotFoundError] thrownBy resolver.resolveEnum(unknown, "e")
+        thrown.getMessage should be("unable to find type 'unknown', searching from 'root::child_1::two::two'")
       }
     }
   }

--- a/jvm/src/test/scala/io/kaitai/struct/exprlang/EnumRefSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/exprlang/EnumRefSpec.scala
@@ -1,0 +1,56 @@
+package io.kaitai.struct.exprlang
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+
+class EnumRefSpec extends AnyFunSpec {
+  describe("Expressions.parseEnumRef") {
+    describe("parses local enum refs") {
+      it("some_enum") {
+        Expressions.parseEnumRef("some_enum") should be(Ast.EnumRef(
+          false, Seq(), "some_enum"
+        ))
+      }
+      it("with spaces: '  some_enum  '") {
+        Expressions.parseEnumRef("  some_enum  ") should be(Ast.EnumRef(
+          false, Seq(), "some_enum"
+        ))
+      }
+
+      it("::some_enum") {
+        Expressions.parseEnumRef("::some_enum") should be(Ast.EnumRef(
+          true, Seq(), "some_enum"
+        ))
+      }
+      it("with spaces: '  ::  some_enum  '") {
+        Expressions.parseEnumRef("  ::  some_enum  ") should be(Ast.EnumRef(
+          true, Seq(), "some_enum"
+        ))
+      }
+    }
+
+    describe("parses path enum refs") {
+      it("some::enum") {
+        Expressions.parseEnumRef("some::enum") should be(Ast.EnumRef(
+          false, Seq("some"), "enum"
+        ))
+      }
+      it("with spaces: '  some  ::  enum  '") {
+        Expressions.parseEnumRef("  some  ::  enum  ") should be(Ast.EnumRef(
+          false, Seq("some"), "enum"
+        ))
+      }
+
+      it("::some::enum") {
+        Expressions.parseEnumRef("::some::enum") should be(Ast.EnumRef(
+          true, Seq("some"), "enum"
+        ))
+      }
+      it("with spaces: '  ::  some  ::  enum  '") {
+        Expressions.parseEnumRef("  ::  some  ::  enum  ") should be(Ast.EnumRef(
+          true, Seq("some"), "enum"
+        ))
+      }
+    }
+  }
+}

--- a/jvm/src/test/scala/io/kaitai/struct/exprlang/ExpressionsSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/exprlang/ExpressionsSpec.scala
@@ -133,15 +133,14 @@ class ExpressionsSpec extends AnyFunSpec {
 
     // Enums
     it("parses port::http") {
-      Expressions.parse("port::http") should be (EnumByLabel(identifier("port"), identifier("http")))
+      Expressions.parse("port::http") should be (EnumByLabel(EnumRef(false, Seq(), "port"), identifier("http")))
     }
 
     it("parses some_type::port::http") {
       Expressions.parse("some_type::port::http") should be (
         EnumByLabel(
-          identifier("port"),
+          EnumRef(false, Seq("some_type"), "port"),
           identifier("http"),
-          typeId(absolute = false, Seq("some_type"))
         )
       )
     }
@@ -149,9 +148,8 @@ class ExpressionsSpec extends AnyFunSpec {
     it("parses parent_type::child_type::port::http") {
       Expressions.parse("parent_type::child_type::port::http") should be (
         EnumByLabel(
-          identifier("port"),
+          EnumRef(false, Seq("parent_type", "child_type"), "port"),
           identifier("http"),
-          typeId(absolute = false, Seq("parent_type", "child_type"))
         )
       )
     }
@@ -159,9 +157,8 @@ class ExpressionsSpec extends AnyFunSpec {
     it("parses ::parent_type::child_type::port::http") {
       Expressions.parse("::parent_type::child_type::port::http") should be (
         EnumByLabel(
-          identifier("port"),
+          EnumRef(true, Seq("parent_type", "child_type"), "port"),
           identifier("http"),
-          typeId(absolute = true, Seq("parent_type", "child_type"))
         )
       )
     }
@@ -171,7 +168,7 @@ class ExpressionsSpec extends AnyFunSpec {
         Compare(
           BinOp(
             Attribute(
-              EnumByLabel(identifier("port"),identifier("http")),
+              EnumByLabel(EnumRef(false, Seq(), "port"), identifier("http")),
               identifier("to_i")
             ),
             Add,

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TestTypeProviders.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TestTypeProviders.scala
@@ -15,7 +15,7 @@ object TestTypeProviders {
   abstract class FakeTypeProvider extends TypeProvider {
     val nowClass = ClassSpec.opaquePlaceholder(List("top_class"))
 
-    override def resolveEnum(inType: Ast.typeId, enumName: String) =
+    override def resolveEnum(ref: Ast.EnumRef) =
       throw new NotImplementedError
 
     override def resolveType(typeName: Ast.typeId): DataType = {

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -117,18 +117,18 @@ class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends
     throw new FieldNotFoundError(attrName, inClass)
   }
 
-  override def resolveEnum(inType: Ast.typeId, enumName: String): EnumSpec = {
-    val inClass = if (inType.absolute) topClass else nowClass
+  override def resolveEnum(ref: Ast.EnumRef): EnumSpec = {
+    val inClass = if (ref.absolute) topClass else nowClass
     // When concrete type is not defined, search enum definition in all enclosing types
-    if (inType.names.isEmpty) {
-      resolveEnumName(inClass, enumName)
+    if (ref.typePath.isEmpty) {
+      resolveEnumName(inClass, ref.name)
     } else {
-      val ty = resolveTypePath(inClass, inType.names)
-      ty.enums.get(enumName) match {
+      val ty = resolveTypePath(inClass, ref.typePath)
+      ty.enums.get(ref.name) match {
         case Some(spec) =>
           spec
         case None =>
-          throw new EnumNotFoundInTypeError(enumName, ty)
+          throw new EnumNotFoundInTypeError(ref.name, ty)
       }
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassTypeProvider.scala
@@ -148,13 +148,10 @@ class ClassTypeProvider(classSpecs: ClassSpecs, var topClass: ClassSpec) extends
   }
 
   override def resolveType(typeName: Ast.typeId): DataType =
-    resolveClassSpec(typeName).toDataType
-
-  private def resolveClassSpec(typeName: Ast.typeId): ClassSpec =
     resolveTypePath(
       if (typeName.absolute) topClass else nowClass,
       typeName.names
-    )
+    ).toDataType
 
   def resolveTypePath(inClass: ClassSpec, path: Seq[String]): ClassSpec = {
     if (path.isEmpty)

--- a/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
@@ -349,8 +349,8 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
         exprs.flatMap(affectedVars).toList
       case _: Ast.expr.EnumByLabel =>
         List()
-      case Ast.expr.EnumById(_, id, _) =>
-        affectedVars(id)
+      case Ast.expr.EnumById(_, expr) =>
+        affectedVars(expr)
       case Ast.expr.Attribute(value, attr) =>
         if (attr.name == Identifier.SIZEOF) {
           val vars = value match {

--- a/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/GraphvizClassCompiler.scala
@@ -295,7 +295,7 @@ class GraphvizClassCompiler(classSpecs: ClassSpecs, topClass: ClassSpec) extends
       case blt: BytesLimitType => expressionSize(blt.size, attrName)
       case StrFromBytesType(basedOn, _, _) => dataTypeSizeAsString(basedOn, attrName)
       case utb: UserTypeFromBytes => dataTypeSizeAsString(utb.bytes, attrName)
-      case EnumType(_, _, basedOn) => dataTypeSizeAsString(basedOn, attrName)
+      case EnumType(_, basedOn) => dataTypeSizeAsString(basedOn, attrName)
       case _ =>
         CalculateSeqSizes.dataTypeBitsSize(dataType) match {
           case FixedSized(n) =>
@@ -486,7 +486,7 @@ object GraphvizClassCompiler extends LanguageCompilerStatic {
   ): LanguageCompiler = ???
 
   def type2class(name: List[String]) = name.last
-  def type2display(name: List[String]) = name.map(Utils.upperCamelCase).mkString("::")
+  def type2display(name: Seq[String]) = name.map(Utils.upperCamelCase).mkString("::")
 
   def dataTypeName(dataType: DataType, valid: Option[ValidationSpec]): String = {
     dataType match {
@@ -509,8 +509,8 @@ object GraphvizClassCompiler extends LanguageCompilerStatic {
         val bytesStr = dataTypeName(basedOn, valid)
         val comma = if (bytesStr.isEmpty) "" else ", "
         s"str($bytesStr$comma$encoding)"
-      case EnumType(name, owner, basedOn) =>
-        s"${dataTypeName(basedOn, valid)}→${type2display(owner :+ name)}"
+      case EnumType(ref, basedOn) =>
+        s"${dataTypeName(basedOn, valid)}→${type2display(ref.fullName)}"
       case BitsType(width, bitEndian) => s"b$width${bitEndian.toSuffix}"
       case BitsType1(bitEndian) => s"b1${bitEndian.toSuffix}→bool"
       case _ => dataType.toString

--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -259,7 +259,7 @@ object DataType {
     def isOwning = false
   }
 
-  case class EnumType(name: String, owner: List[String], basedOn: IntType) extends DataType {
+  case class EnumType(ref: Ast.EnumRef, basedOn: IntType) extends DataType {
     var enumSpec: Option[EnumSpec] = None
 
     /**
@@ -459,10 +459,7 @@ object DataType {
     enumRef match {
       case Some(enumName) =>
         r match {
-          case numType: IntType => {
-            val names = classNameToList(enumName)
-            EnumType(names.last, names.dropRight(1), numType)
-          }
+          case numType: IntType => EnumType(Expressions.parseEnumRef(enumName), numType)
           case _ =>
             throw KSYParseError(s"tried to resolve non-integer $r to enum", path).toException
         }

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -76,8 +76,10 @@ object Ast {
     case class FloatNum(n: BigDecimal) extends expr
     case class Str(s: String) extends expr
     case class Bool(n: Boolean) extends expr
-    case class EnumByLabel(enumName: identifier, label: identifier, inType: typeId = EmptyTypeId) extends expr
-    case class EnumById(enumName: identifier, id: expr, inType: typeId = EmptyTypeId) extends expr
+    /** Take named enumeration constant from the specified enumeration. */
+    case class EnumByLabel(ref: EnumRef, label: identifier) extends expr
+    /** Cast specified expression to the enumerated type. Used only by value instances with `enum` key. */
+    case class EnumById(ref: EnumRef, expr: expr) extends expr
 
     case class Attribute(value: expr, attr: identifier) extends expr
     case class CastToType(value: expr, typeName: typeId) extends expr

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -143,5 +143,18 @@ object Ast {
     case object GtE extends cmpop
   }
 
+  /**
+    * Reference to an enum in scope. Scope is defined by the `absolute` flag and
+    * a path to a type (which can be empty) in which enum is defined.
+    */
+  case class EnumRef(absolute: Boolean, typePath: Seq[String], name: String) {
+    /** @return Type path and name of enum in one list. */
+    def fullName: Seq[String] = typePath :+ name
+    /**
+      * @return Enum designation name as human-readable string, to be used in compiler
+      *         error messages.
+      */
+    def asStr: String = fullName.mkString(if (absolute) "::" else "", "::", "")
+  }
   case class TypeWithArguments(typeName: typeId, arguments: expr.List)
 }

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
@@ -176,14 +176,11 @@ object Expressions {
     case (first, names: Seq[Ast.identifier]) =>
       val isAbsolute = first.nonEmpty
       val (enumName, enumLabel) = names.takeRight(2) match {
-        case Seq(a, b) => (a, b)
+        case Seq(a, b) => (a.name, b)
       }
-      val typePath = names.dropRight(2)
-      if (typePath.isEmpty) {
-        Ast.expr.EnumByLabel(enumName, enumLabel, Ast.EmptyTypeId)
-      } else {
-        Ast.expr.EnumByLabel(enumName, enumLabel, Ast.typeId(isAbsolute, typePath.map(_.name)))
-      }
+      val typePath = names.dropRight(2).map(n => n.name)
+      val ref = Ast.EnumRef(isAbsolute, typePath, enumName)
+      Ast.expr.EnumByLabel(ref, enumLabel)
   }
 
   def byteSizeOfType[$: P]: P[Ast.expr.ByteSizeOfType] =

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Expressions.scala
@@ -200,6 +200,13 @@ object Expressions {
     case (path, Some(args)) => Ast.TypeWithArguments(path, args)
   }
 
+  def enumRef[$: P]: P[Ast.EnumRef] = P(Start ~ "::".!.? ~ NAME.rep(1, "::") ~ End).map {
+    case (absolute, names) =>
+      // List have at least one element, so we always can split it into head and the last element
+      val typePath :+ enumName = names
+      Ast.EnumRef(absolute.nonEmpty, typePath.map(i => i.name), enumName.name)
+  }
+
   class ParseException(val src: String, val failure: Parsed.Failure)
     extends RuntimeException(failure.msg)
 
@@ -215,6 +222,14 @@ object Expressions {
    *         corresponding list is empty. List with path always contains at least one element
    */
   def parseTypeRef(src: String): Ast.TypeWithArguments = realParse(src, typeRef(_))
+
+  /**
+   * Parse string with reference to enumeration definition, optionally in full path format.
+   *
+   * @param src Enum reference as string, like `::path::to::enum`
+   * @return Object that represents path to enum
+   */
+  def parseEnumRef(src: String): Ast.EnumRef = realParse(src, enumRef(_))
 
   private def realParse[T](src: String, parser: P[_] => P[T]): T = {
     val r = fastparse.parse(src.trim, parser)

--- a/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/AttrSpec.scala
@@ -233,7 +233,7 @@ object AttrSpec {
       case _: BytesType => LEGAL_KEYS_BYTES
       case _: StrFromBytesType => LEGAL_KEYS_STR
       case _: UserType => LEGAL_KEYS_BYTES
-      case EnumType(_, _, _) => LEGAL_KEYS_ENUM
+      case EnumType(_, _) => LEGAL_KEYS_ENUM
       case _: SwitchType => LEGAL_KEYS_BYTES
       case _ => Set()
     })

--- a/shared/src/main/scala/io/kaitai/struct/format/InstanceSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/InstanceSpec.scala
@@ -61,7 +61,7 @@ object InstanceSpec {
           case None =>
             value
           case Some(enumName) =>
-            Ast.expr.EnumById(Ast.identifier(enumName), value)
+            Ast.expr.EnumById(Expressions.parseEnumRef(enumName), value)
         }
 
         val ifExpr = ParseUtils.getOptValueExpression(srcMap, "if", path)

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -708,7 +708,7 @@ object CSharpCompiler extends LanguageCompilerStatic
       case KaitaiStreamType | OwnedKaitaiStreamType => kstreamName
 
       case t: UserType => types2class(t.name)
-      case EnumType(name, owner, _) => types2class(owner :+ name)
+      case EnumType(ref, _) => types2class(ref.fullName)
 
       case at: ArrayType => {
         importList.add("System.Collections.Generic")

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -1182,7 +1182,7 @@ object CppCompiler extends LanguageCompilerStatic
         types2class(if (absolute) {
           t.enumSpec.get.name
         } else {
-          t.owner :+ t.name
+          t.ref.fullName
         })
 
       case at: ArrayType => {
@@ -1243,7 +1243,7 @@ object CppCompiler extends LanguageCompilerStatic
     )
   }
 
-  def types2class(components: List[String]) =
+  def types2class(components: Seq[String]) =
     components.map(type2class).mkString("::")
 
   def type2class(name: String) = Utils.lowerUnderscoreCase(name) + "_t"

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -744,12 +744,12 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
     val onType = typeProvider._currentSwitchType.get
     onType match {
-      case EnumType(name, owner, _) => {
-        val enumClass = types2class(owner :+ name)
+      case EnumType(ref, _) => {
+        val enumClass = types2class(ref.fullName)
         // Open a block scope to isolate the "on" variable
         out.puts("{")
         out.inc
-        out.puts(s"final ${enum2iface(name, owner)} on = ${expression(on)};")
+        out.puts(s"final ${enum2iface(ref)} on = ${expression(on)};")
         out.puts(s"if (on instanceof $enumClass) {")
         out.inc
         out.puts(s"switch (($enumClass)on) {")
@@ -1248,7 +1248,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     err: ValidationNotInEnumError,
     useIo: Boolean
   ): Unit = {
-    val enumClass = types2class(et.owner :+ et.name)
+    val enumClass = types2class(et.ref.fullName)
     attrValidate(attr, s"!(${translator.translate(valueExpr)} instanceof $enumClass)", err, useIo, valueExpr, None)
   }
 
@@ -1371,7 +1371,7 @@ object JavaCompiler extends LanguageCompilerStatic
       case KaitaiStructType | CalcKaitaiStructType(_) => kstructNameFull(config)
 
       case t: UserType => types2class(t.name)
-      case EnumType(name, owner, _) => enum2iface(name, owner)
+      case EnumType(ref, _) => enum2iface(ref)
 
       case _: ArrayType => kaitaiType2JavaTypeBoxed(attrType, importList, config)
 
@@ -1415,7 +1415,7 @@ object JavaCompiler extends LanguageCompilerStatic
       case KaitaiStructType | CalcKaitaiStructType(_) => kstructNameFull(config)
 
       case t: UserType => types2class(t.name)
-      case EnumType(name, owner, _) => enum2iface(name, owner)
+      case EnumType(ref, _) => enum2iface(ref)
 
       case at: ArrayType => {
         importList.add("java.util.List")
@@ -1429,8 +1429,8 @@ object JavaCompiler extends LanguageCompilerStatic
   def types2class(names: Iterable[String]) = names.map(x => type2class(x)).mkString(".")
 
   def enum2iface(name: String) = s"I${type2class(name)}"
-  def enum2iface(name: String, owner: List[String]): String =
-    (owner.map(type2class) :+ enum2iface(name)).mkString(".")
+  def enum2iface(ref: Ast.EnumRef): String =
+    (ref.typePath.map(type2class) :+ enum2iface(ref.name)).mkString(".")
 
   override def kstreamName: String = "KaitaiStream"
   override def kstructName: String = "KaitaiStruct"

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -1300,7 +1300,7 @@ object RustCompiler
   def classTypeName(c: ClassSpec): String =
     s"${types2class(c.name)}"
 
-  def types2class(names: List[String]): String =
+  def types2class(names: Seq[String]): String =
   // TODO: Use `mod` to scope types instead of weird names
     names.map(x => type2class(x)).mkString("_")
 
@@ -1327,7 +1327,7 @@ object RustCompiler
       case t: EnumType =>
         val baseName = t.enumSpec match {
           case Some(spec) => s"${types2class(spec.name)}"
-          case None => s"${types2class(t.owner :+ t.name)}"
+          case None => s"${types2class(t.ref.fullName)}"
         }
         baseName
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
@@ -813,7 +813,7 @@ object ZigCompiler extends LanguageCompilerStatic
         if (isExternal) {
           externalTypeDeclaration(ExternalEnum(et.enumSpec.get), importList)
         }
-        types2class(et.owner :+ et.name, isExternal)
+        types2class(et.ref.fullName, isExternal)
       }
 
       case at: ArrayType => s"*_imp_std.ArrayList(${kaitaiType2NativeType(at.elType, importList, curClass)})"
@@ -854,7 +854,7 @@ object ZigCompiler extends LanguageCompilerStatic
       case ut: UserType => ut.name.last
       // NOTE: at the time of writing, this is unreachable because the `enum` key is not compatible
       // with type switching
-      case et: EnumType => et.name
+      case et: EnumType => et.ref.name
     }
 
   def switchTaggedUnionName(id: Identifier): String = {
@@ -866,7 +866,7 @@ object ZigCompiler extends LanguageCompilerStatic
   }
 
   /** @note Same as [[PythonCompiler.types2class]] */
-  def types2class(name: List[String], isExternal: Boolean): String = {
+  def types2class(name: Seq[String], isExternal: Boolean): String = {
     val prefix = if (isExternal) {
       s"_imp_${name.head}."
     } else {

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/GenericChecks.scala
@@ -66,8 +66,8 @@ trait GenericChecks extends LanguageCompiler with EveryReadIsExpression {
       case Ast.expr.InterpolatedStr(values: Seq[Ast.expr]) =>
         values.exists(v => userExprDependsOnIo(v))
       case _: Ast.expr.Bool => false
-      case Ast.expr.EnumById(_, id, _) =>
-        userExprDependsOnIo(id)
+      case Ast.expr.EnumById(_, expr) =>
+        userExprDependsOnIo(expr)
       case _: Ast.expr.EnumByLabel => false
       case n: Ast.expr.Name =>
         val t = getArrayItemType(translator.detectType(n))

--- a/shared/src/main/scala/io/kaitai/struct/precompile/CalculateSeqSizes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/CalculateSeqSizes.scala
@@ -86,7 +86,7 @@ object CalculateSeqSizes {
     dataType match {
       case BitsType1(_) => FixedSized(1)
       case BitsType(width, _) => FixedSized(width)
-      case EnumType(_, _, basedOn) => dataTypeBitsSize(basedOn)
+      case EnumType(_, basedOn) => dataTypeBitsSize(basedOn)
       case ut: UserTypeInstream => getSeqSize(ut.classSpec.get)
       case _ =>
         dataTypeByteSize(dataType) match {

--- a/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
@@ -15,8 +15,11 @@ class WrongMethodCall(val dataType: MethodArgType, val methodName: String, val e
   extends ExpressionError(s"wrong arguments to method call `$methodName` on $dataType: expected ${expectedSigs.mkString(" or ")}, got $actualSig")
 
 sealed abstract class NotFoundError(msg: String) extends ExpressionError(msg)
-class TypeNotFoundError(val name: String, val curClass: ClassSpec)
-  extends NotFoundError(s"unable to find type '$name', searching from '${curClass.nameAsStr}'")
+sealed abstract class TypeNotFoundError(msg: String) extends NotFoundError(msg)
+class TypeNotFoundInHierarchyError(val name: String, val curClass: ClassSpec)
+  extends TypeNotFoundError(s"unable to find type '$name', searching from '${curClass.nameAsStr}'")
+class TypeNotFoundInTypeError(val name: String, val curClass: ClassSpec)
+  extends TypeNotFoundError(s"unable to find type '$name' in '${curClass.nameAsStr}'")
 class FieldNotFoundError(val name: String, val curClass: ClassSpec)
   extends NotFoundError(s"unable to access '$name' in '${curClass.nameAsStr}' context")
 class EnumNotFoundError(val name: String, val curClass: ClassSpec)

--- a/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
@@ -16,11 +16,11 @@ class WrongMethodCall(val dataType: MethodArgType, val methodName: String, val e
 
 sealed abstract class NotFoundError(msg: String) extends ExpressionError(msg)
 class TypeNotFoundError(val name: String, val curClass: ClassSpec)
-  extends NotFoundError(s"unable to find type '$name', searching from ${curClass.nameAsStr}")
+  extends NotFoundError(s"unable to find type '$name', searching from '${curClass.nameAsStr}'")
 class FieldNotFoundError(val name: String, val curClass: ClassSpec)
-  extends NotFoundError(s"unable to access '$name' in ${curClass.nameAsStr} context")
+  extends NotFoundError(s"unable to access '$name' in '${curClass.nameAsStr}' context")
 class EnumNotFoundError(val name: String, val curClass: ClassSpec)
-  extends NotFoundError(s"unable to find enum '$name', searching from ${curClass.nameAsStr}")
+  extends NotFoundError(s"unable to find enum '$name', searching from '${curClass.nameAsStr}'")
 class EnumMemberNotFoundError(val label: String, val enumName: String, val enumDefPath: String)
   extends NotFoundError(s"unable to find enum member '$enumName::$label' (enum '$enumName' defined at /$enumDefPath)")
 

--- a/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/Exceptions.scala
@@ -22,8 +22,13 @@ class TypeNotFoundInTypeError(val name: String, val curClass: ClassSpec)
   extends TypeNotFoundError(s"unable to find type '$name' in '${curClass.nameAsStr}'")
 class FieldNotFoundError(val name: String, val curClass: ClassSpec)
   extends NotFoundError(s"unable to access '$name' in '${curClass.nameAsStr}' context")
-class EnumNotFoundError(val name: String, val curClass: ClassSpec)
-  extends NotFoundError(s"unable to find enum '$name', searching from '${curClass.nameAsStr}'")
+
+sealed abstract class EnumNotFoundError(msg: String) extends NotFoundError(msg)
+class EnumNotFoundInHierarchyError(val name: String, val curClass: ClassSpec)
+  extends EnumNotFoundError(s"unable to find enum '$name', searching from '${curClass.nameAsStr}'")
+class EnumNotFoundInTypeError(val name: String, val curClass: ClassSpec)
+  extends EnumNotFoundError(s"unable to find enum '$name' in '${curClass.nameAsStr}'")
+
 class EnumMemberNotFoundError(val label: String, val enumName: String, val enumDefPath: String)
   extends NotFoundError(s"unable to find enum member '$enumName::$label' (enum '$enumName' defined at /$enumDefPath)")
 

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -19,7 +19,7 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
     * ClassSpec.
     * @param curClass class to start from, might be top-level class
     */
-  def resolveUserTypes(curClass: ClassSpec): Iterable[CompilationProblem] = {
+  private def resolveUserTypes(curClass: ClassSpec): Iterable[CompilationProblem] = {
     val seqProblems: Iterable[CompilationProblem] =
       curClass.seq.flatMap((attr) => resolveUserTypeForMember(curClass, attr))
 
@@ -40,10 +40,10 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
     seqProblems ++ instancesProblems ++ paramsProblems
   }
 
-  def resolveUserTypeForMember(curClass: ClassSpec, attr: MemberSpec): Iterable[CompilationProblem] =
+  private def resolveUserTypeForMember(curClass: ClassSpec, attr: MemberSpec): Iterable[CompilationProblem] =
     resolveUserType(curClass, attr.dataType, attr.path)
 
-  def resolveUserType(curClass: ClassSpec, dataType: DataType, path: List[String]): Iterable[CompilationProblem] = {
+  private def resolveUserType(curClass: ClassSpec, dataType: DataType, path: List[String]): Iterable[CompilationProblem] = {
     dataType match {
       case ut: UserType =>
         val (resClassSpec, problems) = resolveUserType(curClass, ut.name, path ++ List("type"))
@@ -68,7 +68,7 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
     }
   }
 
-  def resolveUserType(curClass: ClassSpec, typeName: List[String], path: List[String]): (Option[ClassSpec], Option[CompilationProblem]) = {
+  private def resolveUserType(curClass: ClassSpec, typeName: List[String], path: List[String]): (Option[ClassSpec], Option[CompilationProblem]) = {
     val res = realResolveUserType(curClass, typeName, path)
 
     res match {
@@ -136,7 +136,7 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
     }
   }
 
-  def resolveEnumSpec(curClass: ClassSpec, typeName: List[String]): Option[EnumSpec] = {
+  private def resolveEnumSpec(curClass: ClassSpec, typeName: List[String]): Option[EnumSpec] = {
     Log.enumResolve.info(() => s"resolveEnumSpec: at ${curClass.name} doing ${typeName.mkString("|")}")
 
     val res = realResolveEnumSpec(curClass, typeName)

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -70,7 +70,7 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
       case et: EnumType =>
         try {
           val resolver = new ClassTypeProvider(specs, curClass)
-          val ty = resolver.resolveEnum(Ast.typeId(et.ref.absolute, et.ref.typePath), et.ref.name)
+          val ty = resolver.resolveEnum(et.ref)
           Log.enumResolve.info(() => s"    => ${ty.nameAsStr}")
           et.enumSpec = Some(ty)
           None

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -70,18 +70,18 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
       case et: EnumType =>
         try {
           val resolver = new ClassTypeProvider(specs, curClass)
-          val ty = resolver.resolveEnum(Ast.typeId(false, et.owner), et.name)
+          val ty = resolver.resolveEnum(Ast.typeId(et.ref.absolute, et.ref.typePath), et.ref.name)
           Log.enumResolve.info(() => s"    => ${ty.nameAsStr}")
           et.enumSpec = Some(ty)
           None
         } catch {
           case ex: TypeNotFoundError =>
-            Log.typeResolve.info(() => s"    => ??? (while resolving enum '${et.owner :+ et.name}'): $ex")
-            Log.enumResolve.info(() => s"    => ??? (enclosing type not found, enum '${et.owner :+ et.name}'): $ex")
-            Some(TypeNotFoundErr(et.owner, curClass, path :+ "enum"))
+            Log.typeResolve.info(() => s"    => ??? (while resolving enum '${et.ref}'): $ex")
+            Log.enumResolve.info(() => s"    => ??? (enclosing type not found, enum '${et.ref}'): $ex")
+            Some(TypeNotFoundErr(et.ref.typePath, curClass, path :+ "enum"))
           case ex: EnumNotFoundError =>
-            Log.enumResolve.info(() => s"    => ??? (enum '${et.owner :+ et.name}'): $ex")
-            Some(EnumNotFoundErr(et.owner :+ et.name, curClass, path :+ "enum"))
+            Log.enumResolve.info(() => s"    => ??? (enum '${et.ref}'): $ex")
+            Some(EnumNotFoundErr(et.ref, curClass, path :+ "enum"))
         }
       case st: SwitchType =>
         st.cases.flatMap { case (caseName, ut) =>

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -1,8 +1,9 @@
 package io.kaitai.struct.precompile
 
-import io.kaitai.struct.Log
+import io.kaitai.struct.{ClassTypeProvider, Log}
 import io.kaitai.struct.datatype.DataType
 import io.kaitai.struct.datatype.DataType.{ArrayType, EnumType, SwitchType, UserType}
+import io.kaitai.struct.exprlang.Ast
 import io.kaitai.struct.format._
 import io.kaitai.struct.problems._
 
@@ -50,11 +51,20 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
         ut.classSpec = resClassSpec
         problems
       case et: EnumType =>
-        et.enumSpec = resolveEnumSpec(curClass, et.owner :+ et.name)
-        if (et.enumSpec.isEmpty) {
-          Some(EnumNotFoundErr(et.owner :+ et.name, curClass, path ++ List("enum")))
-        } else {
+        try {
+          val resolver = new ClassTypeProvider(specs, curClass)
+          val ty = resolver.resolveEnum(Ast.typeId(false, et.owner), et.name)
+          Log.enumResolve.info(() => s"    => ${ty.nameAsStr}")
+          et.enumSpec = Some(ty)
           None
+        } catch {
+          case ex: TypeNotFoundError =>
+            Log.typeResolve.info(() => s"    => ??? (while resolving enum '${et.owner :+ et.name}'): $ex")
+            Log.enumResolve.info(() => s"    => ??? (enclosing type not found, enum '${et.owner :+ et.name}'): $ex")
+            Some(TypeNotFoundErr(et.owner, curClass, path :+ "enum"))
+          case ex: EnumNotFoundError =>
+            Log.enumResolve.info(() => s"    => ??? (enum '${et.owner :+ et.name}'): $ex")
+            Some(EnumNotFoundErr(et.owner :+ et.name, curClass, path :+ "enum"))
         }
       case st: SwitchType =>
         st.cases.flatMap { case (caseName, ut) =>
@@ -129,66 +139,6 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
                   resolvedTop
                 } else {
                   realResolveUserType(classSpec, restNames, path)
-                }
-              }
-            }
-        }
-    }
-  }
-
-  private def resolveEnumSpec(curClass: ClassSpec, typeName: List[String]): Option[EnumSpec] = {
-    Log.enumResolve.info(() => s"resolveEnumSpec: at ${curClass.name} doing ${typeName.mkString("|")}")
-
-    val res = realResolveEnumSpec(curClass, typeName)
-    res match {
-      case None => {
-        Log.enumResolve.info(() => s"    => ???")
-        res
-      }
-      case Some(x) => {
-        Log.enumResolve.info(() => s"    => ${x.nameAsStr}")
-        res
-      }
-    }
-  }
-
-  private def realResolveEnumSpec(curClass: ClassSpec, typeName: List[String]): Option[EnumSpec] = {
-    // First, try to do it in current class
-
-    // If we're seeking composite name, we only have to resolve the very first
-    // part of it at this stage
-    val firstName :: restNames = typeName
-
-    val resolvedHere = if (restNames.isEmpty) {
-      curClass.enums.get(firstName)
-    } else {
-      curClass.types.get(firstName).flatMap((nestedClass) =>
-        resolveEnumSpec(nestedClass, restNames)
-      )
-    }
-
-    resolvedHere match {
-      case Some(_) => resolvedHere
-      case None =>
-        // No luck resolving here, let's try upper levels, if they exist
-        curClass.upClass match {
-          case Some(upClass) =>
-            resolveEnumSpec(upClass, typeName)
-          case None =>
-            // Check this class if it's top-level class
-            if (curClass.name.head == firstName) {
-              resolveEnumSpec(curClass, restNames)
-            } else {
-              // Check if top-level specs has this name
-              // If there's None => no luck at all
-              val resolvedTop = specs.get(firstName)
-              resolvedTop match {
-                case None => None
-                case Some(classSpec) => if (restNames.isEmpty) {
-                  // resolved everything, but this points to a type name, not enum name
-                  None
-                } else {
-                  resolveEnumSpec(classSpec, restNames)
                 }
               }
             }

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -79,7 +79,13 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
   }
 
   private def resolveUserType(curClass: ClassSpec, typeName: List[String], path: List[String]): (Option[ClassSpec], Option[CompilationProblem]) = {
-    val res = realResolveUserType(curClass, typeName, path)
+    val res = try {
+      val resolver = new ClassTypeProvider(specs, curClass)
+      Some(resolver.resolveTypePath(curClass, typeName))
+    } catch {
+      case _: TypeNotFoundError =>
+        None
+    }
 
     res match {
       case None =>
@@ -96,53 +102,6 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
       case Some(x) =>
         Log.typeResolve.info(() => s"    => ${x.nameAsStr}")
         (res, None)
-    }
-  }
-
-  private def realResolveUserType(curClass: ClassSpec, typeName: List[String], path: List[String]): Option[ClassSpec] = {
-    Log.typeResolve.info(() => s"resolveUserType: at ${curClass.name} doing ${typeName.mkString("|")}")
-
-    // First, try to do it in current class
-
-    // If we're seeking composite name, we only have to resolve the very first
-    // part of it at this stage
-    val firstName :: restNames = typeName
-
-    val resolvedHere = curClass.types.get(firstName).flatMap((nestedClass) =>
-      if (restNames.isEmpty) {
-        // No further names to resolve, here's our answer
-        Some(nestedClass)
-      } else {
-        // Try to resolve recursively
-        realResolveUserType(nestedClass, restNames, path)
-      }
-    )
-
-    resolvedHere match {
-      case Some(_) => resolvedHere
-      case None =>
-        // No luck resolving here, let's try upper levels, if they exist
-        curClass.upClass match {
-          case Some(upClass) =>
-            realResolveUserType(upClass, typeName, path)
-          case None =>
-            // Check this class if it's top-level class
-            if (curClass.name.head == firstName) {
-              Some(curClass)
-            } else {
-              // Check if top-level specs has this name
-              // If there's None => no luck at all
-              val resolvedTop = specs.get(firstName)
-              resolvedTop match {
-                case None => None
-                case Some(classSpec) => if (restNames.isEmpty) {
-                  resolvedTop
-                } else {
-                  realResolveUserType(classSpec, restNames, path)
-                }
-              }
-            }
-        }
     }
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -47,9 +47,26 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
   private def resolveUserType(curClass: ClassSpec, dataType: DataType, path: List[String]): Iterable[CompilationProblem] = {
     dataType match {
       case ut: UserType =>
-        val (resClassSpec, problems) = resolveUserType(curClass, ut.name, path ++ List("type"))
-        ut.classSpec = resClassSpec
-        problems
+        try {
+          val resolver = new ClassTypeProvider(specs, curClass)
+          val ty = resolver.resolveTypePath(curClass, ut.name)
+          Log.typeResolve.info(() => s"    => ${ty.nameAsStr}")
+          ut.classSpec = Some(ty)
+          None
+        } catch {
+          case _: TypeNotFoundError =>
+            // Type definition not found
+            if (opaqueTypes) {
+              // Generate special "opaque placeholder" ClassSpec
+              Log.typeResolve.info(() => "    => ??? (generating opaque type)")
+              ut.classSpec = Some(ClassSpec.opaquePlaceholder(ut.name))
+              None
+            } else {
+              // Opaque types are disabled => that is an error
+              Log.typeResolve.info(() => "    => ??? (opaque type are disabled => error)")
+              Some(TypeNotFoundErr(ut.name, curClass, path :+ "type"))
+            }
+        }
       case et: EnumType =>
         try {
           val resolver = new ClassTypeProvider(specs, curClass)
@@ -75,27 +92,6 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
       case _ =>
         // not a user type, nothing to resolve
         None
-    }
-  }
-
-  private def resolveUserType(curClass: ClassSpec, typeName: List[String], path: List[String]): (Option[ClassSpec], Option[CompilationProblem]) = {
-    try {
-      val resolver = new ClassTypeProvider(specs, curClass)
-      val ty = resolver.resolveTypePath(curClass, typeName)
-      Log.typeResolve.info(() => s"    => ${ty.nameAsStr}")
-      (Some(ty), None)
-    } catch {
-      case _: TypeNotFoundError =>
-        // Type definition not found
-        if (opaqueTypes) {
-          // Generate special "opaque placeholder" ClassSpec
-          Log.typeResolve.info(() => "    => ??? (generating opaque type)")
-          (Some(ClassSpec.opaquePlaceholder(typeName)), None)
-        } else {
-          // Opaque types are disabled => that is an error
-          Log.typeResolve.info(() => "    => ??? (opaque type are disabled => error)")
-          (None, Some(TypeNotFoundErr(typeName, curClass, path)))
-        }
     }
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -79,16 +79,13 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
   }
 
   private def resolveUserType(curClass: ClassSpec, typeName: List[String], path: List[String]): (Option[ClassSpec], Option[CompilationProblem]) = {
-    val res = try {
+    try {
       val resolver = new ClassTypeProvider(specs, curClass)
-      Some(resolver.resolveTypePath(curClass, typeName))
+      val ty = resolver.resolveTypePath(curClass, typeName)
+      Log.typeResolve.info(() => s"    => ${ty.nameAsStr}")
+      (Some(ty), None)
     } catch {
       case _: TypeNotFoundError =>
-        None
-    }
-
-    res match {
-      case None =>
         // Type definition not found
         if (opaqueTypes) {
           // Generate special "opaque placeholder" ClassSpec
@@ -99,9 +96,6 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
           Log.typeResolve.info(() => "    => ??? (opaque type are disabled => error)")
           (None, Some(TypeNotFoundErr(typeName, curClass, path)))
         }
-      case Some(x) =>
-        Log.typeResolve.info(() => s"    => ${x.nameAsStr}")
-        (res, None)
     }
   }
 }

--- a/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
+++ b/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
@@ -173,7 +173,7 @@ case class ParamMismatchError(idx: Int, argType: DataType, paramName: String, pa
 case class TypeNotFoundErr(name: List[String], curClass: ClassSpec, path: List[String], fileName: Option[String] = None)
   extends CompilationProblem {
 
-  override def text = s"unable to find type '${name.mkString("::")}', searching from ${curClass.nameAsStr}"
+  override def text = s"unable to find type '${name.mkString("::")}', searching from '${curClass.nameAsStr}'"
   override val coords: ProblemCoords = ProblemCoords(fileName, Some(path))
   override def localizedInFile(fileName: String): CompilationProblem =
     copy(fileName = Some(fileName))
@@ -183,7 +183,7 @@ case class TypeNotFoundErr(name: List[String], curClass: ClassSpec, path: List[S
 case class EnumNotFoundErr(name: List[String], curClass: ClassSpec, path: List[String], fileName: Option[String] = None)
   extends CompilationProblem {
 
-  override def text = s"unable to find enum '${name.mkString("::")}', searching from ${curClass.nameAsStr}"
+  override def text = s"unable to find enum '${name.mkString("::")}', searching from '${curClass.nameAsStr}'"
   override val coords: ProblemCoords = ProblemCoords(fileName, Some(path))
   override def localizedInFile(fileName: String): CompilationProblem =
     copy(fileName = Some(fileName))

--- a/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
+++ b/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
@@ -2,7 +2,7 @@ package io.kaitai.struct.problems
 
 import io.kaitai.struct.{JSON, Jsonable, Utils, problems}
 import io.kaitai.struct.datatype.DataType
-import io.kaitai.struct.exprlang.Expressions
+import io.kaitai.struct.exprlang.{Ast, Expressions}
 import io.kaitai.struct.format.{ClassSpec, Identifier, KSVersion}
 import fastparse.Parsed.Failure
 
@@ -170,7 +170,7 @@ case class ParamMismatchError(idx: Int, argType: DataType, paramName: String, pa
   override def severity: ProblemSeverity = ProblemSeverity.Error
 }
 
-case class TypeNotFoundErr(name: List[String], curClass: ClassSpec, path: List[String], fileName: Option[String] = None)
+case class TypeNotFoundErr(name: Seq[String], curClass: ClassSpec, path: List[String], fileName: Option[String] = None)
   extends CompilationProblem {
 
   override def text = s"unable to find type '${name.mkString("::")}', searching from '${curClass.nameAsStr}'"
@@ -180,10 +180,10 @@ case class TypeNotFoundErr(name: List[String], curClass: ClassSpec, path: List[S
   override def severity: ProblemSeverity = ProblemSeverity.Error
 }
 
-case class EnumNotFoundErr(name: List[String], curClass: ClassSpec, path: List[String], fileName: Option[String] = None)
+case class EnumNotFoundErr(ref: Ast.EnumRef, curClass: ClassSpec, path: List[String], fileName: Option[String] = None)
   extends CompilationProblem {
 
-  override def text = s"unable to find enum '${name.mkString("::")}', searching from '${curClass.nameAsStr}'"
+  override def text = s"unable to find enum '${ref.asStr}', searching from '${curClass.nameAsStr}'"
   override val coords: ProblemCoords = ProblemCoords(fileName, Some(path))
   override def localizedInFile(fileName: String): CompilationProblem =
     copy(fileName = Some(fileName))

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -63,11 +63,11 @@ abstract class BaseTranslator(val provider: TypeProvider)
         doInterpolatedStringLiteral(s)
       case Ast.expr.Bool(n) =>
         doBoolLiteral(n)
-      case Ast.expr.EnumById(enumType, id, inType) =>
-        val enumSpec = provider.resolveEnum(inType, enumType.name)
-        doEnumById(enumSpec, translate(id))
-      case Ast.expr.EnumByLabel(enumType, label, inType) =>
-        val enumSpec = provider.resolveEnum(inType, enumType.name)
+      case Ast.expr.EnumById(ref, expr) =>
+        val enumSpec = provider.resolveEnum(ref)
+        doEnumById(enumSpec, translate(expr))
+      case Ast.expr.EnumByLabel(ref, label) =>
+        val enumSpec = provider.resolveEnum(ref)
         doEnumByLabel(enumSpec, label.name)
       case Ast.expr.Name(name: Ast.identifier) =>
         if (name.name == Identifier.SIZEOF) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/ExpressionValidator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ExpressionValidator.scala
@@ -31,13 +31,13 @@ class ExpressionValidator(val provider: TypeProvider)
            _: Ast.expr.FloatNum |
            _: Ast.expr.Str |
            _: Ast.expr.Bool => // all simple literals are good and valid
-      case Ast.expr.EnumById(enumType, id, inType) =>
-        provider.resolveEnum(inType, enumType.name)
-        validate(id)
-      case Ast.expr.EnumByLabel(enumType, label, inType) =>
-        val enumSpec = provider.resolveEnum(inType, enumType.name)
+      case Ast.expr.EnumById(ref, expr) =>
+        provider.resolveEnum(ref)
+        validate(expr)
+      case Ast.expr.EnumByLabel(ref, label) =>
+        val enumSpec = provider.resolveEnum(ref)
         if (!enumSpec.map.values.exists(_.name == label.name)) {
-          throw new EnumMemberNotFoundError(label.name, enumType.name, enumSpec.path.mkString("/"))
+          throw new EnumMemberNotFoundError(label.name, ref.name, enumSpec.path.mkString("/"))
         }
       case Ast.expr.Name(name: Ast.identifier) =>
         if (name.name == Identifier.SIZEOF) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -69,11 +69,11 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
         trInterpolatedStringLiteral(s)
       case Ast.expr.Bool(n) =>
         trBoolLiteral(n)
-      case Ast.expr.EnumById(enumType, id, inType) =>
-        val enumSpec = provider.resolveEnum(inType, enumType.name)
-        trEnumById(enumSpec.name, translate(id))
-      case Ast.expr.EnumByLabel(enumType, label, inType) =>
-        val enumSpec = provider.resolveEnum(inType, enumType.name)
+      case Ast.expr.EnumById(ref, expr) =>
+        val enumSpec = provider.resolveEnum(ref)
+        trEnumById(enumSpec.name, translate(expr))
+      case Ast.expr.EnumByLabel(ref, label) =>
+        val enumSpec = provider.resolveEnum(ref)
         trEnumByLabel(enumSpec.name, label.name)
       case Ast.expr.Name(name: Ast.identifier) =>
         if (name.name == Identifier.SIZEOF) {

--- a/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
@@ -438,10 +438,10 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig)
 
   override def translate(v: Ast.expr): String = {
     v match {
-      case Ast.expr.EnumById(enumType, id, inType) =>
-        id match {
+      case Ast.expr.EnumById(ref, expr) =>
+        expr match {
           case ifExp: Ast.expr.IfExp =>
-            val enumSpec = provider.resolveEnum(inType, enumType.name)
+            val enumSpec = provider.resolveEnum(ref)
             val enumName = RustCompiler.types2class(enumSpec.name)
             def toStr(ex: Ast.expr) = ex match {
               case Ast.expr.IntNum(n) => s"$enumName::try_from($n)?"

--- a/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
@@ -47,14 +47,13 @@ class TypeDetector(provider: TypeProvider) {
       case Ast.expr.Str(_) => CalcStrType
       case Ast.expr.InterpolatedStr(_) => CalcStrType
       case Ast.expr.Bool(_) => CalcBooleanType
-      case Ast.expr.EnumByLabel(enumType, _, inType) =>
-        val t = EnumType(Ast.EnumRef(false, inType.names.toList, enumType.name), CalcIntType)
-        t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
+      case Ast.expr.EnumByLabel(ref, _) =>
+        val t = EnumType(ref, CalcIntType)
+        t.enumSpec = Some(provider.resolveEnum(ref))
         t
-      case Ast.expr.EnumById(enumType, _, inType) =>
-        // TODO: May be create a type with a name that includes surrounding type?
-        val t = EnumType(Ast.EnumRef(false, List(), enumType.name), CalcIntType)
-        t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
+      case Ast.expr.EnumById(ref, _) =>
+        val t = EnumType(ref, CalcIntType)
+        t.enumSpec = Some(provider.resolveEnum(ref))
         t
       case Ast.expr.Name(name: Ast.identifier) => provider.determineType(name.name).asNonOwning()
       case Ast.expr.InternalName(id) => provider.determineType(id)

--- a/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
@@ -48,11 +48,12 @@ class TypeDetector(provider: TypeProvider) {
       case Ast.expr.InterpolatedStr(_) => CalcStrType
       case Ast.expr.Bool(_) => CalcBooleanType
       case Ast.expr.EnumByLabel(enumType, _, inType) =>
-        val t = EnumType(enumType.name, inType.names.toList, CalcIntType)
+        val t = EnumType(Ast.EnumRef(false, inType.names.toList, enumType.name), CalcIntType)
         t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
         t
       case Ast.expr.EnumById(enumType, _, inType) =>
-        val t = EnumType(enumType.name, List(), CalcIntType)
+        // TODO: May be create a type with a name that includes surrounding type?
+        val t = EnumType(Ast.EnumRef(false, List(), enumType.name), CalcIntType)
         t.enumSpec = Some(provider.resolveEnum(inType, enumType.name))
         t
       case Ast.expr.Name(name: Ast.identifier) => provider.determineType(name.name).asNonOwning()
@@ -419,7 +420,7 @@ object TypeDetector {
           }
         case (t1: EnumType, t2: EnumType) =>
           if (t1.enumSpec.get == t2.enumSpec.get) {
-            val t = EnumType(t1.name, t1.owner, CalcIntType)
+            val t = EnumType(t1.ref, CalcIntType)
             t.enumSpec = t1.enumSpec
             t
           } else {

--- a/shared/src/main/scala/io/kaitai/struct/translators/TypeProvider.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/TypeProvider.scala
@@ -16,7 +16,7 @@ trait TypeProvider {
   def determineType(attrId: Identifier): DataType
   def determineType(inClass: ClassSpec, attrName: String): DataType
   def determineType(inClass: ClassSpec, attrId: Identifier): DataType
-  def resolveEnum(typeName: Ast.typeId, enumName: String): EnumSpec
+  def resolveEnum(ref: Ast.EnumRef): EnumSpec
   def resolveType(typeName: Ast.typeId): DataType
   def isLazy(attrName: String): Boolean
   def isLazy(inClass: ClassSpec, attrName: String): Boolean

--- a/shared/src/main/scala/io/kaitai/struct/translators/ZigTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/ZigTranslator.scala
@@ -116,12 +116,12 @@ class ZigTranslator(provider: TypeProvider, importList: ImportList, config: Runt
   }
 
   override def doEnumByLabel(enumSpec: EnumSpec, label: String): String = {
-    val et = EnumType(enumSpec.name.last, enumSpec.name.dropRight(1), CalcIntType)
+    val et = EnumType(Ast.EnumRef(true, enumSpec.name.dropRight(1), enumSpec.name.last), CalcIntType)
     et.enumSpec = Some(enumSpec)
     s"${ZigCompiler.kaitaiType2NativeType(et, importList, provider.nowClass)}.$label"
   }
   override def doEnumById(enumSpec: EnumSpec, id: String): String = {
-    val et = EnumType(enumSpec.name.last, enumSpec.name.dropRight(1), CalcIntType)
+    val et = EnumType(Ast.EnumRef(true, enumSpec.name.dropRight(1), enumSpec.name.last), CalcIntType)
     et.enumSpec = Some(enumSpec)
     s"@as(${ZigCompiler.kaitaiType2NativeType(et, importList, provider.nowClass)}, @enumFromInt($id))"
   }


### PR DESCRIPTION
Closes https://github.com/kaitai-io/kaitai_struct/issues/857.

This PR started as support for the ability to use absolute paths (which is actually supported by type resolver) and ended as a bug fix for a known issue.

It is based on #309, because I do not want to do the work twice and check that the type resolution works as expected (it was already checked in the base PR).
