### PR TITLE
Add debug information for enum type parameters

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -111,6 +111,18 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
     if (config.readStoresPos) {
       out.puts("this._debug = {};")
+      params.foreach { p =>
+        // Add debug information for enum type parameters
+        p.dataType match {
+          case t: EnumType =>
+            out.puts(s"this._debug['${idToStr(p.id)}'] = {")
+            out.inc
+            out.puts(s"enumName: \"${types2class(t.enumSpec.get.name, false)}\"")
+            out.dec
+            out.puts("};")
+          case _ => // Do nothing for non-enum types
+        }
+      }
     }
     out.puts
   }


### PR DESCRIPTION
- This change improves debugging capabilities by providing more detailed information about enum type parameters in the generated JavaScript code.
- Test @ https://github.com/kaitai-io/kaitai_struct_tests/pull/131