### PR TITLE
Implement new `enums` syntax (enforced underlying `type`, `doc` / `doc-ref` support)

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
@@ -487,7 +487,7 @@ class ClassCompiler(
   }
 
   def compileEnum(curClass: ClassSpec, enumColl: EnumSpec): Unit =
-    lang.enumDeclaration(curClass.name, enumColl.name.last, enumColl.map.toSeq)
+    lang.enumDeclaration(curClass.name, enumColl.name.last, enumColl.doc, enumColl.map.toSeq)
 
   def compileClassDoc(curClass: ClassSpec): Unit = {
     if (!curClass.doc.isEmpty)

--- a/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/ClassCompiler.scala
@@ -487,7 +487,7 @@ class ClassCompiler(
   }
 
   def compileEnum(curClass: ClassSpec, enumColl: EnumSpec): Unit =
-    lang.enumDeclaration(curClass.name, enumColl.name.last, enumColl.doc, enumColl.map.toSeq)
+    lang.enumDeclaration(curClass.name, enumColl.name.last, enumColl.map.toSeq, enumColl)
 
   def compileClassDoc(curClass: ClassSpec): Unit = {
     if (!curClass.doc.isEmpty)

--- a/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
+++ b/shared/src/main/scala/io/kaitai/struct/RuntimeConfig.scala
@@ -10,6 +10,14 @@ package io.kaitai.struct
   * @param useListInitializers If true, allows use of list initializers for
   *                            `std::vector` and `std::set`. Otherwise, throw a fatal
   *                            "not implemented" error.
+  * @param enumsFixedUnderlyingType If true, enums will be declared with fixed
+  * underlying type (see https://github.com/kaitai-io/kaitai_struct/issues/1288).
+  * If false, enums will be declared without a fixed underlying type. Enums without
+  * a fixed underlying type are best avoided, because casting an integer that falls
+  * outside the range of the enum values to the enum type is undefined behavior (see
+  * https://github.com/kaitai-io/kaitai_struct/issues/959). However, in C++98, this
+  * is the only supported option (see
+  * https://cppreference.com/cpp/language/enum#Unscoped_enumerations).
   * @param pointers Choose which style of pointers to use.
   */
 case class CppRuntimeConfig(
@@ -17,6 +25,7 @@ case class CppRuntimeConfig(
   usePragmaOnce: Boolean = false,
   stdStringFrontBack: Boolean = false,
   useListInitializers: Boolean = false,
+  enumsFixedUnderlyingType: Boolean = false,
   pointers: CppRuntimeConfig.Pointers = CppRuntimeConfig.RawPointers
 ) {
   /**
@@ -27,6 +36,7 @@ case class CppRuntimeConfig(
     usePragmaOnce = false,
     stdStringFrontBack = false,
     useListInitializers = false,
+    enumsFixedUnderlyingType = false,
     pointers = CppRuntimeConfig.RawPointers
   )
 
@@ -38,6 +48,7 @@ case class CppRuntimeConfig(
     usePragmaOnce = true,
     stdStringFrontBack = true,
     useListInitializers = true,
+    enumsFixedUnderlyingType = true,
     pointers = CppRuntimeConfig.UniqueAndRawPointers
   )
 }

--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -54,6 +54,53 @@ object DataType {
       * The largest value of the given integer type
       */
     def max: BigInt
+    /**
+      * Render the integer type as a KSY-style "pure" type string (e.g. `u4`,
+      * `s1`, `b3`) without any serialization details, such as endianness.
+      * Intended for use in error messages.
+      */
+    def toPureTypeString: String
+  }
+  object IntType {
+    final val NUM_BITS_IN_BYTE = 8
+
+    /**
+      * Determine whether the two given integer types are equivalent, i.e.
+      * whether they have exactly the same range and can therefore represent the
+      * same set of integer values. Endianness is intentionally not compared,
+      * since it doesn't affect the set of representable values.
+      *
+      * [[CalcIntType]] represents an unspecified integer type, so we cannot
+      * assume that it's equivalent to anything, not even itself.
+      *
+      * This method is used to check whether an integer attribute can be
+      * converted to an enum type with a specific underlying type.
+      * https://github.com/kaitai-io/kaitai_struct/issues/1288 explains why only
+      * integer types equivalent to the underlying type are convertible to the
+      * enum type.
+      *
+      * @param a one integer type
+      * @param b other integer type
+      * @return `true` if the types are equivalent, `false` otherwise
+      */
+    def areEquivalent(a: IntType, b: IntType): Boolean =
+      (a, b) match {
+        case (Int1Type(sa), Int1Type(sb)) =>
+          sa == sb
+        case (IntMultiType(sa, wa, _), IntMultiType(sb, wb, _)) =>
+          sa == sb && wa == wb
+        case (BitsType(wa, _), BitsType(wb, _)) =>
+          wa == wb
+        // `u1` is equivalent to `b8`
+        case (Int1Type(false), BitsType(8, _)) => true
+        case (BitsType(8, _), Int1Type(false)) => true
+        // more generally, `u{N}` is equivalent to `b{8 * N}`
+        case (IntMultiType(false, byteWidth, _), BitsType(bitWidth, _)) =>
+          bitWidth == NUM_BITS_IN_BYTE * byteWidth.width
+        case (BitsType(bitWidth, _), IntMultiType(false, byteWidth, _)) =>
+          bitWidth == NUM_BITS_IN_BYTE * byteWidth.width
+        case _ => false
+      }
   }
   /**
     * In statically typed languages, [[CalcIntType]] is often a signed 32-bit
@@ -64,6 +111,7 @@ object DataType {
   case object CalcIntType extends IntType {
     override final def min: BigInt = ???
     override final def max: BigInt = ???
+    override def toPureTypeString: String = "<calc>"
   }
   case class Int1Type(signed: Boolean) extends IntType with ReadableType {
     override final def min: BigInt =
@@ -78,13 +126,12 @@ object DataType {
       } else {
         0xff
       }
+    override def toPureTypeString: String = if (signed) "s1" else "u1"
     override def apiCall(defEndian: Option[FixedEndian]): String = if (signed) "s1" else "u1"
   }
   case class IntMultiType(signed: Boolean, width: IntWidth, endian: Option[FixedEndian]) extends IntType with ReadableType {
-    private final def bitWidth: Int = {
-      val NUM_BITS_IN_BYTE = 8
-      NUM_BITS_IN_BYTE * width.width
-    }
+    private final def bitWidth: Int =
+      IntType.NUM_BITS_IN_BYTE * width.width
 
     override final def min: BigInt =
       if (signed) {
@@ -94,6 +141,8 @@ object DataType {
       }
     override final def max: BigInt =
       (BigInt(1) << (bitWidth - (if (signed) 1 else 0))) - 1
+    override def toPureTypeString: String =
+      s"${if (signed) 's' else 'u'}${width.width}"
 
     override def apiCall(defEndian: Option[FixedEndian]): String = {
       val ch1 = if (signed) 's' else 'u'
@@ -106,6 +155,8 @@ object DataType {
     override final def min: BigInt = 0
     override final def max: BigInt =
       (BigInt(1) << width) - 1
+    override def toPureTypeString: String =
+      s"b$width"
   }
 
   abstract class FloatType extends NumericType

--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -45,12 +45,56 @@ object DataType {
   abstract sealed class NumericType extends DataType
   abstract sealed class BooleanType extends DataType
 
-  abstract sealed class IntType extends NumericType
-  case object CalcIntType extends IntType
+  abstract sealed class IntType extends NumericType {
+    /**
+      * The smallest value of the given integer type
+      */
+    def min: BigInt
+    /**
+      * The largest value of the given integer type
+      */
+    def max: BigInt
+  }
+  /**
+    * In statically typed languages, [[CalcIntType]] is often a signed 32-bit
+    * integer, but from the compiler's perspective, it represents an unspecified
+    * integer type. Therefore, we deliberately don't implement the [[min]] and
+    * [[max]] methods.
+    */
+  case object CalcIntType extends IntType {
+    override final def min: BigInt = ???
+    override final def max: BigInt = ???
+  }
   case class Int1Type(signed: Boolean) extends IntType with ReadableType {
+    override final def min: BigInt =
+      if (signed) {
+        Byte.MinValue
+      } else {
+        0
+      }
+    override final def max: BigInt =
+      if (signed) {
+        Byte.MaxValue
+      } else {
+        0xff
+      }
     override def apiCall(defEndian: Option[FixedEndian]): String = if (signed) "s1" else "u1"
   }
   case class IntMultiType(signed: Boolean, width: IntWidth, endian: Option[FixedEndian]) extends IntType with ReadableType {
+    private final def bitWidth: Int = {
+      val NUM_BITS_IN_BYTE = 8
+      NUM_BITS_IN_BYTE * width.width
+    }
+
+    override final def min: BigInt =
+      if (signed) {
+        -(BigInt(1) << (bitWidth - 1))
+      } else {
+        0
+      }
+    override final def max: BigInt =
+      (BigInt(1) << (bitWidth - (if (signed) 1 else 0))) - 1
+
     override def apiCall(defEndian: Option[FixedEndian]): String = {
       val ch1 = if (signed) 's' else 'u'
       val finalEnd = endian.orElse(defEndian)
@@ -58,7 +102,11 @@ object DataType {
     }
   }
   case class BitsType1(bitEndian: BitEndianness) extends BooleanType
-  case class BitsType(width: Int, bitEndian: BitEndianness) extends IntType
+  case class BitsType(width: Int, bitEndian: BitEndianness) extends IntType {
+    override final def min: BigInt = 0
+    override final def max: BigInt =
+      (BigInt(1) << width) - 1
+  }
 
   abstract class FloatType extends NumericType
   case object CalcFloatType extends FloatType

--- a/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
+++ b/shared/src/main/scala/io/kaitai/struct/datatype/DataType.scala
@@ -60,47 +60,18 @@ object DataType {
       * Intended for use in error messages.
       */
     def toPureTypeString: String
+
+    final def subsetOf(other: IntType): Boolean = {
+      // This implementation might be slightly inefficient (compared to pattern
+      // matching with a few simple comparisons) because it involves calculating
+      // large `BigInt` values, but it's guaranteed to give the correct result.
+      // That's because it directly tests the "subset of" relationship by
+      // comparing the `min` and `max` bounds.
+      min >= other.min && max <= other.max
+    }
   }
   object IntType {
     final val NUM_BITS_IN_BYTE = 8
-
-    /**
-      * Determine whether the two given integer types are equivalent, i.e.
-      * whether they have exactly the same range and can therefore represent the
-      * same set of integer values. Endianness is intentionally not compared,
-      * since it doesn't affect the set of representable values.
-      *
-      * [[CalcIntType]] represents an unspecified integer type, so we cannot
-      * assume that it's equivalent to anything, not even itself.
-      *
-      * This method is used to check whether an integer attribute can be
-      * converted to an enum type with a specific underlying type.
-      * https://github.com/kaitai-io/kaitai_struct/issues/1288 explains why only
-      * integer types equivalent to the underlying type are convertible to the
-      * enum type.
-      *
-      * @param a one integer type
-      * @param b other integer type
-      * @return `true` if the types are equivalent, `false` otherwise
-      */
-    def areEquivalent(a: IntType, b: IntType): Boolean =
-      (a, b) match {
-        case (Int1Type(sa), Int1Type(sb)) =>
-          sa == sb
-        case (IntMultiType(sa, wa, _), IntMultiType(sb, wb, _)) =>
-          sa == sb && wa == wb
-        case (BitsType(wa, _), BitsType(wb, _)) =>
-          wa == wb
-        // `u1` is equivalent to `b8`
-        case (Int1Type(false), BitsType(8, _)) => true
-        case (BitsType(8, _), Int1Type(false)) => true
-        // more generally, `u{N}` is equivalent to `b{8 * N}`
-        case (IntMultiType(false, byteWidth, _), BitsType(bitWidth, _)) =>
-          bitWidth == NUM_BITS_IN_BYTE * byteWidth.width
-        case (BitsType(bitWidth, _), IntMultiType(false, byteWidth, _)) =>
-          bitWidth == NUM_BITS_IN_BYTE * byteWidth.width
-        case _ => false
-      }
   }
   /**
     * In statically typed languages, [[CalcIntType]] is often a signed 32-bit

--- a/shared/src/main/scala/io/kaitai/struct/format/EnumSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/EnumSpec.scala
@@ -4,8 +4,19 @@ import io.kaitai.struct.problems.KSYParseError
 
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable
+import io.kaitai.struct.Utils
+import io.kaitai.struct.datatype.DataType.IntType
+import io.kaitai.struct.datatype.DataType
+import io.kaitai.struct.datatype.DataType.BitsType1
+import io.kaitai.struct.datatype.DataType.BitsType
+import scala.util.control.NonFatal
 
-case class EnumSpec(path: List[String], map: SortedMap[BigInt, EnumValueSpec]) extends YAMLPath {
+case class EnumSpec(
+  path: List[String],
+  doc: DocSpec,
+  intType: IntType,
+  map: SortedMap[BigInt, EnumValueSpec]
+) extends YAMLPath {
   var name = List[String]()
 
   /**
@@ -26,18 +37,72 @@ case class EnumSpec(path: List[String], map: SortedMap[BigInt, EnumValueSpec]) e
 }
 
 object EnumSpec {
+  val LEGAL_KEYS = Set(
+    "doc",
+    "doc-ref",
+    "type",
+    "values"
+  )
+
   def fromYaml(src: Any, path: List[String]): EnumSpec = {
     val srcMap = ParseUtils.asMap(src, path)
-    val memberNameMap = mutable.Map[String, BigInt]()
-    EnumSpec(path, SortedMap.from(
-      srcMap.map { case (id, desc) =>
-        val idBigInt = ParseUtils.asBigInt(id, path)
-        val value = EnumValueSpec.fromYaml(desc, path ++ List(idBigInt.toString))
+    // Check whether we're dealing with the old enum syntax used in KS 0.11 and
+    // earlier. Strictly speaking, this is not necessary (the old syntax would
+    // be rejected anyway), but we do this to make the error message as helpful
+    // as possible.
+    if (srcMap.nonEmpty && !LEGAL_KEYS.exists(srcMap.contains) && srcMap.exists { case (key, _) =>
+      try {
+        ParseUtils.asBigInt(key, Nil)
+        true
+      } catch {
+        case NonFatal(_) => false
+      }
+    }) {
+      throw KSYParseError.withText(
+        "legacy pre-v0.12 enum syntax; add `type: <int_type>` (e.g. `type: u4`) and indent entries under the `values` key",
+        path
+      )
+    }
 
+    // At this point, either the map is empty or contains no integer keys (in
+    // which case we will report missing mandatory properties of the new
+    // syntax), or an attempt was made to use the new KS 0.12+ syntax (see
+    // https://github.com/kaitai-io/kaitai_struct/issues/1288), so we are
+    // treating it as such
+    val srcMapStr = ParseUtils.anyMapToStrMap(srcMap, path)
+    ParseUtils.ensureLegalKeys(srcMapStr, LEGAL_KEYS, path)
+
+    val typeStr = ParseUtils.getValueStr(srcMapStr, "type", path)
+    val valuesMap = ParseUtils.getValueMap(srcMapStr, "values", path)
+
+    val dataType = DataType.pureFromString(Some(typeStr))
+    val intType = dataType match {
+      case it: IntType => it
+      // `type: b1` is automatically mapped to a boolean by
+      // DataType.pureFromString(). We don't want that here, so we convert it
+      // back to a 1-bit integer.
+      case BitsType1(bitEndian) =>
+        BitsType(1, bitEndian)
+      case other =>
+        throw KSYParseError.withText(
+          s"expected an integer type with no endianness (i.e. `uX` / `sX` / `bX`), got `${typeStr}`",
+          path :+ "type"
+        )
+    }
+
+    val doc = DocSpec.fromYaml(srcMapStr, path)
+
+    val memberNameMap = mutable.Map[String, BigInt]()
+    val valuesPath = path :+ "values"
+
+    EnumSpec(path, doc, intType, SortedMap.from(
+      valuesMap.map { case (id, desc) =>
+        val idBigInt = ParseUtils.asBigInt(id, valuesPath)
+        val value = EnumValueSpec.fromYaml(desc, valuesPath :+ idBigInt.toString)
         memberNameMap.get(value.name).foreach { (prevIdBigInt) =>
           throw KSYParseError.withText(
-            s"duplicate enum member ID: '${value.name}', previously defined at /${(path ++ List(prevIdBigInt.toString)).mkString("/")}",
-            path ++ List(idBigInt.toString)
+            s"duplicate enum member ID: '${value.name}', previously defined at /${(valuesPath :+ prevIdBigInt.toString).mkString("/")}",
+            valuesPath :+ idBigInt.toString
           )
         }
         memberNameMap.put(value.name, idBigInt)

--- a/shared/src/main/scala/io/kaitai/struct/format/EnumSpec.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/EnumSpec.scala
@@ -89,6 +89,8 @@ object EnumSpec {
           path :+ "type"
         )
     }
+    val intTypeMin = intType.min
+    val intTypeMax = intType.max
 
     val doc = DocSpec.fromYaml(srcMapStr, path)
 
@@ -98,6 +100,12 @@ object EnumSpec {
     EnumSpec(path, doc, intType, SortedMap.from(
       valuesMap.map { case (id, desc) =>
         val idBigInt = ParseUtils.asBigInt(id, valuesPath)
+        if (idBigInt < intTypeMin || idBigInt > intTypeMax) {
+          throw KSYParseError.withText(
+            s"integer constant ${idBigInt} is out of range ${intTypeMin}..${intTypeMax} of the enum's underlying type `${typeStr}`",
+            valuesPath :+ idBigInt.toString
+          )
+        }
         val value = EnumValueSpec.fromYaml(desc, valuesPath :+ idBigInt.toString)
         memberNameMap.get(value.name).foreach { (prevIdBigInt) =>
           throw KSYParseError.withText(

--- a/shared/src/main/scala/io/kaitai/struct/format/ParseUtils.scala
+++ b/shared/src/main/scala/io/kaitai/struct/format/ParseUtils.scala
@@ -39,6 +39,15 @@ object ParseUtils {
     }
   }
 
+  def getValueMap(src: Map[String, Any], field: String, path: List[String]): Map[Any, Any] = {
+    src.get(field) match {
+      case Some(value) =>
+        asMap(value, path ++ List(field))
+      case None =>
+        throw KSYParseError.noKey(field, path)
+    }
+  }
+
   def getOptValueStr(src: Map[String, Any], field: String, path: List[String]): Option[String] = {
     src.get(field) match {
       case None =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -547,12 +547,12 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   def flagForInstName(ksName: Identifier) = s"f_${idToStr(ksName)}"
 
-  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)], enumSpec: EnumSpec): Unit = {
     val enumClass = type2class(enumName)
 
     out.puts
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"public enum $enumClass")
     out.puts(s"{")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -547,7 +547,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   def flagForInstName(ksName: Identifier) = s"f_${idToStr(ksName)}"
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     val enumClass = type2class(enumName)
 
     out.puts

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -553,7 +553,7 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts
     if (!enumSpec.doc.isEmpty)
       universalDoc(enumSpec.doc)
-    out.puts(s"public enum $enumClass")
+    out.puts(s"public enum $enumClass : ${kaitaiType2NativeType(enumSpec.intType)}")
     out.puts(s"{")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpCompiler.scala
@@ -551,6 +551,8 @@ class CSharpCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val enumClass = type2class(enumName)
 
     out.puts
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"public enum $enumClass")
     out.puts(s"{")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -885,7 +885,7 @@ class CppCompiler(
     handleAssignmentSimple(instName, valExprConverted)
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     val enumClass = types2class(List(enumName))
 
     outHdr.puts

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -885,12 +885,12 @@ class CppCompiler(
     handleAssignmentSimple(instName, valExprConverted)
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
     val enumClass = types2class(List(enumName))
 
     outHdr.puts
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     outHdr.puts(s"enum $enumClass {")
     outHdr.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -891,7 +891,11 @@ class CppCompiler(
     outHdr.puts
     if (!enumSpec.doc.isEmpty)
       universalDoc(enumSpec.doc)
-    outHdr.puts(s"enum $enumClass {")
+    if (config.cppConfig.enumsFixedUnderlyingType) {
+      outHdr.puts(s"enum $enumClass : ${kaitaiType2NativeType(enumSpec.intType)} {")
+    } else {
+      outHdr.puts(s"enum $enumClass {")
+    }
     outHdr.inc
 
     if (enumColl.size > 1) {

--- a/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CppCompiler.scala
@@ -889,6 +889,8 @@ class CppCompiler(
     val enumClass = types2class(List(enumName))
 
     outHdr.puts
+    if (!doc.isEmpty)
+      universalDoc(doc)
     outHdr.puts(s"enum $enumClass {")
     outHdr.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -491,13 +491,13 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def instanceSetCalculated(instName: InstanceIdentifier): Unit =
     out.puts(s"this.${calculatedFlagForName(instName)} = true")
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
     val fullEnumName: List[String] = curClass ++ List(enumName)
     val fullEnumNameStr = types2class(fullEnumName)
 
     out.puts
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"type $fullEnumNameStr int")
     out.puts("const (")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -491,7 +491,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def instanceSetCalculated(instName: InstanceIdentifier): Unit =
     out.puts(s"this.${calculatedFlagForName(instName)} = true")
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     val fullEnumName: List[String] = curClass ++ List(enumName)
     val fullEnumNameStr = types2class(fullEnumName)
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -498,7 +498,7 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts
     if (!enumSpec.doc.isEmpty)
       universalDoc(enumSpec.doc)
-    out.puts(s"type $fullEnumNameStr int")
+    out.puts(s"type $fullEnumNameStr ${kaitaiType2NativeType(enumSpec.intType)}")
     out.puts("const (")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -496,6 +496,8 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val fullEnumNameStr = types2class(fullEnumName)
 
     out.puts
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"type $fullEnumNameStr int")
     out.puts("const (")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -947,7 +947,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"public void _invalidate${idToSetterStr(instName)}() { ${privateMemberName(instName)} = null; }")
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     val enumClass = type2class(enumName)
 
     out.puts

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -951,6 +951,8 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val enumClass = type2class(enumName)
 
     out.puts
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"public enum $enumClass {")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -1004,6 +1004,8 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
     out.puts("}") // close interface
 
+    if (!doc.isEmpty)
+      universalDoc(doc)
     // public enum <enum> implements I<enum> { ... }
     out.puts(s"public enum $enumClass implements $enumIface {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -966,7 +966,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"public void _invalidate${idToSetterStr(instName)}() { ${privateMemberName(instName)} = null; }")
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     val enumClass = type2class(enumName)
     val enumIface = enum2iface(enumName)
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaCompiler.scala
@@ -966,7 +966,7 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"public void _invalidate${idToSetterStr(instName)}() { ${privateMemberName(instName)} = null; }")
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)], enumSpec: EnumSpec): Unit = {
     val enumClass = type2class(enumName)
     val enumIface = enum2iface(enumName)
 
@@ -1004,8 +1004,8 @@ class JavaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
     out.puts("}") // close interface
 
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     // public enum <enum> implements I<enum> { ... }
     out.puts(s"public enum $enumClass implements $enumIface {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -526,6 +526,8 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   }
 
   override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"${type2class(curClass.last)}.${type2class(enumName)} = Object.freeze({")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -525,7 +525,7 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     out.puts(s"${type2class(curClass.last)}.${type2class(enumName)} = Object.freeze({")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/JavaScriptCompiler.scala
@@ -525,9 +525,9 @@ class JavaScriptCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
-    if (!doc.isEmpty)
-      universalDoc(doc)
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"${type2class(curClass.last)}.${type2class(enumName)} = Object.freeze({")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -276,6 +276,8 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     importList.add("local enum = require(\"enum\")")
 
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"${types2class(curClass)}.${type2class(enumName)} = enum.Enum {")
     out.inc
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -273,7 +273,7 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def instanceReturn(instName: InstanceIdentifier, attrType: DataType, isNullable: Boolean): Unit =
     out.puts(s"return ${privateMemberName(instName)}")
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     importList.add("local enum = require(\"enum\")")
 
     out.puts(s"${types2class(curClass)}.${type2class(enumName)} = enum.Enum {")

--- a/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/LuaCompiler.scala
@@ -273,11 +273,11 @@ class LuaCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def instanceReturn(instName: InstanceIdentifier, attrType: DataType, isNullable: Boolean): Unit =
     out.puts(s"return ${privateMemberName(instName)}")
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
     importList.add("local enum = require(\"enum\")")
 
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"${types2class(curClass)}.${type2class(enumName)} = enum.Enum {")
     out.inc
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -183,12 +183,12 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
   }
   // For this to work, we need a {.lenientCase.} pragma which disables nim's exhaustive case coverage check
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
     val enumClass = namespaced(curClass)
     out.puts(s"${enumClass}_${camelCase(enumName, true)}* = enum")
     out.inc
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     enumColl.foreach { case (id, label) =>
       val order = if (s"$id" == "-9223372036854775808") "low(int64)" else s"$id"
       out.puts(s"${label.name} = $order")

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -187,6 +187,8 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val enumClass = namespaced(curClass)
     out.puts(s"${enumClass}_${camelCase(enumName, true)}* = enum")
     out.inc
+    if (!doc.isEmpty)
+      universalDoc(doc)
     enumColl.foreach { case (id, label) =>
       val order = if (s"$id" == "-9223372036854775808") "low(int64)" else s"$id"
       out.puts(s"${label.name} = $order")

--- a/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/NimCompiler.scala
@@ -183,7 +183,7 @@ class NimCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
   }
   // For this to work, we need a {.lenientCase.} pragma which disables nim's exhaustive case coverage check
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     val enumClass = namespaced(curClass)
     out.puts(s"${enumClass}_${camelCase(enumName, true)}* = enum")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -436,7 +436,7 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     val name = curClass ::: List(enumName)
     classHeader(name, None)
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -438,6 +438,8 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
   override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     val name = curClass ::: List(enumName)
+    if (!doc.isEmpty)
+      universalDoc(doc)
     classHeader(name, None)
     enumColl.foreach { case (id, label) =>
       universalDoc(label.doc)

--- a/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PHPCompiler.scala
@@ -436,10 +436,10 @@ class PHPCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
     val name = curClass ::: List(enumName)
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     classHeader(name, None)
     enumColl.foreach { case (id, label) =>
       universalDoc(label.doc)

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -425,7 +425,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
     out.puts
 
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PerlCompiler.scala
@@ -425,7 +425,7 @@ class PerlCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"return ${privateMemberName(instName)};")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
     out.puts
 
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -757,7 +757,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     importList.add("from enum import IntEnum")
 
     out.puts

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -763,6 +763,8 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts
     out.puts(s"class ${type2class(enumName)}(IntEnum):")
     out.inc
+    if (!doc.isEmpty)
+      universalDoc(doc)
     enumColl.foreach { case (id, label) =>
       out.puts(s"$label = ${translator.doIntLiteral(id)}")
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -757,14 +757,14 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.dec
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)], enumSpec: EnumSpec): Unit = {
     importList.add("from enum import IntEnum")
 
     out.puts
     out.puts(s"class ${type2class(enumName)}(IntEnum):")
     out.inc
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     enumColl.foreach { case (id, label) =>
       out.puts(s"$label = ${translator.doIntLiteral(id)}")
     }

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -460,12 +460,12 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(privateMemberName(instName))
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)], enumSpec: EnumSpec): Unit = {
     val enumConst = value2Const(enumName)
 
     out.puts
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"$enumConst = {")
     out.inc
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -460,7 +460,7 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(privateMemberName(instName))
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     val enumConst = value2Const(enumName)
 
     out.puts

--- a/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RubyCompiler.scala
@@ -464,6 +464,8 @@ class RubyCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val enumConst = value2Const(enumName)
 
     out.puts
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"$enumConst = {")
     out.inc
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -554,13 +554,13 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"Ok(${privateMemberName(instName)})")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit = {
 
     val enumClass = types2class(curClass ::: List(enumName))
 
     // Set up the actual enum definition
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"#[derive(Debug, PartialEq, Clone)]")
     out.puts(s"pub enum $enumClass {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -559,6 +559,8 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     val enumClass = types2class(curClass ::: List(enumName))
 
     // Set up the actual enum definition
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"#[derive(Debug, PartialEq, Clone)]")
     out.puts(s"pub enum $enumClass {")
     out.inc

--- a/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/RustCompiler.scala
@@ -554,7 +554,7 @@ class RustCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts(s"Ok(${privateMemberName(instName)})")
   }
 
-  override def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
+  override def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit = {
 
     val enumClass = types2class(curClass ::: List(enumName))
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
@@ -630,6 +630,8 @@ class ZigCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     val enumClass = type2class(enumName)
 
+    if (!doc.isEmpty)
+      universalDoc(doc)
     out.puts(s"pub const $enumClass = enum(i32) {")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
@@ -632,7 +632,7 @@ class ZigCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
 
     if (!enumSpec.doc.isEmpty)
       universalDoc(enumSpec.doc)
-    out.puts(s"pub const $enumClass = enum(i32) {")
+    out.puts(s"pub const $enumClass = enum(${kaitaiType2NativeType(enumSpec.intType)}) {")
     out.inc
 
     enumColl.foreach { case (id, label) =>

--- a/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
@@ -627,11 +627,11 @@ class ZigCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("_n = false;")
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)], enumSpec: EnumSpec): Unit = {
     val enumClass = type2class(enumName)
 
-    if (!doc.isEmpty)
-      universalDoc(doc)
+    if (!enumSpec.doc.isEmpty)
+      universalDoc(enumSpec.doc)
     out.puts(s"pub const $enumClass = enum(i32) {")
     out.inc
 

--- a/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/ZigCompiler.scala
@@ -627,7 +627,7 @@ class ZigCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
     out.puts("_n = false;")
   }
 
-  override def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit = {
+  override def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit = {
     val enumClass = type2class(enumName)
 
     out.puts(s"pub const $enumClass = enum(i32) {")

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -201,7 +201,7 @@ abstract class LanguageCompiler(
   def instanceHasValueIfHeader(instName: InstanceIdentifier): Unit = {}
   def instanceHasValueIfFooter(): Unit = {}
 
-  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit
+  def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit
 
   /**
     * Outputs class' attributes sequence identifiers as some sort of an ordered sequence,

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -201,7 +201,7 @@ abstract class LanguageCompiler(
   def instanceHasValueIfHeader(instName: InstanceIdentifier): Unit = {}
   def instanceHasValueIfFooter(): Unit = {}
 
-  def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit
+  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit
 
   /**
     * Outputs class' attributes sequence identifiers as some sort of an ordered sequence,

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/NoNeedForFullClassPath.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/NoNeedForFullClassPath.scala
@@ -20,7 +20,7 @@ trait NoNeedForFullClassPath {
     instanceHeader(className.last, instName, dataType, isNullable)
   def instanceHeader(className: String, instName: InstanceIdentifier, dataType: DataType, isNullable: Boolean): Unit
 
-  def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit =
-    enumDeclaration(curClass.last, enumName, doc, enumColl.map((x) => (x._1, x._2.name)))
-  def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit
+  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)], enumSpec: EnumSpec): Unit =
+    enumDeclaration(curClass.last, enumName, enumColl.map((x) => (x._1, x._2.name)), enumSpec)
+  def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)], enumSpec: EnumSpec): Unit
 }

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/NoNeedForFullClassPath.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/NoNeedForFullClassPath.scala
@@ -20,7 +20,7 @@ trait NoNeedForFullClassPath {
     instanceHeader(className.last, instName, dataType, isNullable)
   def instanceHeader(className: String, instName: InstanceIdentifier, dataType: DataType, isNullable: Boolean): Unit
 
-  def enumDeclaration(curClass: List[String], enumName: String, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit =
-    enumDeclaration(curClass.last, enumName, enumColl.map((x) => (x._1, x._2.name)))
-  def enumDeclaration(curClass: String, enumName: String, enumColl: Seq[(BigInt, String)]): Unit
+  def enumDeclaration(curClass: List[String], enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, EnumValueSpec)]): Unit =
+    enumDeclaration(curClass.last, enumName, doc, enumColl.map((x) => (x._1, x._2.name)))
+  def enumDeclaration(curClass: String, enumName: String, doc: DocSpec, enumColl: Seq[(BigInt, String)]): Unit
 }

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -139,9 +139,8 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
 
   /**
     * Checks whether the attribute's integer type (the `basedOn` of an
-    * [[EnumType]]) matches the underlying integer type declared by the enum
-    * itself. Endianness is deliberately not compared: the enum declaration
-    * does not carry endianness, so only signedness and width are relevant.
+    * [[EnumType]]) fits into (i.e. is a subset of) the underlying integer type
+    * declared by the enum itself.
     */
   private def checkEnumUnderlyingType(
     attrType: IntType,
@@ -149,7 +148,7 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
     enumName: List[String],
     path: List[String]
   ): Option[CompilationProblem] = {
-    if (IntType.areEquivalent(attrType, enumSpec.intType)) {
+    if (attrType.subsetOf(enumSpec.intType)) {
       None
     } else {
       Some(EnumUnderlyingTypeMismatchError(enumName, attrType, enumSpec.intType, path :+ "enum"))

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -2,7 +2,7 @@ package io.kaitai.struct.precompile
 
 import io.kaitai.struct.Log
 import io.kaitai.struct.datatype.DataType
-import io.kaitai.struct.datatype.DataType.{ArrayType, EnumType, SwitchType, UserType}
+import io.kaitai.struct.datatype.DataType.{ArrayType, BitsType, CalcIntType, EnumType, Int1Type, IntMultiType, IntType, SwitchType, UserType}
 import io.kaitai.struct.format._
 import io.kaitai.struct.problems._
 
@@ -51,10 +51,11 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
         problems
       case et: EnumType =>
         et.enumSpec = resolveEnumSpec(curClass, et.name)
-        if (et.enumSpec.isEmpty) {
-          Some(EnumNotFoundErr(et.name, curClass, path ++ List("enum")))
-        } else {
-          None
+        et.enumSpec match {
+          case None =>
+            Some(EnumNotFoundErr(et.name, curClass, path ++ List("enum")))
+          case Some(enumSpec) =>
+            checkEnumUnderlyingType(et.basedOn, enumSpec, et.name, path)
         }
       case st: SwitchType =>
         st.cases.flatMap { case (caseName, ut) =>
@@ -133,6 +134,25 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
               }
             }
         }
+    }
+  }
+
+  /**
+    * Checks whether the attribute's integer type (the `basedOn` of an
+    * [[EnumType]]) matches the underlying integer type declared by the enum
+    * itself. Endianness is deliberately not compared: the enum declaration
+    * does not carry endianness, so only signedness and width are relevant.
+    */
+  private def checkEnumUnderlyingType(
+    attrType: IntType,
+    enumSpec: EnumSpec,
+    enumName: List[String],
+    path: List[String]
+  ): Option[CompilationProblem] = {
+    if (IntType.areEquivalent(attrType, enumSpec.intType)) {
+      None
+    } else {
+      Some(EnumUnderlyingTypeMismatchError(enumName, attrType, enumSpec.intType, path :+ "enum"))
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
+++ b/shared/src/main/scala/io/kaitai/struct/precompile/ResolveTypes.scala
@@ -2,7 +2,7 @@ package io.kaitai.struct.precompile
 
 import io.kaitai.struct.Log
 import io.kaitai.struct.datatype.DataType
-import io.kaitai.struct.datatype.DataType.{ArrayType, EnumType, SwitchType, UserType}
+import io.kaitai.struct.datatype.DataType.{ArrayType, BitsType, CalcIntType, EnumType, Int1Type, IntMultiType, IntType, SwitchType, UserType}
 import io.kaitai.struct.format._
 import io.kaitai.struct.problems._
 
@@ -51,10 +51,11 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
         problems
       case et: EnumType =>
         et.enumSpec = resolveEnumSpec(curClass, et.owner :+ et.name)
-        if (et.enumSpec.isEmpty) {
-          Some(EnumNotFoundErr(et.owner :+ et.name, curClass, path ++ List("enum")))
-        } else {
-          None
+        et.enumSpec match {
+          case None =>
+            Some(EnumNotFoundErr(et.owner :+ et.name, curClass, path ++ List("enum")))
+          case Some(enumSpec) =>
+            checkEnumUnderlyingType(et.basedOn, enumSpec, et.owner :+ et.name, path)
         }
       case st: SwitchType =>
         st.cases.flatMap { case (caseName, ut) =>
@@ -133,6 +134,25 @@ class ResolveTypes(specs: ClassSpecs, topClass: ClassSpec, opaqueTypes: Boolean)
               }
             }
         }
+    }
+  }
+
+  /**
+    * Checks whether the attribute's integer type (the `basedOn` of an
+    * [[EnumType]]) matches the underlying integer type declared by the enum
+    * itself. Endianness is deliberately not compared: the enum declaration
+    * does not carry endianness, so only signedness and width are relevant.
+    */
+  private def checkEnumUnderlyingType(
+    attrType: IntType,
+    enumSpec: EnumSpec,
+    enumName: List[String],
+    path: List[String]
+  ): Option[CompilationProblem] = {
+    if (IntType.areEquivalent(attrType, enumSpec.intType)) {
+      None
+    } else {
+      Some(EnumUnderlyingTypeMismatchError(enumName, attrType, enumSpec.intType, path :+ "enum"))
     }
   }
 

--- a/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
+++ b/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
@@ -190,6 +190,23 @@ case class EnumNotFoundErr(name: List[String], curClass: ClassSpec, path: List[S
   override def severity: ProblemSeverity = ProblemSeverity.Error
 }
 
+case class EnumUnderlyingTypeMismatchError(
+  enumName: List[String],
+  attrType: DataType.IntType,
+  enumType: DataType.IntType,
+  path: List[String],
+  fileName: Option[String] = None
+) extends CompilationProblem {
+  override def text =
+    s"unable to convert type `${attrType.toPureTypeString}` " +
+      s"to enum `${enumName.mkString("::")}` " +
+      s"with underlying type `${enumType.toPureTypeString}`"
+  override val coords: ProblemCoords = ProblemCoords(fileName, Some(path))
+  override def localizedInFile(fileName: String): CompilationProblem =
+    copy(fileName = Some(fileName))
+  override def severity: ProblemSeverity = ProblemSeverity.Error
+}
+
 abstract class StyleWarning(val coords: ProblemCoords) extends CompilationProblem {
   /**
     * @return main warning text, without references to the style guide

--- a/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
+++ b/shared/src/main/scala/io/kaitai/struct/problems/CompilationProblem.scala
@@ -197,10 +197,15 @@ case class EnumUnderlyingTypeMismatchError(
   path: List[String],
   fileName: Option[String] = None
 ) extends CompilationProblem {
-  override def text =
-    s"unable to convert type `${attrType.toPureTypeString}` " +
+  override def text = {
+    val attrTypeStr = attrType.toPureTypeString
+    val enumTypeStr = enumType.toPureTypeString
+    s"unable to convert type `${attrTypeStr}` " +
       s"to enum `${enumName.mkString("::")}` " +
-      s"with underlying type `${enumType.toPureTypeString}`"
+      s"with underlying type `${enumTypeStr}` " +
+      s"(range ${attrType.min}..${attrType.max} of `${attrTypeStr}` is not fully contained in " +
+      s"range ${enumType.min}..${enumType.max} of `${enumTypeStr}`)"
+  }
   override val coords: ProblemCoords = ProblemCoords(fileName, Some(path))
   override def localizedInFile(fileName: String): CompilationProblem =
     copy(fileName = Some(fileName))

--- a/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/CSharpTranslator.scala
@@ -111,16 +111,7 @@ class CSharpTranslator(provider: TypeProvider, importList: ImportList) extends B
     s"Convert.ToInt64(${translate(s)}, ${translate(base)})"
   }
   override def enumToInt(v: expr, et: EnumType): String =
-    // Always casting to `int` works fine at the time of writing this, because the
-    // enums we generate for C# are `int`-based (we generate `public enum $enumClass
-    // { ... }`, see `CSharpCompiler.enumDeclaration`, and according to
-    // <https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum>:
-    // "By default, the associated constant values of enum members are of type
-    // `int`").
-    //
-    // However, once we start generating enums with underlying types other than
-    // `int`, we will have to change this.
-    s"((int) ${translate(v, METHOD_PRECEDENCE)})"
+    s"((${CSharpCompiler.kaitaiType2NativeType(importList, et.enumSpec.get.intType)}) ${translate(v, METHOD_PRECEDENCE)})"
   override def floatToInt(v: expr): String =
     s"(long) (${translate(v)})"
   override def intToStr(i: expr): String =

--- a/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/TypeDetector.scala
@@ -219,7 +219,7 @@ class TypeDetector(provider: TypeProvider) {
         }
       case et: EnumType =>
         attr.name match {
-          case "to_i" => CalcIntType
+          case "to_i" => et.enumSpec.get.intType
           case _ => throw new MethodNotFoundError(attr.name, valType)
         }
       case _: BooleanType =>


### PR DESCRIPTION
- Resolves https://github.com/kaitai-io/kaitai_struct/issues/1288
- Resolves https://github.com/kaitai-io/kaitai_struct/issues/358
- Fixes https://github.com/kaitai-io/kaitai_struct/issues/862
- Fixes https://github.com/kaitai-io/kaitai_struct/issues/92
- Closes https://github.com/kaitai-io/kaitai_struct_compiler/pull/248
- Solves https://github.com/kaitai-io/kaitai_struct/issues/959 for C++11 only (but not for C++98)

Related PR in the KST repo to update the test suite accordingly: https://github.com/kaitai-io/kaitai_struct_tests/pull/140

As explained in https://github.com/kaitai-io/kaitai_struct/issues/1288, this is a breaking change: the current `enums` syntax is declared old and unsupported ("legacy pre-v0.12 enum syntax"), and only the new syntax is accepted.

I can imagine that this will have a big impact, because suddenly almost everyone will have to update their .ksy specs. I suppose it would be possible to maintain support for the old syntax somehow, but that would significantly limit adoption of the new one... So I'm not sure if that's really what we want.