### PR TITLE
Fix operator precedence handling across target languages

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -159,9 +159,17 @@ class TranslatorSpec extends AnyFunSpec {
       PythonCompiler -> "3 - ((1 + 2) // (7 * 8) + 5)"
     ))
 
-    everybody("1 + 2 << 5", "1 + 2 << 5")
-    everybody("(1 + 2) << 5", "1 + 2 << 5")
-    everybody("1 + (2 << 5)", "1 + (2 << 5)")
+    everybodyExcept("1 + 2 << 5", "1 + 2 << 5", ResultMap(
+      GoCompiler -> "(1 + 2) << 5"
+    ))
+
+    everybodyExcept("(1 + 2) << 5", "1 + 2 << 5", ResultMap(
+      GoCompiler -> "(1 + 2) << 5"
+    ))
+
+    everybodyExcept("1 + (2 << 5)", "1 + (2 << 5)", ResultMap(
+      GoCompiler -> "1 + 2 << 5"
+    ))
 
     everybodyExcept("~777", "~777", ResultMap(
       GoCompiler -> "^777"
@@ -175,11 +183,26 @@ class TranslatorSpec extends AnyFunSpec {
     everybodyExcept("(0b01 & 0b10) >> 1", "(1 & 2) >> 1", ResultMap(
       JavaScriptCompiler -> "(1 & 2) >>> 1"
     ))
+
+    everybodyExcept("3 | 1 ^ 2", "3 | 1 ^ 2", ResultMap(
+      GoCompiler -> "3 | (1 ^ 2)",
+      LuaCompiler -> "3 | 1 ~ 2",
+      PerlCompiler -> "3 | (1 ^ 2)",
+      RubyCompiler -> "3 | (1 ^ 2)"
+    ))
   }
 
   describe("integer comparisons") {
     everybody("1 < 2", "1 < 2", CalcBooleanType)
     everybody("1 == 2", "1 == 2", CalcBooleanType)
+
+    everybodyExcept("100 & 1 == 0", "(100 & 1) == 0", ResultMap(
+      GoCompiler -> "100 & 1 == 0",
+      LuaCompiler -> "100 & 1 == 0",
+      PythonCompiler -> "100 & 1 == 0",
+      RubyCompiler -> "100 & 1 == 0",
+      RustCompiler -> "100 & 1 == 0",
+    ), CalcBooleanType)
   }
 
   describe("integer method calls") {

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -599,7 +599,7 @@ class TranslatorSpec extends AnyFunSpec {
       ), CalcStrType)
 
       everybodyExcept("\"str1\" == \"str2\"", "\"str1\" == \"str2\"", ResultMap(
-        CppCompiler -> "std::string(\"str1\") == (std::string(\"str2\"))",
+        CppCompiler -> "std::string(\"str1\") == std::string(\"str2\")",
         JavaCompiler -> "\"str1\".equals(\"str2\")",
         LuaCompiler -> "\"str1\" == \"str2\"",
         PerlCompiler -> "\"str1\" eq \"str2\"",

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -484,7 +484,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "this.A[42 - 2]",
         JavaCompiler -> "a().get((int) (42 - 2))",
         JavaScriptCompiler -> "this.a[42 - 2]",
-        LuaCompiler -> "self.a[42 - 2 + 1]", // TODO: self.a[41]
+        LuaCompiler -> "self.a[(42 - 2) + 1]", // TODO: self.a[41]
         PerlCompiler -> "@{$self->a()}[42 - 2]",
         PHPCompiler -> "$this->a()[42 - 2]",
         PythonCompiler -> "self.a[42 - 2]",
@@ -608,7 +608,7 @@ class TranslatorSpec extends AnyFunSpec {
 
       everybodyExcept("\"str1\" != \"str2\"", "\"str1\" != \"str2\"", ResultMap(
         CppCompiler -> "std::string(\"str1\") != std::string(\"str2\")",
-        JavaCompiler -> "!(\"str1\").equals(\"str2\")",
+        JavaCompiler -> "!\"str1\".equals(\"str2\")",
         LuaCompiler -> "\"str1\" ~= \"str2\"",
         PerlCompiler -> "\"str1\" ne \"str2\"",
         PythonCompiler -> "u\"str1\" != u\"str2\""

--- a/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/translators/TranslatorSpec.scala
@@ -56,9 +56,9 @@ class TranslatorSpec extends AnyFunSpec {
       everybody("-2147483647", "-2147483647")
       // -0x8000_0000
       everybodyExcept("-2147483648", "-2147483648", ResultMap(
-        CppCompiler -> "-2147483647 - 1",
-        LuaCompiler -> "-2147483647 - 1",
-        PHPCompiler -> "-2147483647 - 1",
+        CppCompiler -> "(-2147483647 - 1)",
+        LuaCompiler -> "(-2147483647 - 1)",
+        PHPCompiler -> "(-2147483647 - 1)",
       ))
       // -0x8000_0001
       everybodyExcept("-2147483649", "-2147483649", ResultMap(
@@ -79,7 +79,7 @@ class TranslatorSpec extends AnyFunSpec {
         GoCompiler -> "uint64(9223372036854775808)",
         JavaCompiler -> "0x8000000000000000L",
         LuaCompiler -> "0x8000000000000000",
-        PHPCompiler -> "-9223372036854775807 - 1",
+        PHPCompiler -> "(-9223372036854775807 - 1)",
       ))
       // 0xffff_ffff_ffff_ffff
       everybodyExcept("18446744073709551615", "18446744073709551615", ResultMap(
@@ -97,11 +97,11 @@ class TranslatorSpec extends AnyFunSpec {
       ))
       // -0x8000_0000_0000_0000
       everybodyExcept("-9223372036854775808", "-9223372036854775808", ResultMap(
-        CppCompiler -> "-9223372036854775807LL - 1",
+        CppCompiler -> "(-9223372036854775807LL - 1)",
         GoCompiler -> "int64(-9223372036854775808)",
         JavaCompiler -> "-9223372036854775808L",
-        LuaCompiler -> "-9223372036854775807 - 1",
-        PHPCompiler -> "-9223372036854775807 - 1",
+        LuaCompiler -> "(-9223372036854775807 - 1)",
+        PHPCompiler -> "(-9223372036854775807 - 1)",
       ))
     }
   }

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -106,7 +106,9 @@ object Ast {
     case object Or extends boolop
   }
 
-  sealed trait operator
+  trait binaryop
+
+  sealed trait operator extends binaryop
   case object operator {
     case object Add extends operator
     case object Sub  extends operator
@@ -131,7 +133,7 @@ object Ast {
     case object Minus extends unaryop
   }
 
-  sealed trait cmpop
+  sealed trait cmpop extends binaryop
   object cmpop {
     case object Eq extends cmpop
     case object NotEq extends cmpop

--- a/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
+++ b/shared/src/main/scala/io/kaitai/struct/exprlang/Ast.scala
@@ -106,7 +106,7 @@ object Ast {
     case object Or extends boolop
   }
 
-  trait binaryop
+  sealed trait binaryop
 
   sealed trait operator extends binaryop
   case object operator {

--- a/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/BaseTranslator.scala
@@ -86,26 +86,26 @@ abstract class BaseTranslator(val provider: TypeProvider)
       case Ast.expr.Compare(left: Ast.expr, op: Ast.cmpop, right: Ast.expr) =>
         (detectType(left), detectType(right)) match {
           case (_: NumericType, _: NumericType) =>
-            doNumericCompareOp(left, op, right)
+            doNumericCompareOp(left, op, right, extPrec)
           case (_: BooleanType, _: BooleanType) =>
             op match {
               case Ast.cmpop.Eq | Ast.cmpop.NotEq =>
                 // FIXME: probably for some languages we'll need non-numeric comparison
-                doNumericCompareOp(left, op, right)
+                doNumericCompareOp(left, op, right, extPrec)
               case _ =>
                 throw new TypeMismatchError(s"can't compare booleans using $op operator")
             }
           case (_: StrType, _: StrType) =>
-            doStrCompareOp(left, op, right)
+            doStrCompareOp(left, op, right, extPrec)
           case (_: BytesType, _: BytesType) =>
-            doBytesCompareOp(left, op, right)
+            doBytesCompareOp(left, op, right, extPrec)
           case (et1: EnumType, et2: EnumType) =>
             val et1Spec = et1.enumSpec.get
             val et2Spec = et2.enumSpec.get
             if (et1Spec != et2Spec) {
               throw new TypeMismatchError(s"can't compare enums type ${et1Spec.nameAsStr} and ${et2Spec.nameAsStr}")
             } else {
-              doEnumCompareOp(left, op, right)
+              doEnumCompareOp(left, op, right, extPrec)
             }
           case (ltype, rtype) =>
             throw new TypeMismatchError(s"can't compare $ltype and $rtype")

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -9,6 +9,22 @@ import io.kaitai.struct.format.{EnumSpec, Identifier}
 import io.kaitai.struct.languages.CSharpCompiler
 
 class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends BaseTranslator(provider) {
+  override def translate(v: Ast.expr, extPrec: Int): String = {
+    val expr = super.translate(v, extPrec)
+    v match {
+      case Ast.expr.UnaryOp(op: Ast.unaryop, inner: Ast.expr) =>
+        if (extPrec == METHOD_PRECEDENCE) {
+          // This is needed so that `(-2).to_s` and `(~12).to_s` are not incorrectly
+          // translated as `-2.ToString()` and `~12.ToString()`.
+          s"($expr)"
+        } else {
+          expr
+        }
+      case _ =>
+        expr
+    }
+  }
+
   override def doArrayLiteral(t: DataType, value: Seq[expr]): String = {
     val nativeType = CSharpCompiler.kaitaiType2NativeType(importList, t)
     val commaStr = value.map((v) => translate(v)).mkString(", ")

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -38,7 +38,7 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
 
   override def strLiteralGenericCC(code: Char): String = strLiteralUnicode(code)
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Mod) =>
         s"${CSharpCompiler.kstreamName}.Mod(${translate(left)}, ${translate(right)})"
@@ -71,17 +71,15 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
     CSharpCompiler.types2class(enumTypeRel)
   }
 
-  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr) = {
-    if (op == Ast.cmpop.Eq) {
-      s"${translate(left)} == ${translate(right)}"
-    } else if (op == Ast.cmpop.NotEq) {
-      s"${translate(left)} != ${translate(right)}"
+  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int) = {
+    if (op == Ast.cmpop.Eq || op == Ast.cmpop.NotEq) {
+      super.doStrCompareOp(left, op, right, extPrec)
     } else {
       s"(${translate(left)}.CompareTo(${translate(right)}) ${cmpOp(op)} 0)"
     }
   }
 
-  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
+  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
     s"(${CSharpCompiler.kstreamName}.ByteArrayCompare(${translate(left)}, ${translate(right)}) ${cmpOp(op)} 0)"
 
   override def arraySubscript(container: expr, idx: expr): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala
@@ -145,7 +145,7 @@ abstract trait CommonMethods[T] extends TypeDetector {
     *  - if `obj` is complex (like an expression `a + b`), then this will ensure framing as
     *    `(a + b).method(args)`.
     */
-  val METHOD_PRECEDENCE = 999
+  final val METHOD_PRECEDENCE = CommonMethods.METHOD_PRECEDENCE
 
   /**
     * Translates a certain attribute call (as in `foo.bar`) into a rendition
@@ -278,4 +278,8 @@ abstract trait CommonMethods[T] extends TypeDetector {
   def boolToInt(value: Ast.expr): T
 
   def byteSizeOfValue(attrName: String, valType: DataType): T
+}
+
+object CommonMethods {
+  final val METHOD_PRECEDENCE = 999
 }

--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonOps.scala
@@ -7,13 +7,18 @@ trait CommonOps extends AbstractTranslator {
    * Provides operator precedence table, used for deciding whether
    * parenthesis guarding expression are necessary or not.
    *
-   * This is the default table, based on Python operator precedence model.
+   * This is the default table, based on c++ operator precedence model.
    * This is good enough for most C-like languages. Individual languages'
    * translators can override it if and when necessary to alter behavior.
    *
-   * @see https://docs.python.org/3/reference/expressions.html#operator-precedence
+   * @see https://en.cppreference.com/w/cpp/language/operator_precedence
+   * @see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence
+   * @see https://docs.oracle.com/javase/tutorial/java/nutsandbolts/operators.html
+   * @see https://www.php.net/manual/en/language.operators.precedence.php
    */
-  val OPERATOR_PRECEDENCE = Map[Ast.operator, Int](
+
+  val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
     Ast.operator.Mult -> 130,
     Ast.operator.Div -> 130,
     Ast.operator.Mod -> 130,
@@ -21,9 +26,15 @@ trait CommonOps extends AbstractTranslator {
     Ast.operator.Sub -> 120,
     Ast.operator.LShift -> 110,
     Ast.operator.RShift -> 110,
-    Ast.operator.BitAnd -> 100,
-    Ast.operator.BitXor -> 90,
-    Ast.operator.BitOr -> 80,
+    Ast.cmpop.Lt -> 100,
+    Ast.cmpop.LtE -> 100,
+    Ast.cmpop.Gt -> 100,
+    Ast.cmpop.GtE -> 100,
+    Ast.cmpop.Eq -> 90,
+    Ast.cmpop.NotEq -> 90,
+    Ast.operator.BitAnd -> 80,
+    Ast.operator.BitXor -> 70,
+    Ast.operator.BitOr -> 60
   )
 
   def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int): String =
@@ -55,17 +66,22 @@ trait CommonOps extends AbstractTranslator {
     }
   }
 
+  def doCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String = {
+    val thisPrec = OPERATOR_PRECEDENCE(op)
+    s"${translate(left, thisPrec)} ${cmpOp(op)} ${translate(right, thisPrec)}"
+  }
+
   def doNumericCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    s"${translate(left)} ${cmpOp(op)} ${translate(right)}"
+    doCompareOp(left, op, right)
 
   def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    s"${translate(left)} ${cmpOp(op)} ${translate(right)}"
+    doCompareOp(left, op, right)
 
   def doEnumCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    s"${translate(left)} ${cmpOp(op)} ${translate(right)}"
+    doCompareOp(left, op, right)
 
   def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    s"${translate(left)} ${cmpOp(op)} ${translate(right)}"
+    doCompareOp(left, op, right)
 
   def cmpOp(op: Ast.cmpop): String = {
     op match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/CommonOps.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CommonOps.scala
@@ -7,7 +7,7 @@ trait CommonOps extends AbstractTranslator {
    * Provides operator precedence table, used for deciding whether
    * parenthesis guarding expression are necessary or not.
    *
-   * This is the default table, based on c++ operator precedence model.
+   * This is the default table, based on C++ operator precedence model.
    * This is good enough for most C-like languages. Individual languages'
    * translators can override it if and when necessary to alter behavior.
    *
@@ -37,10 +37,15 @@ trait CommonOps extends AbstractTranslator {
     Ast.operator.BitOr -> 60
   )
 
-  def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int): String =
-    genericBinOpStr(left, op, binOp(op), right, extPrec)
+  def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int): String = {
+    val opStr = op match {
+      case op: Ast.operator => binOp(op)
+      case op: Ast.cmpop => cmpOp(op)
+    }
+    genericBinOpStr(left, op, opStr, right, extPrec)
+  }
 
-  def genericBinOpStr(left: Ast.expr, op: Ast.operator, opStr: String, right: Ast.expr, extPrec: Int): String = {
+  def genericBinOpStr(left: Ast.expr, op: Ast.binaryop, opStr: String, right: Ast.expr, extPrec: Int): String = {
     val thisPrec = OPERATOR_PRECEDENCE(op)
     val leftStr = translate(left, thisPrec)
     val rightStr = translate(right, thisPrec)
@@ -66,22 +71,17 @@ trait CommonOps extends AbstractTranslator {
     }
   }
 
-  def doCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String = {
-    val thisPrec = OPERATOR_PRECEDENCE(op)
-    s"${translate(left, thisPrec)} ${cmpOp(op)} ${translate(right, thisPrec)}"
-  }
+  def doNumericCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
+    genericBinOp(left, op, right, extPrec)
 
-  def doNumericCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    doCompareOp(left, op, right)
+  def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
+    genericBinOp(left, op, right, extPrec)
 
-  def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    doCompareOp(left, op, right)
+  def doEnumCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
+    genericBinOp(left, op, right, extPrec)
 
-  def doEnumCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    doCompareOp(left, op, right)
-
-  def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    doCompareOp(left, op, right)
+  def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
+    genericBinOp(left, op, right, extPrec)
 
   def cmpOp(op: Ast.cmpop): String = {
     op match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -168,7 +168,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     if (op == Ast.cmpop.Eq || op == Ast.cmpop.NotEq) {
       super.doStrCompareOp(left, op, right, extPrec)
     } else {
-      s"(${translate(left)}.compare(${translate(right)}) ${cmpOp(op)} 0)"
+      s"(${translate(left, METHOD_PRECEDENCE)}.compare(${translate(right)}) ${cmpOp(op)} 0)"
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CppTranslator.scala
@@ -131,7 +131,7 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
     }
   }
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Mod) =>
         s"${CppCompiler.kstreamName}::mod(${translate(left)}, ${translate(right)})"
@@ -164,11 +164,9 @@ class CppTranslator(provider: TypeProvider, importListSrc: CppImportList, import
   override def doEnumById(enumSpec: EnumSpec, id: String): String =
     s"static_cast<${CppCompiler.types2class(enumSpec.name)}>($id)"
 
-  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr) = {
-    if (op == Ast.cmpop.Eq) {
-      s"${translate(left)} == (${translate(right)})"
-    } else if (op == Ast.cmpop.NotEq) {
-      s"${translate(left)} != ${translate(right)}"
+  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int) = {
+    if (op == Ast.cmpop.Eq || op == Ast.cmpop.NotEq) {
+      super.doStrCompareOp(left, op, right, extPrec)
     } else {
       s"(${translate(left)}.compare(${translate(right)}) ${cmpOp(op)} 0)"
     }

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -28,6 +28,28 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
 
   var returnRes: Option[String] = None
 
+  /**
+  * @see https://go.dev/ref/spec#Operator_precedence
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.LShift -> 130,
+    Ast.operator.RShift -> 130,
+    Ast.operator.BitAnd -> 130,
+    Ast.operator.Add -> 120,
+    Ast.operator.Sub -> 120,
+    Ast.operator.BitXor -> 120,
+    Ast.operator.BitOr -> 120,
+    Ast.cmpop.Lt -> 110,
+    Ast.cmpop.LtE -> 110,
+    Ast.cmpop.Gt -> 110,
+    Ast.cmpop.GtE -> 110,
+    Ast.cmpop.Eq -> 110,
+    Ast.cmpop.NotEq -> 110
+  )
+
   override def translate(v: Ast.expr, extPrec: Int): String = resToStr(translateExpr(v, extPrec))
 
   def resToStr(r: TranslatorResult): String = r match {

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -167,7 +167,7 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
     (detectType(left), detectType(right), op) match {
       case (t1: IntType, t2: IntType, Ast.operator.Mod) =>
         val v1 = allocateLocalVar()
-        out.puts(s"${localVarName(v1)} := ${translate(left)} % ${translate(right)}")
+        out.puts(s"${localVarName(v1)} := ${genericBinOp(left, Ast.operator.Mod, right, 0)}")
         out.puts(s"if ${localVarName(v1)} < 0 {")
         out.inc
         out.puts(s"${localVarName(v1)} += ${translate(right)}")

--- a/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/GoTranslator.scala
@@ -98,15 +98,15 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
       case Ast.expr.Compare(left, op, right) =>
         (detectType(left), detectType(right)) match {
           case (_: NumericType, _: NumericType) =>
-            trNumericCompareOp(left, op, right)
+            trNumericCompareOp(left, op, right, extPrec)
           case (_: StrType, _: StrType) =>
-            trStrCompareOp(left, op, right)
+            trStrCompareOp(left, op, right, extPrec)
           case (_: BytesType, _: BytesType) =>
             trBytesCompareOp(left, op, right)
           case (_: BooleanType, _: BooleanType) =>
-            trNumericCompareOp(left, op, right)
+            trNumericCompareOp(left, op, right, extPrec)
           case (_: EnumType, _: EnumType) =>
-            trNumericCompareOp(left, op, right)
+            trNumericCompareOp(left, op, right, extPrec)
           case (ltype, rtype) =>
             throw new TypeMismatchError(s"can't do $ltype $op $rtype")
         }
@@ -182,11 +182,11 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
   def trStrConcat(left: Ast.expr, right: Ast.expr, extPrec: Int): TranslatorResult =
     ResultString(genericBinOp(left, Ast.operator.Add, right, extPrec))
 
-  def trNumericCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): TranslatorResult =
-    ResultString(doNumericCompareOp(left, op, right))
+  def trNumericCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): TranslatorResult =
+    ResultString(doNumericCompareOp(left, op, right, extPrec))
 
-  def trStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): TranslatorResult =
-    ResultString(doStrCompareOp(left, op, right))
+  def trStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): TranslatorResult =
+    ResultString(doStrCompareOp(left, op, right, extPrec))
 
   def trBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): TranslatorResult = {
     importList.add("bytes")
@@ -280,7 +280,7 @@ class GoTranslator(out: StringLanguageOutputWriter, provider: TypeProvider, impo
   def trEnumById(enumTypeAbs: List[String], id: String) =
     ResultString(s"${types2class(enumTypeAbs)}($id)")
 
-  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String = {
+  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = {
     op match {
       case Ast.cmpop.Eq =>
         s"Arrays.equals(${translate(left)}, ${translate(right)})"

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaScriptTranslator.scala
@@ -26,7 +26,7 @@ class JavaScriptTranslator(provider: TypeProvider, importList: ImportList) exten
   override def strLiteralGenericCC(code: Char): String =
     "\\x%02x".format(code.toInt)
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>
         s"Math.floor(${super.genericBinOp(left, op, right, 0)})"
@@ -70,7 +70,7 @@ class JavaScriptTranslator(provider: TypeProvider, importList: ImportList) exten
     // Just an integer, without any casts / resolutions - one would have to look up constants manually
     id
 
-  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
+  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
     s"(${JavaScriptCompiler.kstreamName}.byteArrayCompare(${translate(left)}, ${translate(right)}) ${cmpOp(op)} 0)"
 
   override def arraySubscript(container: expr, idx: expr): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -78,11 +78,11 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
 
   override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = op match {
     case Ast.cmpop.Eq =>
-      s"${translate(left)}.equals(${translate(right)})"
+      s"${translate(left, METHOD_PRECEDENCE)}.equals(${translate(right)})"
     case Ast.cmpop.NotEq =>
-      s"!(${translate(left)}).equals(${translate(right)})"
+      s"!${translate(left, METHOD_PRECEDENCE)}.equals(${translate(right)})"
     case _ =>
-      s"(${translate(left)}.compareTo(${translate(right)}) ${cmpOp(op)} 0)"
+      s"(${translate(left, METHOD_PRECEDENCE)}.compareTo(${translate(right)}) ${cmpOp(op)} 0)"
   }
 
   override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = {

--- a/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/JavaTranslator.scala
@@ -45,7 +45,7 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def doByteArrayNonLiteral(elts: Seq[expr]): String =
     s"new byte[] { ${elts.map(translate).mkString(", ")} }"
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Mod) =>
         s"${JavaCompiler.kstreamName}.mod(${translate(left)}, ${translate(right)})"
@@ -76,7 +76,7 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     enumTypeRel.map((x) => Utils.upperCamelCase(x)).mkString(".")
   }
 
-  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String = op match {
+  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = op match {
     case Ast.cmpop.Eq =>
       s"${translate(left)}.equals(${translate(right)})"
     case Ast.cmpop.NotEq =>
@@ -85,7 +85,7 @@ class JavaTranslator(provider: TypeProvider, importList: ImportList) extends Bas
       s"(${translate(left)}.compareTo(${translate(right)}) ${cmpOp(op)} 0)"
   }
 
-  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String = {
+  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String = {
     op match {
       case Ast.cmpop.Eq =>
         importList.add("java.util.Arrays")

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -10,6 +10,28 @@ import io.kaitai.struct.Utils
 
 class LuaTranslator(provider: TypeProvider, importList: ImportList) extends BaseTranslator(provider)
     with MinSignedIntegers {
+  /**
+  * @see https://www.lua.org/manual/5.4/manual.html#3.4.8
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.Add -> 120,
+    Ast.operator.Sub -> 120,
+    Ast.operator.LShift -> 110,
+    Ast.operator.RShift -> 110,
+    Ast.operator.BitAnd -> 100,
+    Ast.operator.BitXor -> 90,
+    Ast.operator.BitOr -> 80,
+    Ast.cmpop.Lt -> 70,
+    Ast.cmpop.LtE -> 70,
+    Ast.cmpop.Gt -> 70,
+    Ast.cmpop.GtE -> 70,
+    Ast.cmpop.Eq -> 70,
+    Ast.cmpop.NotEq -> 70
+  )
+
   override def doIntLiteral(n: BigInt): String = {
     if (n > Long.MaxValue && n <= Utils.MAX_UINT64) {
       // See <https://www.lua.org/manual/5.4/manual.html#3.1>:

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -78,7 +78,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
 
   override def arraySubscript(container: Ast.expr, idx: Ast.expr): String = {
     // Lua indexes start at 1, so we need to offset them
-    s"${translate(container)}[${translate(idx)} + 1]"
+    s"${translate(container)}[${translate(Ast.expr.BinOp(idx, Ast.operator.Add, Ast.expr.IntNum(1)))}]"
   }
   override def doIfExp(condition: Ast.expr, ifTrue: Ast.expr, ifFalse: Ast.expr): String = {
     importList.add("local utils = require(\"utils\")")
@@ -128,7 +128,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def boolToInt(v: Ast.expr): String =
     s"(${translate(v)} and 1 or 0)"
   override def floatToInt(v: Ast.expr): String =
-    s"(${translate(v)} > 0) and math.floor(${translate(v)}) or math.ceil(${translate(v)})"
+    s"((${translate(v)} > 0) and math.floor(${translate(v)}) or math.ceil(${translate(v)}))"
   override def intToStr(i: Ast.expr): String =
     s"tostring(${translate(i)})"
   override def bytesToStr(bytesExpr: String, encoding: String): String = {
@@ -137,7 +137,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
     s"""str_decode.decode($bytesExpr, ${doStringLiteral(encoding)})"""
   }
   override def bytesSubscript(container: Ast.expr, idx: Ast.expr): String = {
-    s"string.byte(${translate(container)}, ${translate(idx)} + 1)"
+    s"string.byte(${translate(container)}, ${translate(Ast.expr.BinOp(idx, Ast.operator.Add, Ast.expr.IntNum(1)))})"
   }
   override def bytesFirst(a: Ast.expr): String =
     s"string.byte(${translate(a)}, 1)"

--- a/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/LuaTranslator.scala
@@ -67,7 +67,7 @@ class LuaTranslator(provider: TypeProvider, importList: ImportList) extends Base
   override def strLiteralUnicode(code: Char): String =
     "\\u{%04x}".format(code.toInt)
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>
         s"math.floor(${super.genericBinOp(left, op, right, 0)})"

--- a/shared/src/main/scala/io/kaitai/struct/translators/MinSignedIntegers.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/MinSignedIntegers.scala
@@ -26,7 +26,13 @@ trait MinSignedIntegers
           Ast.expr.IntNum(n + 1),
           Ast.operator.Sub,
           Ast.expr.IntNum(1)
-        )
+        ),
+        // We have no information about which expression operators might be around. To be on the
+        // safe side, we assume that the operator outside has the highest possible precedence
+        // `METHOD_PRECEDENCE`, which will cause this expression to be wrapped in parentheses. This
+        // avoids bugs like this:
+        // https://github.com/kaitai-io/kaitai_struct_compiler/pull/277#discussion_r1526970949
+        CommonMethods.METHOD_PRECEDENCE
       )
     } else {
       super.doIntLiteral(n)

--- a/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/NimTranslator.scala
@@ -10,6 +10,29 @@ import io.kaitai.struct.format.{EnumSpec, Identifier}
 import io.kaitai.struct.languages.NimCompiler.{ksToNim, namespaced, camelCase}
 
 class NimTranslator(provider: TypeProvider, importList: ImportList) extends BaseTranslator(provider) {
+  /**
+  * @see https://nim-lang.org/docs/manual.html#syntax-precedence
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.LShift -> 120,
+    Ast.operator.RShift -> 120,
+    Ast.operator.Add -> 110,
+    Ast.operator.Sub -> 110,
+    Ast.cmpop.Lt -> 100,
+    Ast.cmpop.LtE -> 100,
+    Ast.cmpop.Gt -> 100,
+    Ast.cmpop.GtE -> 100,
+    Ast.cmpop.Eq -> 100,
+    Ast.cmpop.NotEq -> 100,
+    Ast.operator.BitAnd -> 90,
+    Ast.operator.BitXor -> 80,
+    Ast.operator.BitOr -> 80
+
+  )
+
   // Members declared in io.kaitai.struct.translators.BaseTranslator
   override def bytesToStr(bytesExpr: String, encoding: String): String = {
     s"""encode($bytesExpr, ${doStringLiteral(encoding)})"""

--- a/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PHPTranslator.scala
@@ -42,7 +42,7 @@ class PHPTranslator(provider: TypeProvider, config: RuntimeConfig) extends BaseT
   override def strLiteralUnicode(code: Char): String =
     "\\u{%x}".format(code.toInt)
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>
         s"intval(${super.genericBinOp(left, op, right, 0)})"

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -8,6 +8,27 @@ import io.kaitai.struct.format.{EnumSpec, Identifier}
 import io.kaitai.struct.languages.PerlCompiler
 
 class PerlTranslator(provider: TypeProvider, importList: ImportList) extends BaseTranslator(provider) {
+  /**
+  * @see https://perldoc.perl.org/perlop#Operator-Precedence-and-Associativity
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.Add -> 120,
+    Ast.operator.Sub -> 120,
+    Ast.operator.LShift -> 110,
+    Ast.operator.RShift -> 110,
+    Ast.cmpop.Lt -> 100,
+    Ast.cmpop.LtE -> 100,
+    Ast.cmpop.Gt -> 100,
+    Ast.cmpop.GtE -> 100,
+    Ast.cmpop.Eq -> 90,
+    Ast.cmpop.NotEq -> 90,
+    Ast.operator.BitAnd -> 80,
+    Ast.operator.BitXor -> 70,
+    Ast.operator.BitOr -> 70
+  )
   // http://perldoc.perl.org/perlrebackslash.html#Character-Escapes
   override val asciiCharQuoteMap: Map[Char, String] = Map(
     '\t' -> "\\t",

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -55,7 +55,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
   override def strLiteralUnicode(code: Char): String =
     "\\N{U+%04x}".format(code.toInt)
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>
         s"int(${super.genericBinOp(left, op, right, 0)})"
@@ -116,7 +116,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
     enumTypeRel.map((x) => Utils.upperCamelCase(x)).mkString(".")
   }
 
-  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr) = {
+  override def doStrCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int) = {
     val opStr = op match {
       case Ast.cmpop.Eq => "eq"
       case Ast.cmpop.NotEq => "ne"
@@ -125,11 +125,11 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
       case Ast.cmpop.Gt => "gt"
       case Ast.cmpop.GtE => "ge"
     }
-    s"${translate(left)} $opStr ${translate(right)}"
+    super.genericBinOpStr(left, op, opStr, right, extPrec)
   }
 
-  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr): String =
-    doStrCompareOp(left, op, right)
+  override def doBytesCompareOp(left: Ast.expr, op: Ast.cmpop, right: Ast.expr, extPrec: Int): String =
+    doStrCompareOp(left, op, right, extPrec)
 
   override def arraySubscript(container: Ast.expr, idx: Ast.expr): String =
     s"@{${translate(container)}}[${translate(idx)}]"

--- a/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PerlTranslator.scala
@@ -147,7 +147,7 @@ class PerlTranslator(provider: TypeProvider, importList: ImportList) extends Bas
       case "8" =>
         s"oct(${translate(s)})"
       case "10" =>
-        s"${translate(s)} + 0"
+        s"(${translate(s)} + 0)"
       case "16" =>
         s"hex(${translate(s)})"
       case _ => throw new UnsupportedOperationException(baseStr)

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -7,6 +7,28 @@ import io.kaitai.struct.format.{EnumSpec, Identifier}
 import io.kaitai.struct.languages.{PythonCompiler, RubyCompiler}
 
 class PythonTranslator(provider: TypeProvider, importList: ImportList, config: RuntimeConfig) extends BaseTranslator(provider) {
+  /**
+  * @see https://docs.python.org/3/reference/expressions.html#operator-precedence
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.Add -> 120,
+    Ast.operator.Sub -> 120,
+    Ast.operator.LShift -> 110,
+    Ast.operator.RShift -> 110,
+    Ast.operator.BitAnd -> 100,
+    Ast.operator.BitXor -> 90,
+    Ast.operator.BitOr -> 80,
+    Ast.cmpop.Lt -> 70,
+    Ast.cmpop.LtE -> 70,
+    Ast.cmpop.Gt -> 70,
+    Ast.cmpop.GtE -> 70,
+    Ast.cmpop.Eq -> 70,
+    Ast.cmpop.NotEq -> 70
+  )
+
   override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>

--- a/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/PythonTranslator.scala
@@ -29,7 +29,7 @@ class PythonTranslator(provider: TypeProvider, importList: ImportList, config: R
     Ast.cmpop.NotEq -> 70
   )
 
-  override def genericBinOp(left: Ast.expr, op: Ast.operator, right: Ast.expr, extPrec: Int) = {
+  override def genericBinOp(left: Ast.expr, op: Ast.binaryop, right: Ast.expr, extPrec: Int) = {
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Div) =>
         genericBinOpStr(left, op, "//", right, extPrec)

--- a/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RubyTranslator.scala
@@ -8,6 +8,28 @@ import io.kaitai.struct.languages.RubyCompiler
 
 class RubyTranslator(provider: TypeProvider) extends BaseTranslator(provider)
   with ByteArraysAsTrueArrays[String] {
+  /**
+  * @see https://ruby-doc.org/core-2.6.2/doc/syntax/precedence_rdoc.html
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.Add -> 120,
+    Ast.operator.Sub -> 120,
+    Ast.operator.LShift -> 110,
+    Ast.operator.RShift -> 110,
+    Ast.operator.BitAnd -> 100,
+    Ast.operator.BitXor -> 90,
+    Ast.operator.BitOr -> 90,
+    Ast.cmpop.Lt -> 70,
+    Ast.cmpop.LtE -> 70,
+    Ast.cmpop.Gt -> 70,
+    Ast.cmpop.GtE -> 70,
+    Ast.cmpop.Eq -> 60,
+    Ast.cmpop.NotEq -> 60
+  )
+
   override def doByteArrayLiteral(arr: Seq[Byte]): String =
     s"[${arr.map(_ & 0xff).mkString(", ")}].pack('C*')"
   override def doByteArrayNonLiteral(elts: Seq[Ast.expr]): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/RustTranslator.scala
@@ -16,6 +16,28 @@ class RustTranslator(provider: TypeProvider, config: RuntimeConfig)
 
   var lastFoundMemberClass: ClassSpec = provider.nowClass
 
+  /**
+  * @see https://doc.rust-lang.org/reference/expressions.html
+  */
+  override val OPERATOR_PRECEDENCE = Map[Ast.binaryop, Int](
+    Ast.operator.Mult -> 130,
+    Ast.operator.Div -> 130,
+    Ast.operator.Mod -> 130,
+    Ast.operator.Add -> 120,
+    Ast.operator.Sub -> 120,
+    Ast.operator.LShift -> 110,
+    Ast.operator.RShift -> 110,
+    Ast.operator.BitAnd -> 100,
+    Ast.operator.BitXor -> 90,
+    Ast.operator.BitOr -> 80,
+    Ast.cmpop.Lt -> 70,
+    Ast.cmpop.LtE -> 70,
+    Ast.cmpop.Gt -> 70,
+    Ast.cmpop.GtE -> 70,
+    Ast.cmpop.Eq -> 70,
+    Ast.cmpop.NotEq -> 70
+  )
+
   override def doByteArrayLiteral(arr: Seq[Byte]): String =
     "vec![" + arr.map(x => "%0#2xu8".format(x & 0xff)).mkString(", ") + "]"
   override def doByteArrayNonLiteral(elts: Seq[Ast.expr]): String =


### PR DESCRIPTION
- Adds proper operator precedence tables for each target language and updates comparison operator handling to respect precedence rules.
- Fixes issues with bitwise operations and comparisons in Go, Lua, Perl, Ruby and other languages.