### PR TITLE
Python: order standard library imports first

### DIFF
--- a/jvm/src/test/scala/io/kaitai/struct/languages/PythonCompilerSpec.scala
+++ b/jvm/src/test/scala/io/kaitai/struct/languages/PythonCompilerSpec.scala
@@ -1,0 +1,39 @@
+package io.kaitai.struct.languages
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PythonCompilerSpec extends AnyFunSpec with Matchers {
+  describe("formatImports") {
+    it("places standard library imports before other imports") {
+      PythonCompiler.formatImports(List(
+        "import kaitaistruct",
+        "from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO",
+        "import collections",
+        "from enum import IntEnum",
+        "import struct",
+        "import zlib",
+        "import imported_type",
+      )) shouldEqual
+        """import collections
+          |from enum import IntEnum
+          |import struct
+          |import zlib
+          |
+          |import kaitaistruct
+          |from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+          |import imported_type
+          |""".stripMargin
+    }
+
+    it("does not add an empty import group") {
+      PythonCompiler.formatImports(List(
+        "import kaitaistruct",
+        "from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO",
+      )) shouldEqual
+        """import kaitaistruct
+          |from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+          |""".stripMargin
+    }
+  }
+}

--- a/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/PythonCompiler.scala
@@ -39,7 +39,7 @@ class PythonCompiler(typeProvider: ClassTypeProvider, config: RuntimeConfig)
   override def outFileName(topClassName: String): String = s"$topClassName.py"
 
   override def outImports(topClass: ClassSpec) =
-    importList.toList.mkString("", "\n", "\n")
+    PythonCompiler.formatImports(importList.toList)
 
   override def fileHeader(topClassName: String): Unit = {
     outHeader.puts(s"# $headerComment")
@@ -953,6 +953,26 @@ object PythonCompiler extends LanguageCompilerStatic
   with UpperCamelCaseClasses
   with StreamStructNames
   with ExceptionNames {
+  private[languages] val standardLibraryImports = Set(
+    "collections",
+    "enum",
+    "struct",
+    "zlib",
+  )
+
+  private[languages] def formatImports(imports: List[String]): String = {
+    val (standardLibrary, other) = imports.partition { importLine =>
+      standardLibraryImports.exists { module =>
+        importLine == s"import $module" || importLine.startsWith(s"from $module import ")
+      }
+    }
+
+    Seq(standardLibrary, other)
+      .filter(_.nonEmpty)
+      .map(_.mkString("\n"))
+      .mkString("", "\n\n", "\n")
+  }
+
   override def getCompiler(
     tp: ClassTypeProvider,
     config: RuntimeConfig


### PR DESCRIPTION
## Summary

Update the Python code generator to place standard-library imports before `kaitaistruct` and generated-module imports.

Standard-library and other imports are emitted as separate groups, with a blank line between them.

Fixes kaitai-io/kaitai_struct#1299.

## Root cause

Python imports were previously emitted in discovery order. The compiler adds `kaitaistruct` while generating the file header, but imports such as `collections`, `enum`, `struct`, and `zlib` are discovered later.

This produced output such as:

```python
import kaitaistruct
from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
from enum import IntEnum
import collections