### PR TITLE
C++: Use unsigned size type for loop index

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -593,8 +593,10 @@ class CppCompiler(
 
   override def condRepeatExprHeader(id: Identifier, io: String, dataType: DataType, repeatExpr: Ast.expr): Unit = {
     val lenVar = s"l_${idToStr(id)}"
-    outSrc.puts(s"const int $lenVar = ${expression(repeatExpr)};")
-    outSrc.puts(s"for (int i = 0; i < $lenVar; i++) {")
+    val cppElType = kaitaiType2NativeType(dataType)
+    val sizeType = s"std::vector<$cppElType>::size_type"
+    outSrc.puts(s"const $sizeType $lenVar = ${expression(repeatExpr)};")
+    outSrc.puts(s"for ($sizeType i = 0; i < $lenVar; i++) {")
     outSrc.inc
   }
 


### PR DESCRIPTION
This avoids a wrong sign conversion when the loop expression casts to a negative signed int.

Fixes: https://github.com/kaitai-io/kaitai_struct/issues/1220

----

I did intend to add a test for this based on the reproducing case in the linked issue, but I could not figure out how to actually run the tests.

I tried `build-tests cpp_stl` in the tests repo, but it errored out with complaints about Julia(?):

```
[error] /home/john/src/kaitai_struct/tests/translator/src/main/scala/io/kaitai/struct/testtranslator/specgenerators/JuliaSG.scala:6:8: object JuliaCompiler is not a member of package io.kaitai.struct.languages
[error] did you mean JavaCompiler or LuaCompiler?
[error] import _root_.io.kaitai.struct.languages.JuliaCompiler
```

How can I build/run the tests? I'll be more than happy to add a test if I know how!