### PR TITLE
Go: Add support for custom `process`

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/GoCompiler.scala
@@ -213,8 +213,10 @@ class GoCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
         }
         s"kaitai.ProcessRotateLeft($srcExpr, int($expr))"
       case ProcessCustom(name, args) =>
-        // TODO(jchw): This hack is necessary because Go tests fail catastrophically otherwise...
-        s"$srcExpr"
+        val procClass = GoCompiler.types2class(name)
+        val argsStr   = args.map(expression).mkString(", ")
+        translator.resToStr(translator.outVarCheckRes(
+          s"kaitai.ProcessCustom(New$procClass($argsStr), $srcExpr)"))
     }
   }
 


### PR DESCRIPTION
I was quite disappointed when I learnt that Go's runtime does not support custom processors, so I decided to add it.

See also:
- the runtime change kaitai-io/kaitai_struct_go_runtime#33
- updated tests kaitai-io/kaitai_struct_tests#141